### PR TITLE
fix: YAML frontmatter quoting in lint-and-validate skill

### DIFF
--- a/skills/lint-and-validate/SKILL.md
+++ b/skills/lint-and-validate/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: lint-and-validate
-description: Automatic quality control, linting, and static analysis procedures. Use after every code modification to ensure syntax correctness and project standards. Triggers onKeywords: lint, format, check, validate, types, static analysis.
+description: "Automatic quality control, linting, and static analysis procedures. Use after every code modification to ensure syntax correctness and project standards. Triggers onKeywords: lint, format, check, validate, types, static analysis."
 allowed-tools: Read, Glob, Grep, Bash
 ---
 


### PR DESCRIPTION
## Description

This update fixes an invalid YAML frontmatter in the `lint-and-validate` skill that caused OpenCode to fail when parsing skills (e.g., during the **“list all available skills”** operation).

The issue was caused by an unquoted string in the YAML frontmatter. This PR adds proper quoting to ensure the frontmatter is valid YAML and can be safely parsed by OpenCode and standard YAML parsers.

This is a minimal, non-breaking change.

---

## What Was Changed

- Fixed YAML frontmatter quoting in:
  - `skills/lint-and-validate/SKILL.md`
- No functional or behavioral changes to the skill logic
- No new dependencies introduced

---

## Checklist

- [x] Skill structure follows the creation guidelines
- [ ] `validate_skills.py` was run (not required for this small fix)
- [ ] Credits updated (not applicable for bug fix)

---

## Type of Change

- [x] Bug Fix
- [ ] New Skill
- [ ] Documentation Update
- [ ] Infrastructure

---

## Impact

- Prevents OpenCode from throwing a YAML parsing error
- Allows `opencode debug skill` and skill listing to run without failure
- Improves robustness for all users loading this skill

---

## Screenshots


<img width="1912" height="330" alt="Screenshot 2026-01-25 081713" src="https://github.com/user-attachments/assets/48048d83-2a60-47aa-bd73-a2f7a7568607" />
