### PR TITLE
fix: correct AdaL CLI information

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 [![Copilot](https://img.shields.io/badge/GitHub%20Copilot-VSCode-lightblue)](https://github.com/features/copilot)
 [![OpenCode](https://img.shields.io/badge/OpenCode-CLI-gray)](https://github.com/opencode-ai/opencode)
 [![Antigravity](https://img.shields.io/badge/Antigravity-DeepMind-red)](https://github.com/sickn33/antigravity-awesome-skills)
-[![AdaL](https://img.shields.io/badge/AdaL-Self--evolving%20Agent-pink)](https://github.com/HumanSignal/Adala)
+[![AdaL CLI](https://img.shields.io/badge/AdaL%20CLI-SylphAI-pink)](https://sylph.ai/)
 
 **Antigravity Awesome Skills** is a curated, battle-tested library of **626 high-performance agentic skills** designed to work seamlessly across all major AI coding assistants:
 
@@ -21,7 +21,7 @@
 - 🩵 **GitHub Copilot** (VSCode Extension)
 - 🟠 **Cursor** (AI-native IDE)
 - ⚪ **OpenCode** (Open-source CLI)
-- 🌸 **AdaL** (Self-evolving AI Agent)
+- 🌸 **AdaL CLI** (Self-evolving Coding Agent)
 
 This repository provides essential skills to transform your AI assistant into a **full-stack digital agency**, including official capabilities from **Anthropic**, **OpenAI**, **Google**, **Supabase**, and **Vercel Labs**.
 
@@ -95,7 +95,7 @@ These skills follow the universal **SKILL.md** format and work with any AI codin
 | **Cursor**      | IDE   | `@skill-name (in Chat)`           | `.cursor/skills/` |
 | **Copilot**     | Ext   | `(Paste content manually)`        | N/A               |
 | **OpenCode**    | CLI   | `opencode run @skill-name`        | `.agent/skills/`  |
-| **AdaL**        | Agent | `(Agent Mode) Use skill...`       | `.agent/skills/`  |
+| **AdaL CLI**    | CLI   | `(Auto) Skills load on-demand`    | `.adal/skills/`   |
 
 > [!TIP]
 > **Universal Path**: We recommend cloning to `.agent/skills/`. Most modern tools (Antigravity, recent CLIs) look here by default.


### PR DESCRIPTION
## Summary
Fix several inaccuracies in the AdaL CLI entry.

## Changes
| Field | Before | After |
|-------|--------|-------|
| Type | Agent | CLI |
| Badge Link | HumanSignal/Adala | sylph.ai (SylphAI) |
| Description | Self-evolving AI Agent | Self-evolving Coding Agent |
| Invocation | (Agent Mode) Use skill... | (Auto) Skills load on-demand |
| Path | .agent/skills/ | .adal/skills/ |

## Why
The previous entry incorrectly linked to [HumanSignal/Adala](https://github.com/HumanSignal/Adala), which is an entirely different project. AdaL CLI is made by [SylphAI](https://sylph.ai/).

AdaL CLI is a terminal-based AI coding agent (CLI type, not Agent type) that is fully compatible with Claude Code skills. Skills load automatically on-demand when relevant to the task.

**Reference:** [AdaL CLI Skills Documentation](https://docs.sylph.ai/docs/features/plugins-and-skills)

🌸 Generated with [AdaL](https://sylph.ai/)