### PR TITLE
Add Yandex Direct audit skill (55 checks, A-F scoring)

### DIFF
--- a/README.md
+++ b/README.md
@@ -386,6 +386,7 @@ This collection would not be possible without the incredible work of the Claude 
 - **[zircote/.claude](https://github.com/zircote/.claude)**: Shopify development skill reference.
 - **[vibeforge1111/vibeship-spawner-skills](https://github.com/vibeforge1111/vibeship-spawner-skills)**: AI Agents, Integrations, Maker Tools (57 skills, Apache 2.0).
 - **[coreyhaines31/marketingskills](https://github.com/coreyhaines31/marketingskills)**: Marketing skills for CRO, copywriting, SEO, paid ads, and growth (23 skills, MIT).
+- **[Silverov/yandex-direct-skill](https://github.com/Silverov/yandex-direct-skill)**: Yandex Direct (API v5) advertising audit skill — 55 automated checks, A-F scoring, campaign/ad/keyword analysis for the Russian PPC market (MIT).
 - **[vudovn/antigravity-kit](https://github.com/vudovn/antigravity-kit)**: AI Agent templates with Skills, Agents, and Workflows (33 skills, MIT).
 - **[affaan-m/everything-claude-code](https://github.com/affaan-m/everything-claude-code)**: Complete Claude Code configuration collection from Anthropic hackathon winner - skills only (8 skills, MIT).
 - **[whatiskadudoing/fp-ts-skills](https://github.com/whatiskadudoing/fp-ts-skills)**: Practical fp-ts skills for TypeScript – fp-ts-pragmatic, fp-ts-react, fp-ts-errors (v4.4.0).


### PR DESCRIPTION
## New Skill: Yandex Direct Audit

**Repository:** [Silverov/yandex-direct-skill](https://github.com/Silverov/yandex-direct-skill)

**What it does:**
- Full audit of Yandex Direct advertising accounts via API v5
- 55 automated checks across 8 categories (bids, negative keywords, sitelinks, callouts, mobile adjustments, budgets, ad groups, ad copy quality)
- A-F scoring system with weighted formula
- Works with Claude Code, OpenClaw, and other agentic platforms

**Why add it:**
- First agentic skill for Yandex Direct (Russian PPC market)
- MIT license
- Fills a gap — no existing skills cover Russian advertising platforms

Built by [Stepback AI Agency](https://stepback.ru).