### PR TITLE
feat: Add DDD skills, bundles, workflows

### DIFF
--- a/CATALOG.md
+++ b/CATALOG.md
@@ -2,9 +2,9 @@
 
 Generated at: 2026-02-08T00:00:00.000Z
 
-Total skills: 864
+Total skills: 868
 
-## architecture (64)
+## architecture (68)
 
 | Skill | Description | Tags | Triggers |
 | --- | --- | --- | --- |
@@ -31,8 +31,12 @@ Total skills: 864
 | `core-components` | Core component library and design system patterns. Use when building UI, using design tokens, or working with the component library. | core, components | core, components, component, library, building, ui, tokens, working |
 | `cpp-pro` | Write idiomatic C++ code with modern features, RAII, smart pointers, and STL algorithms. Handles templates, move semantics, and performance optimization. Use... | cpp | cpp, pro, write, idiomatic, code, features, raii, smart, pointers, stl, algorithms, move |
 | `cqrs-implementation` | Implement Command Query Responsibility Segregation for scalable architectures. Use when separating read and write models, optimizing query performance, or bu... | cqrs | cqrs, command, query, responsibility, segregation, scalable, architectures, separating, read, write, models, optimizing |
+| `ddd-context-mapping` | Map relationships between bounded contexts and define integration contracts using DDD context mapping patterns. | ddd, context-map, anti-corruption-layer, integration | ddd, context-map, anti-corruption-layer, integration, context, mapping, map, relationships, between, bounded, contexts, define |
+| `ddd-strategic-design` | Design DDD strategic artifacts including subdomains, bounded contexts, and ubiquitous language for complex business domains. | ddd, strategic-design, bounded-context, ubiquitous-language | ddd, strategic-design, bounded-context, ubiquitous-language, strategic, artifacts, including, subdomains, bounded, contexts, ubiquitous, language |
+| `ddd-tactical-patterns` | Apply DDD tactical patterns in code using entities, value objects, aggregates, repositories, and domain events with explicit invariants. | ddd, tactical, aggregates, value-objects, domain-events | ddd, tactical, aggregates, value-objects, domain-events, apply, code, entities, value, objects, repositories, domain |
 | `doc-coauthoring` | Guide users through a structured workflow for co-authoring documentation. Use when user wants to write documentation, proposals, technical specs, decision do... | doc, coauthoring | doc, coauthoring, users, through, structured, co, authoring, documentation, user, wants, write, proposals |
 | `docs-architect` | Creates comprehensive technical documentation from existing codebases. Analyzes architecture, design patterns, and implementation details to produce long-for... | docs | docs, architect, creates, technical, documentation, existing, codebases, analyzes, architecture, details, produce, long |
+| `domain-driven-design` | Plan and route Domain-Driven Design work from strategic modeling to tactical implementation and evented architecture patterns. | ddd, domain, bounded-context, architecture | ddd, domain, bounded-context, architecture, driven, plan, route, work, strategic, modeling, tactical, evented |
 | `elixir-pro` | Write idiomatic Elixir code with OTP patterns, supervision trees, and Phoenix LiveView. Masters concurrency, fault tolerance, and distributed systems. Use PR... | elixir | elixir, pro, write, idiomatic, code, otp, supervision, trees, phoenix, liveview, masters, concurrency |
 | `email-systems` | Email has the highest ROI of any marketing channel. $36 for every $1 spent. Yet most startups treat it as an afterthought - bulk blasts, no personalization, ... | email | email, highest, roi, any, marketing, channel, 36, every, spent, yet, most, startups |
 | `error-detective` | Search logs and codebases for error patterns, stack traces, and anomalies. Correlates errors across systems and identifies root causes. Use PROACTIVELY when ... | error, detective | error, detective, search, logs, codebases, stack, traces, anomalies, correlates, errors, identifies, root |

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# 🌌 Antigravity Awesome Skills: 864+ Agentic Skills for Claude Code, Gemini CLI, Cursor, Copilot & More
+# 🌌 Antigravity Awesome Skills: 868+ Agentic Skills for Claude Code, Gemini CLI, Cursor, Copilot & More
 
-> **The Ultimate Collection of 864+ Universal Agentic Skills for AI Coding Assistants — Claude Code, Gemini CLI, Codex CLI, Antigravity IDE, GitHub Copilot, Cursor, OpenCode, AdaL**
+> **The Ultimate Collection of 868+ Universal Agentic Skills for AI Coding Assistants — Claude Code, Gemini CLI, Codex CLI, Antigravity IDE, GitHub Copilot, Cursor, OpenCode, AdaL**
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![Claude Code](https://img.shields.io/badge/Claude%20Code-Anthropic-purple)](https://claude.ai)
@@ -16,7 +16,7 @@
 
 If this project helps you, you can [support it here](https://buymeacoffee.com/sickn33) or simply ⭐ the repo.
 
-**Antigravity Awesome Skills** is a curated, battle-tested library of **864 high-performance agentic skills** designed to work seamlessly across all major AI coding assistants:
+**Antigravity Awesome Skills** is a curated, battle-tested library of **868 high-performance agentic skills** designed to work seamlessly across all major AI coding assistants:
 
 - 🟣 **Claude Code** (Anthropic CLI)
 - 🔵 **Gemini CLI** (Google DeepMind)
@@ -39,7 +39,7 @@ This repository provides essential skills to transform your AI assistant into a 
 - [🎁 Curated Collections (Bundles)](#curated-collections)
 - [🧭 Antigravity Workflows](#antigravity-workflows)
 - [📦 Features & Categories](#features--categories)
-- [📚 Browse 864+ Skills](#browse-864-skills)
+- [📚 Browse 868+ Skills](#browse-868-skills)
 - [🤝 How to Contribute](#how-to-contribute)
 - [🤝 Community](#community)
 - [☕ Support the Project](#support-the-project)
@@ -292,7 +292,7 @@ The repository is organized into specialized domains to transform your AI into a
 
 Counts change as new skills are added. For the current full registry, see [CATALOG.md](CATALOG.md).
 
-## Browse 864+ Skills
+## Browse 868+ Skills
 
 We have moved the full skill registry to a dedicated catalog to keep this README clean.
 

--- a/data/catalog.json
+++ b/data/catalog.json
@@ -1,6 +1,6 @@
 {
   "generatedAt": "2026-02-08T00:00:00.000Z",
-  "total": 864,
+  "total": 868,
   "skills": [
     {
       "id": "3d-web-experience",
@@ -8168,6 +8168,88 @@
       "path": "skills/dbt-transformation-patterns/SKILL.md"
     },
     {
+      "id": "ddd-context-mapping",
+      "name": "ddd-context-mapping",
+      "description": "Map relationships between bounded contexts and define integration contracts using DDD context mapping patterns.",
+      "category": "architecture",
+      "tags": [
+        "ddd",
+        "context-map",
+        "anti-corruption-layer",
+        "integration"
+      ],
+      "triggers": [
+        "ddd",
+        "context-map",
+        "anti-corruption-layer",
+        "integration",
+        "context",
+        "mapping",
+        "map",
+        "relationships",
+        "between",
+        "bounded",
+        "contexts",
+        "define"
+      ],
+      "path": "skills/ddd-context-mapping/SKILL.md"
+    },
+    {
+      "id": "ddd-strategic-design",
+      "name": "ddd-strategic-design",
+      "description": "Design DDD strategic artifacts including subdomains, bounded contexts, and ubiquitous language for complex business domains.",
+      "category": "architecture",
+      "tags": [
+        "ddd",
+        "strategic-design",
+        "bounded-context",
+        "ubiquitous-language"
+      ],
+      "triggers": [
+        "ddd",
+        "strategic-design",
+        "bounded-context",
+        "ubiquitous-language",
+        "strategic",
+        "artifacts",
+        "including",
+        "subdomains",
+        "bounded",
+        "contexts",
+        "ubiquitous",
+        "language"
+      ],
+      "path": "skills/ddd-strategic-design/SKILL.md"
+    },
+    {
+      "id": "ddd-tactical-patterns",
+      "name": "ddd-tactical-patterns",
+      "description": "Apply DDD tactical patterns in code using entities, value objects, aggregates, repositories, and domain events with explicit invariants.",
+      "category": "architecture",
+      "tags": [
+        "ddd",
+        "tactical",
+        "aggregates",
+        "value-objects",
+        "domain-events"
+      ],
+      "triggers": [
+        "ddd",
+        "tactical",
+        "aggregates",
+        "value-objects",
+        "domain-events",
+        "apply",
+        "code",
+        "entities",
+        "value",
+        "objects",
+        "repositories",
+        "domain"
+      ],
+      "path": "skills/ddd-tactical-patterns/SKILL.md"
+    },
+    {
       "id": "debugger",
       "name": "debugger",
       "description": "Debugging specialist for errors, test failures, and unexpected behavior. Use proactively when encountering any issues.",
@@ -8820,6 +8902,33 @@
         "text"
       ],
       "path": "skills/docx-official/SKILL.md"
+    },
+    {
+      "id": "domain-driven-design",
+      "name": "domain-driven-design",
+      "description": "Plan and route Domain-Driven Design work from strategic modeling to tactical implementation and evented architecture patterns.",
+      "category": "architecture",
+      "tags": [
+        "ddd",
+        "domain",
+        "bounded-context",
+        "architecture"
+      ],
+      "triggers": [
+        "ddd",
+        "domain",
+        "bounded-context",
+        "architecture",
+        "driven",
+        "plan",
+        "route",
+        "work",
+        "strategic",
+        "modeling",
+        "tactical",
+        "evented"
+      ],
+      "path": "skills/domain-driven-design/SKILL.md"
     },
     {
       "id": "dotnet-architect",

--- a/data/workflows.json
+++ b/data/workflows.json
@@ -211,6 +211,63 @@
           "notes": "Classify failures by root cause: selector drift, timing, environment, data."
         }
       ]
+    },
+    {
+      "id": "design-ddd-core-domain",
+      "name": "Design a DDD Core Domain",
+      "description": "Workflow to model complex domains and implement tactical and evented patterns with explicit boundaries.",
+      "category": "architecture",
+      "relatedBundles": [
+        "core-dev",
+        "ops-core"
+      ],
+      "steps": [
+        {
+          "title": "Assess DDD fit and scope",
+          "goal": "Decide if full DDD is justified and define the modeling scope.",
+          "recommendedSkills": [
+            "domain-driven-design",
+            "architecture-decision-records"
+          ],
+          "notes": "Document why DDD is needed, where to keep it lightweight, and what success looks like."
+        },
+        {
+          "title": "Create strategic model",
+          "goal": "Define subdomains, bounded contexts, and ubiquitous language.",
+          "recommendedSkills": [
+            "ddd-strategic-design"
+          ],
+          "notes": "Classify subdomains and assign ownership before making implementation decisions."
+        },
+        {
+          "title": "Map context relationships",
+          "goal": "Define context integration patterns, ownership, and translation boundaries.",
+          "recommendedSkills": [
+            "ddd-context-mapping"
+          ],
+          "notes": "Prefer explicit contracts and anti-corruption layers where domain models diverge."
+        },
+        {
+          "title": "Implement tactical model",
+          "goal": "Encode invariants with aggregates, value objects, repositories, and domain events.",
+          "recommendedSkills": [
+            "ddd-tactical-patterns",
+            "test-driven-development"
+          ],
+          "notes": "Start from invariants and transaction boundaries, not from tables or endpoints."
+        },
+        {
+          "title": "Adopt evented patterns selectively",
+          "goal": "Apply CQRS, event store, projections, and sagas only where required.",
+          "recommendedSkills": [
+            "cqrs-implementation",
+            "event-store-design",
+            "projection-patterns",
+            "saga-orchestration"
+          ],
+          "notes": "Use evented patterns where consistency and scale tradeoffs are explicit and accepted."
+        }
+      ]
     }
   ]
 }

--- a/docs/BUNDLES.md
+++ b/docs/BUNDLES.md
@@ -327,6 +327,19 @@ _For system design and technical decisions._
 - [`event-sourcing-architect`](../skills/event-sourcing-architect/): Event sourcing and CQRS.
 - [`architecture-decision-records`](../skills/architecture-decision-records/): Document technical decisions.
 
+### 🧱 The "DDD & Evented Architecture" Pack
+
+_For teams modeling complex domains and evolving toward evented systems._
+
+- [`domain-driven-design`](../skills/domain-driven-design/): Route DDD work from strategic modeling to implementation patterns.
+- [`ddd-strategic-design`](../skills/ddd-strategic-design/): Subdomains, bounded contexts, and ubiquitous language.
+- [`ddd-context-mapping`](../skills/ddd-context-mapping/): Cross-context integration and anti-corruption boundaries.
+- [`ddd-tactical-patterns`](../skills/ddd-tactical-patterns/): Aggregates, value objects, repositories, and domain events.
+- [`cqrs-implementation`](../skills/cqrs-implementation/): Read/write model separation.
+- [`event-store-design`](../skills/event-store-design/): Event persistence and replay architecture.
+- [`saga-orchestration`](../skills/saga-orchestration/): Cross-context long-running transaction coordination.
+- [`projection-patterns`](../skills/projection-patterns/): Materialized read models from event streams.
+
 ---
 
 ## 🧰 Maintainer & OSS

--- a/docs/WORKFLOWS.md
+++ b/docs/WORKFLOWS.md
@@ -169,6 +169,47 @@ Create resilient browser automation with deterministic execution in CI.
 
 ---
 
+## Workflow: Design a DDD Core Domain
+
+Model a complex domain coherently, then implement tactical and evented patterns only where justified.
+
+**Related bundles:** `Architecture & Design`, `DDD & Evented Architecture`
+
+### Prerequisites
+
+- Access to at least one domain expert or product owner proxy.
+- Current system context and integration landscape available.
+- Agreement on business goals and key domain outcomes.
+
+### Steps
+
+1. **Assess DDD fit and scope**
+   - **Goal:** Decide whether full DDD, partial DDD, or simple modular architecture is appropriate.
+   - **Skills:** [`@domain-driven-design`](../skills/domain-driven-design/), [`@architecture-decision-records`](../skills/architecture-decision-records/)
+   - **Prompt example:** `Use @domain-driven-design to evaluate if full DDD is justified for our billing and fulfillment platform.`
+
+2. **Create strategic model**
+   - **Goal:** Define subdomains, bounded contexts, and ubiquitous language.
+   - **Skills:** [`@ddd-strategic-design`](../skills/ddd-strategic-design/)
+   - **Prompt example:** `Use @ddd-strategic-design to classify subdomains and propose bounded contexts with ownership.`
+
+3. **Map context relationships**
+   - **Goal:** Define upstream/downstream contracts and anti-corruption boundaries.
+   - **Skills:** [`@ddd-context-mapping`](../skills/ddd-context-mapping/)
+   - **Prompt example:** `Use @ddd-context-mapping to model Checkout, Billing, and Inventory interactions with clear contract ownership.`
+
+4. **Implement tactical model**
+   - **Goal:** Encode invariants with aggregates, value objects, and domain events.
+   - **Skills:** [`@ddd-tactical-patterns`](../skills/ddd-tactical-patterns/), [`@test-driven-development`](../skills/test-driven-development/)
+   - **Prompt example:** `Use @ddd-tactical-patterns to design aggregates and invariants for order lifecycle transitions.`
+
+5. **Adopt evented patterns selectively**
+   - **Goal:** Apply CQRS, event store, projections, and sagas only where complexity and scale require them.
+   - **Skills:** [`@cqrs-implementation`](../skills/cqrs-implementation/), [`@event-store-design`](../skills/event-store-design/), [`@projection-patterns`](../skills/projection-patterns/), [`@saga-orchestration`](../skills/saga-orchestration/)
+   - **Prompt example:** `Use @cqrs-implementation and @projection-patterns to scale read-side reporting without compromising domain invariants.`
+
+---
+
 ## Machine-Readable Workflows
 
 For tooling and automation, workflow metadata is available in [data/workflows.json](../data/workflows.json).

--- a/skills/ddd-context-mapping/SKILL.md
+++ b/skills/ddd-context-mapping/SKILL.md
@@ -1,0 +1,51 @@
+---
+name: ddd-context-mapping
+description: Map relationships between bounded contexts and define integration contracts using DDD context mapping patterns.
+risk: safe
+source: self
+tags: [ddd, context-map, anti-corruption-layer, integration]
+---
+
+# DDD Context Mapping
+
+## Use this skill when
+
+- Defining integration patterns between bounded contexts.
+- Preventing domain leakage across service boundaries.
+- Planning anti-corruption layers during migration.
+- Clarifying upstream and downstream ownership for contracts.
+
+## Do not use this skill when
+
+- You have a single-context system with no integrations.
+- You only need internal class design.
+- You are selecting cloud infrastructure tooling.
+
+## Instructions
+
+1. List all context pairs and dependency direction.
+2. Choose relationship patterns per pair.
+3. Define translation rules and ownership boundaries.
+4. Add failure modes, fallback behavior, and versioning policy.
+
+If detailed mapping structures are needed, open `references/context-map-patterns.md`.
+
+## Output requirements
+
+- Relationship map for all context pairs
+- Contract ownership matrix
+- Translation and anti-corruption decisions
+- Known coupling risks and mitigation plan
+
+## Examples
+
+```text
+Use @ddd-context-mapping to define how Checkout integrates with Billing,
+Inventory, and Fraud contexts, including ACL and contract ownership.
+```
+
+## Limitations
+
+- This skill does not replace API-level schema design.
+- It does not guarantee organizational alignment by itself.
+- It should be revisited when team ownership changes.

--- a/skills/ddd-context-mapping/references/context-map-patterns.md
+++ b/skills/ddd-context-mapping/references/context-map-patterns.md
@@ -1,0 +1,25 @@
+# Context Mapping Patterns
+
+## Common relationship patterns
+
+- Partnership
+- Shared Kernel
+- Customer-Supplier
+- Conformist
+- Anti-Corruption Layer
+- Open Host Service
+- Published Language
+
+## Mapping template
+
+| Upstream context | Downstream context | Pattern | Contract owner | Translation needed |
+| --- | --- | --- | --- | --- |
+| Billing | Checkout | Customer-Supplier | Billing | Yes |
+| Identity | Checkout | Conformist | Identity | No |
+
+## ACL checklist
+
+- Define canonical domain model for receiving context.
+- Translate external terms into local ubiquitous language.
+- Keep ACL code at boundary, not inside domain core.
+- Add contract tests for mapped behavior.

--- a/skills/ddd-strategic-design/SKILL.md
+++ b/skills/ddd-strategic-design/SKILL.md
@@ -1,0 +1,51 @@
+---
+name: ddd-strategic-design
+description: Design DDD strategic artifacts including subdomains, bounded contexts, and ubiquitous language for complex business domains.
+risk: safe
+source: self
+tags: [ddd, strategic-design, bounded-context, ubiquitous-language]
+---
+
+# DDD Strategic Design
+
+## Use this skill when
+
+- Defining core, supporting, and generic subdomains.
+- Splitting a monolith or service landscape by domain boundaries.
+- Aligning teams and ownership with bounded contexts.
+- Building a shared ubiquitous language with domain experts.
+
+## Do not use this skill when
+
+- The domain model is stable and already well bounded.
+- You need tactical code patterns only.
+- The task is purely infrastructure or UI oriented.
+
+## Instructions
+
+1. Extract domain capabilities and classify subdomains.
+2. Define bounded contexts around consistency and ownership.
+3. Establish a ubiquitous language glossary and anti-terms.
+4. Capture context boundaries in ADRs before implementation.
+
+If detailed templates are needed, open `references/strategic-design-template.md`.
+
+## Required artifacts
+
+- Subdomain classification table
+- Bounded context catalog
+- Glossary with canonical terms
+- Boundary decisions with rationale
+
+## Examples
+
+```text
+Use @ddd-strategic-design to map our commerce domain into bounded contexts,
+classify subdomains, and propose team ownership.
+```
+
+## Limitations
+
+- This skill does not produce executable code.
+- It cannot infer business truth without stakeholder input.
+- It should be followed by tactical design before implementation.

--- a/skills/ddd-strategic-design/references/strategic-design-template.md
+++ b/skills/ddd-strategic-design/references/strategic-design-template.md
@@ -1,0 +1,22 @@
+# Strategic Design Template
+
+## Subdomain classification
+
+| Capability | Subdomain type | Why | Owner team |
+| --- | --- | --- | --- |
+| Pricing | Core | Differentiates business value | Commerce |
+| Identity | Supporting | Needed but not differentiating | Platform |
+
+## Bounded context catalog
+
+| Context | Responsibility | Upstream dependencies | Downstream consumers |
+| --- | --- | --- | --- |
+| Catalog | Product data lifecycle | Supplier feed | Checkout, Search |
+| Checkout | Order placement and payment authorization | Catalog, Pricing | Fulfillment, Billing |
+
+## Ubiquitous language
+
+| Term | Definition | Context |
+| --- | --- | --- |
+| Order | Confirmed purchase request | Checkout |
+| Reservation | Temporary inventory hold | Fulfillment |

--- a/skills/ddd-tactical-patterns/SKILL.md
+++ b/skills/ddd-tactical-patterns/SKILL.md
@@ -1,0 +1,52 @@
+---
+name: ddd-tactical-patterns
+description: Apply DDD tactical patterns in code using entities, value objects, aggregates, repositories, and domain events with explicit invariants.
+risk: safe
+source: self
+tags: [ddd, tactical, aggregates, value-objects, domain-events]
+---
+
+# DDD Tactical Patterns
+
+## Use this skill when
+
+- Translating domain rules into code structures.
+- Designing aggregate boundaries and invariants.
+- Refactoring an anemic model into behavior-rich domain objects.
+- Defining repository contracts and domain event boundaries.
+
+## Do not use this skill when
+
+- You are still defining strategic boundaries.
+- The task is only API documentation or UI layout.
+- Full DDD complexity is not justified.
+
+## Instructions
+
+1. Identify invariants first and design aggregates around them.
+2. Model immutable value objects for validated concepts.
+3. Keep domain behavior in domain objects, not controllers.
+4. Emit domain events for meaningful state transitions.
+5. Keep repositories at aggregate root boundaries.
+
+If detailed checklists are needed, open `references/tactical-checklist.md`.
+
+## Example
+
+```typescript
+class Order {
+  private status: "draft" | "submitted" = "draft";
+
+  submit(itemsCount: number): void {
+    if (itemsCount === 0) throw new Error("Order cannot be submitted empty");
+    if (this.status !== "draft") throw new Error("Order already submitted");
+    this.status = "submitted";
+  }
+}
+```
+
+## Limitations
+
+- This skill does not define deployment architecture.
+- It does not choose databases or transport protocols.
+- It should be paired with testing patterns for invariant coverage.

--- a/skills/ddd-tactical-patterns/references/tactical-checklist.md
+++ b/skills/ddd-tactical-patterns/references/tactical-checklist.md
@@ -1,0 +1,25 @@
+# Tactical Pattern Checklist
+
+## Aggregate design
+
+- One aggregate root per transaction boundary
+- Invariants enforced inside aggregate methods
+- Avoid cross-aggregate synchronous consistency rules
+
+## Value objects
+
+- Immutable by default
+- Validation at construction
+- Equality by value, not identity
+
+## Repositories
+
+- Persist and load aggregate roots only
+- Expose domain-friendly query methods
+- Avoid leaking ORM entities into domain layer
+
+## Domain events
+
+- Past-tense event names (for example, `OrderSubmitted`)
+- Include minimal, stable event payloads
+- Version event schema before breaking changes

--- a/skills/domain-driven-design/SKILL.md
+++ b/skills/domain-driven-design/SKILL.md
@@ -1,0 +1,73 @@
+---
+name: domain-driven-design
+description: Plan and route Domain-Driven Design work from strategic modeling to tactical implementation and evented architecture patterns.
+risk: safe
+source: self
+tags: [ddd, domain, bounded-context, architecture]
+---
+
+# Domain-Driven Design
+
+## Use this skill when
+
+- You need to model a complex business domain with explicit boundaries.
+- You want to decide whether full DDD is worth the added complexity.
+- You need to connect strategic design decisions to implementation patterns.
+- You are planning CQRS, event sourcing, sagas, or projections from domain needs.
+
+## Do not use this skill when
+
+- The problem is simple CRUD with low business complexity.
+- You only need localized bug fixes.
+- There is no access to domain knowledge and no proxy product expert.
+
+## Instructions
+
+1. Run a viability check before committing to full DDD.
+2. Produce strategic artifacts first: subdomains, bounded contexts, language glossary.
+3. Route to specialized skills based on current task.
+4. Define success criteria and evidence for each stage.
+
+### Viability check
+
+Use full DDD only when at least two of these are true:
+
+- Business rules are complex or fast-changing.
+- Multiple teams are causing model collisions.
+- Integration contracts are unstable.
+- Auditability and explicit invariants are critical.
+
+### Routing map
+
+- Strategic model and boundaries: `@ddd-strategic-design`
+- Cross-context integrations and translation: `@ddd-context-mapping`
+- Tactical code modeling: `@ddd-tactical-patterns`
+- Read/write separation: `@cqrs-implementation`
+- Event history as source of truth: `@event-sourcing-architect` and `@event-store-design`
+- Long-running workflows: `@saga-orchestration`
+- Read models: `@projection-patterns`
+- Decision log: `@architecture-decision-records`
+
+If templates are needed, open `references/ddd-deliverables.md`.
+
+## Output requirements
+
+Always return:
+
+- Scope and assumptions
+- Current stage (strategic, tactical, or evented)
+- Explicit artifacts produced
+- Open risks and next step recommendation
+
+## Examples
+
+```text
+Use @domain-driven-design to assess if this billing platform should adopt full DDD.
+Then route to the right next skill and list artifacts we must produce this week.
+```
+
+## Limitations
+
+- This skill does not replace direct workshops with domain experts.
+- It does not provide framework-specific code generation.
+- It should not be used as a justification to over-engineer simple systems.

--- a/skills/domain-driven-design/references/ddd-deliverables.md
+++ b/skills/domain-driven-design/references/ddd-deliverables.md
@@ -1,0 +1,24 @@
+# DDD Deliverables Checklist
+
+Use this checklist to keep DDD adoption practical and measurable.
+
+## Strategic deliverables
+
+- Subdomain map (core, supporting, generic)
+- Bounded context map and ownership
+- Ubiquitous language glossary
+- 1-2 ADRs documenting critical boundary decisions
+
+## Tactical deliverables
+
+- Aggregate list with invariants
+- Value object list
+- Domain events list
+- Repository contracts and transaction boundaries
+
+## Evented deliverables (only when required)
+
+- Command and query separation rationale
+- Event schema versioning policy
+- Saga compensation matrix
+- Projection rebuild strategy

--- a/skills/event-store-design/resources/implementation-playbook.md
+++ b/skills/event-store-design/resources/implementation-playbook.md
@@ -1,0 +1,25 @@
+# Event Store Design Playbook
+
+## Schema and stream strategy
+
+- Use append-only writes with optimistic concurrency.
+- Keep per-stream ordering and global ordering indexes.
+- Include metadata fields for causation and correlation IDs.
+
+## Operational guardrails
+
+- Never mutate historical events in production.
+- Version event schema with explicit upcasters/downcasters policy.
+- Define retention and archival strategy by stream type.
+
+## Subscription and projection safety
+
+- Track per-subscriber checkpoint positions.
+- Make handlers idempotent and replay-safe.
+- Support projection rebuild from a clean checkpoint.
+
+## Performance checklist
+
+- Index stream id + version.
+- Index global position.
+- Add snapshot policy for long-lived aggregates.

--- a/skills/saga-orchestration/resources/implementation-playbook.md
+++ b/skills/saga-orchestration/resources/implementation-playbook.md
@@ -1,0 +1,26 @@
+# Saga Orchestration Playbook
+
+## When to choose orchestration vs choreography
+
+- Choose orchestration when business flow visibility and centralized control are required.
+- Choose choreography when autonomy is high and coupling is low.
+
+## Saga design checklist
+
+- Define explicit saga state machine.
+- Define timeout policy per step.
+- Define compensation action for each irreversible step.
+- Use idempotency keys for command handling.
+- Store correlation IDs across all events and logs.
+
+## Failure handling
+
+- Retry transient failures with bounded exponential backoff.
+- Escalate non-recoverable failures to compensation state.
+- Capture operator-visible failure reason and current step.
+
+## Verification
+
+- Simulate failure at every step and confirm compensation path.
+- Validate duplicate message handling.
+- Validate recovery from orchestrator restart.

--- a/skills_index.json
+++ b/skills_index.json
@@ -2898,6 +2898,33 @@
     "source": "unknown"
   },
   {
+    "id": "ddd-context-mapping",
+    "path": "skills/ddd-context-mapping",
+    "category": "uncategorized",
+    "name": "ddd-context-mapping",
+    "description": "Map relationships between bounded contexts and define integration contracts using DDD context mapping patterns.",
+    "risk": "safe",
+    "source": "self"
+  },
+  {
+    "id": "ddd-strategic-design",
+    "path": "skills/ddd-strategic-design",
+    "category": "uncategorized",
+    "name": "ddd-strategic-design",
+    "description": "Design DDD strategic artifacts including subdomains, bounded contexts, and ubiquitous language for complex business domains.",
+    "risk": "safe",
+    "source": "self"
+  },
+  {
+    "id": "ddd-tactical-patterns",
+    "path": "skills/ddd-tactical-patterns",
+    "category": "uncategorized",
+    "name": "ddd-tactical-patterns",
+    "description": "Apply DDD tactical patterns in code using entities, value objects, aggregates, repositories, and domain events with explicit invariants.",
+    "risk": "safe",
+    "source": "self"
+  },
+  {
     "id": "debugger",
     "path": "skills/debugger",
     "category": "uncategorized",
@@ -3139,6 +3166,15 @@
     "description": "Comprehensive document creation, editing, and analysis with support for tracked changes, comments, formatting preservation, and text extraction. When Claude needs to work with professional documents (.docx files) for: (1) Creating new documents, (2) Modifying or editing content, (3) Working with tracked changes, (4) Adding comments, or any other document tasks",
     "risk": "unknown",
     "source": "unknown"
+  },
+  {
+    "id": "domain-driven-design",
+    "path": "skills/domain-driven-design",
+    "category": "uncategorized",
+    "name": "domain-driven-design",
+    "description": "Plan and route Domain-Driven Design work from strategic modeling to tactical implementation and evented architecture patterns.",
+    "risk": "safe",
+    "source": "self"
   },
   {
     "id": "dotnet-architect",


### PR DESCRIPTION
## Pull Request Description

This PR introduces a Domain-Driven Design (DDD) skill suite and connects it to repo workflows/bundles.

### Summary of changes

Added new skills:
- `domain-driven-design` (router/entry skill for DDD adoption decisions)
- `ddd-strategic-design` (subdomains, bounded contexts, ubiquitous language)
- `ddd-context-mapping` (context relationships, ACL boundaries, contract ownership)
- `ddd-tactical-patterns` (aggregates, value objects, repositories, domain events)

Fixed existing skills:
- Added missing `resources/implementation-playbook.md` for:
  - `saga-orchestration`
  - `event-store-design`

Documentation and workflow updates:
- Added **DDD & Evented Architecture** bundle section in `docs/BUNDLES.md`
- Added **Design a DDD Core Domain** workflow in `docs/WORKFLOWS.md`
- Added machine-readable workflow entry in `data/workflows.json`
- Regenerated `skills_index.json` to include new skills

## Quality Bar Checklist ✅

- [x] **Standards**: I have read `docs/QUALITY_BAR.md` and `docs/SECURITY_GUARDRAILS.md`.
- [x] **Metadata**: The `SKILL.md` frontmatter is valid (checked with `scripts/validate_skills.py`).
- [x] **Risk Label**: I have assigned the correct `risk:` tag (`none`, `safe`, `critical`, `offensive`).
- [x] **Triggers**: The "When to use" section is clear and specific.
- [x] **Security**: If this is an _offensive_ skill, I included the "Authorized Use Only" disclaimer. (N/A: no offensive skills added)
- [x] **Local Test**: I have verified the skill works locally. (validated via `python3 scripts/validate_skills.py`, workflow/JSON parse checks, and index regeneration)
- [x] **Credits**: I have added the source credit in `README.md` (if applicable). (N/A: `source: self` for newly added skills)

## Type of Change

- [x] New Skill (Feature)
- [ ] Documentation Update
- [ ] Infrastructure

## Screenshots (if applicable)
N/a