### PR TITLE
fix(front-matter): code-reviewer, architect-review and etc.

### DIFF
--- a/skills/architect-review/SKILL.md
+++ b/skills/architect-review/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: architect-review
-description: "Master software architect specializing in modern architecture"
+description: Master software architect specializing in modern architecture
   patterns, clean architecture, microservices, event-driven systems, and DDD.
   Reviews system designs and code changes for architectural integrity,
   scalability, and maintainability. Use PROACTIVELY for architectural decisions.

--- a/skills/c-pro/SKILL.md
+++ b/skills/c-pro/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: c-pro
-description: "Write efficient C code with proper memory management, pointer"
+description: Write efficient C code with proper memory management, pointer
   arithmetic, and system calls. Handles embedded systems, kernel modules, and
   performance-critical code. Use PROACTIVELY for C optimization, memory issues,
   or system programming.

--- a/skills/code-reviewer/SKILL.md
+++ b/skills/code-reviewer/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: code-reviewer
-description: "Elite code review expert specializing in modern AI-powered code"
+description: Elite code review expert specializing in modern AI-powered code
   analysis, security vulnerabilities, performance optimization, and production
   reliability. Masters static analysis tools, security scanning, and
   configuration review with 2024/2025 best practices. Use PROACTIVELY for code

--- a/skills/design-orchestration/SKILL.md
+++ b/skills/design-orchestration/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: design-orchestration
-description: ">"
+description: 
   Orchestrates design workflows by routing work through
   brainstorming, multi-agent review, and execution readiness
   in the correct order. Prevents premature implementation,

--- a/skills/haskell-pro/SKILL.md
+++ b/skills/haskell-pro/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: haskell-pro
-description: "Expert Haskell engineer specializing in advanced type systems, pure"
+description: Expert Haskell engineer specializing in advanced type systems, pure
   functional design, and high-reliability software. Use PROACTIVELY for
   type-level programming, concurrency, and architecture guidance.
 metadata:

--- a/skills/multi-agent-brainstorming/SKILL.md
+++ b/skills/multi-agent-brainstorming/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: multi-agent-brainstorming
-description: ">"
+description: 
   Use this skill when a design or idea requires higher confidence,
   risk reduction, or formal review. This skill orchestrates a
   structured, sequential multi-agent design review where each agent

--- a/skills/performance-engineer/SKILL.md
+++ b/skills/performance-engineer/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: performance-engineer
-description: "Expert performance engineer specializing in modern observability,"
+description: Expert performance engineer specializing in modern observability,
   application optimization, and scalable system performance. Masters
   OpenTelemetry, distributed tracing, load testing, multi-tier caching, Core Web
   Vitals, and performance monitoring. Handles end-to-end optimization, real user

--- a/skills/search-specialist/SKILL.md
+++ b/skills/search-specialist/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: search-specialist
-description: "Expert web researcher using advanced search techniques and"
+description: Expert web researcher using advanced search techniques and
   synthesis. Masters search operators, result filtering, and multi-source
   verification. Handles competitive analysis and fact-checking. Use PROACTIVELY
   for deep research, information gathering, or trend analysis.


### PR DESCRIPTION
# Pull Request Description

Wrong front matter in architect-review. Tested by yq-go, `yq --front-matter=format SKILL.md`.

## Quality Bar Checklist ✅

**All items must be checked before merging.**

- [ ] **Standards**: I have read `docs/QUALITY_BAR.md` and `docs/SECURITY_GUARDRAILS.md`.
- [ ] **Metadata**: The `SKILL.md` frontmatter is valid (checked with `scripts/validate_skills.py`).
- [ ] **Risk Label**: I have assigned the correct `risk:` tag (`none`, `safe`, `critical`, `offensive`).
- [ ] **Triggers**: The "When to use" section is clear and specific.
- [ ] **Security**: If this is an _offensive_ skill, I included the "Authorized Use Only" disclaimer.
- [x] **Local Test**: I have verified the skill works locally.
- [ ] **Credits**: I have added the source credit in `README.md` (if applicable).

## Type of Change

- [ ] New Skill (Feature)
- [ ] Documentation Update
- [ ] Infrastructure

## Screenshots (if applicable)
