### PR TITLE
Update README with AdaL CLI instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,6 +168,9 @@ npx antigravity-awesome-skills --kiro
 # OpenCode
 npx antigravity-awesome-skills --path .agents/skills
 
+# AdaL CLI
+npx antigravity-awesome-skills --path .adal/skills
+
 # Workspace-specific (e.g. .agent/skills for Antigravity workspace)
 npx antigravity-awesome-skills --path ~/.agent/skills
 
@@ -211,6 +214,9 @@ git clone https://github.com/sickn33/antigravity-awesome-skills.git .cursor/skil
 
 # OpenCode
 git clone https://github.com/sickn33/antigravity-awesome-skills.git .agents/skills
+
+# AdaL CLI specific
+git clone https://github.com/sickn33/antigravity-awesome-skills.git .adal/skills
 ```
 
 ### Option C: Kiro IDE Import (GUI)


### PR DESCRIPTION
# Pull Request Description

### Summary
AdaL CLI is currently listed in the supported tools table at the bottom of the `README.md`, but its specific installation commands were missing from the `npx` and `git clone` options sections. 

This PR adds the missing installation snippets for AdaL CLI (using the `.adal/skills` path) to keep the documentation consistent and helpful for new AdaL users.

## Quality Bar Checklist ✅

**All items must be checked before merging.**
*(Note: I only checked the boxes applicable to a README/documentation update. The rest are marked N/A as no new SKILL.md was added).*

- [x] **Standards**: I have read `docs/QUALITY_BAR.md` and `docs/SECURITY_GUARDRAILS.md`.
- [ ] **Metadata**: The `SKILL.md` frontmatter is valid (checked with `scripts/validate_skills.py`). *(N/A)*
- [ ] **Risk Label**: I have assigned the correct `risk:` tag (`none`, `safe`, `critical`, `offensive`). *(N/A)*
- [ ] **Triggers**: The "When to use" section is clear and specific. *(N/A)*
- [ ] **Security**: If this is an _offensive_ skill, I included the "Authorized Use Only" disclaimer. *(N/A)*
- [x] **Local Test**: I have verified the skill works locally. *(Markdown formatting verified locally)*
- [ ] **Credits**: I have added the source credit in `README.md` (if applicable). *(N/A)*

## Type of Change

- [ ] New Skill (Feature)
- [x] Documentation Update
- [ ] Infrastructure

## Screenshots (if applicable)
N/A (Text-only documentation update).