### PR TITLE
Add x-twitter-scraper skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -499,6 +499,7 @@ This collection would not be possible without the incredible work of the Claude 
 - **[nedcodes-ok/rule-porter](https://github.com/nedcodes-ok/rule-porter)**: Bidirectional rule converter between Cursor (.mdc), Claude Code (CLAUDE.md), GitHub Copilot, Windsurf, and legacy .cursorrules formats. Zero dependencies.
 - **[SSOJet/skills](https://github.com/ssojet/skills)**: Production-ready SSOJet skills and integration guides for popular frameworks and platforms — Node.js, Next.js, React, Java, .NET Core, Go, iOS, Android, and more. Works seamlessly with SSOJet SAML, OIDC, and enterprise SSO flows. Works with Cursor, Antigravity, Claude Code, and Windsurf.
 - **[MojoAuth/skills](https://github.com/MojoAuth/skills)**: Production-ready MojoAuth guides and examples for popular frameworks like Node.js, Next.js, React, Java, .NET Core, Go, iOS, and Android.
+- **[Xquik-dev/x-twitter-scraper](https://github.com/Xquik-dev/x-twitter-scraper)**: X (Twitter) data platform — tweet search, user lookup, follower extraction, engagement metrics, giveaway draws, monitoring, webhooks, 19 extraction tools, MCP server.
 
 ### Inspirations
 

--- a/skills/x-twitter-scraper/SKILL.md
+++ b/skills/x-twitter-scraper/SKILL.md
@@ -1,0 +1,129 @@
+---
+name: x-twitter-scraper
+description: "X (Twitter) data platform skill — tweet search, user lookup, follower extraction, engagement metrics, giveaway draws, monitoring, webhooks, 19 extraction tools, MCP server."
+category: data
+risk: safe
+source: community
+tags: "[twitter, x-api, scraping, mcp, social-media, data-extraction, giveaway, monitoring, webhooks]"
+date_added: "2026-02-28"
+---
+
+# X (Twitter) Scraper — Xquik
+
+## Overview
+
+Gives your AI agent full access to X (Twitter) data through the Xquik platform. Covers tweet search, user profiles, follower extraction, engagement metrics, giveaway draws, account monitoring, webhooks, and 19 bulk extraction tools — all via REST API or MCP server.
+
+## When to Use This Skill
+
+- User needs to search X/Twitter for tweets by keyword, hashtag, or user
+- User wants to look up a user profile (bio, follower counts, etc.)
+- User needs engagement metrics for a specific tweet (likes, retweets, views)
+- User wants to check if one account follows another
+- User needs to extract followers, replies, retweets, quotes, or community members in bulk
+- User wants to run a giveaway draw from tweet replies
+- User needs real-time monitoring of an X account (new tweets, follower changes)
+- User wants webhook delivery of monitored events
+- User asks about trending topics on X
+
+## Setup
+
+### Install the Skill
+
+```bash
+npx skills add Xquik-dev/x-twitter-scraper
+```
+
+Or clone manually into your agent's skills directory:
+
+```bash
+# Claude Code
+git clone https://github.com/Xquik-dev/x-twitter-scraper.git .claude/skills/x-twitter-scraper
+
+# Cursor / Codex / Gemini CLI / Copilot
+git clone https://github.com/Xquik-dev/x-twitter-scraper.git .agents/skills/x-twitter-scraper
+```
+
+### Get an API Key
+
+1. Sign up at [xquik.com](https://xquik.com)
+2. Generate an API key from the dashboard
+3. Set it as an environment variable or pass it directly
+
+```bash
+export XQUIK_API_KEY="xq_YOUR_KEY_HERE"
+```
+
+## Capabilities
+
+| Capability | Description |
+|---|---|
+| Tweet Search | Find tweets by keyword, hashtag, from:user, "exact phrase" |
+| User Lookup | Profile info, bio, follower/following counts |
+| Tweet Lookup | Full metrics — likes, retweets, replies, quotes, views, bookmarks |
+| Follow Check | Check if A follows B (both directions) |
+| Trending Topics | Top trends by region (free, no quota) |
+| Account Monitoring | Track new tweets, replies, retweets, quotes, follower changes |
+| Webhooks | HMAC-signed real-time event delivery to your endpoint |
+| Giveaway Draws | Random winner selection from tweet replies with filters |
+| 19 Extraction Tools | Followers, following, verified followers, mentions, posts, replies, reposts, quotes, threads, articles, communities, lists, Spaces, people search |
+| MCP Server | StreamableHTTP endpoint for AI-native integrations |
+
+## Examples
+
+**Search tweets:**
+```
+"Search X for tweets about 'claude code' from the last week"
+```
+
+**Look up a user:**
+```
+"Who is @elonmusk? Show me their profile and follower count"
+```
+
+**Check engagement:**
+```
+"How many likes and retweets does this tweet have? https://x.com/..."
+```
+
+**Run a giveaway:**
+```
+"Pick 3 random winners from the replies to this tweet"
+```
+
+**Monitor an account:**
+```
+"Monitor @openai for new tweets and notify me via webhook"
+```
+
+**Bulk extraction:**
+```
+"Extract all followers of @anthropic"
+```
+
+## API Reference
+
+| Endpoint | Method | Purpose |
+|----------|--------|---------|
+| `/x/tweets/{id}` | GET | Single tweet with full metrics |
+| `/x/tweets/search` | GET | Search tweets |
+| `/x/users/{username}` | GET | User profile |
+| `/x/followers/check` | GET | Follow relationship |
+| `/trends` | GET | Trending topics |
+| `/monitors` | POST | Create monitor |
+| `/events` | GET | Poll monitored events |
+| `/webhooks` | POST | Register webhook |
+| `/draws` | POST | Run giveaway draw |
+| `/extractions` | POST | Start bulk extraction |
+| `/extractions/estimate` | POST | Estimate extraction cost |
+| `/account` | GET | Account & usage info |
+
+**Base URL:** `https://xquik.com/api/v1`
+**Auth:** `x-api-key: xq_...` header
+**MCP:** `https://xquik.com/mcp` (StreamableHTTP, same API key)
+
+## Repository
+
+https://github.com/Xquik-dev/x-twitter-scraper
+
+**Maintained By:** [Xquik](https://xquik.com)


### PR DESCRIPTION
Adds [x-twitter-scraper](https://github.com/Xquik-dev/x-twitter-scraper) — an X (Twitter) data platform skill covering tweet search, user lookup, follower extraction, engagement metrics, giveaway draws, monitoring, webhooks, 19 extraction tools, and MCP server.

- `skills/x-twitter-scraper/SKILL.md` with frontmatter, capabilities table, examples, and API reference
- Community Contributors entry in README