### PR TITLE
Add shmlkv/dna-claude-analysis to Community Contributors

### DIFF
--- a/README.md
+++ b/README.md
@@ -500,6 +500,7 @@ This collection would not be possible without the incredible work of the Claude 
 - **[SSOJet/skills](https://github.com/ssojet/skills)**: Production-ready SSOJet skills and integration guides for popular frameworks and platforms — Node.js, Next.js, React, Java, .NET Core, Go, iOS, Android, and more. Works seamlessly with SSOJet SAML, OIDC, and enterprise SSO flows. Works with Cursor, Antigravity, Claude Code, and Windsurf.
 - **[MojoAuth/skills](https://github.com/MojoAuth/skills)**: Production-ready MojoAuth guides and examples for popular frameworks like Node.js, Next.js, React, Java, .NET Core, Go, iOS, and Android.
 - **[Xquik-dev/x-twitter-scraper](https://github.com/Xquik-dev/x-twitter-scraper)**: X (Twitter) data platform — tweet search, user lookup, follower extraction, engagement metrics, giveaway draws, monitoring, webhooks, 19 extraction tools, MCP server.
+- **[shmlkv/dna-claude-analysis](https://github.com/shmlkv/dna-claude-analysis)**: Personal genome analysis toolkit — Python scripts analyzing raw DNA data across 17 categories (health risks, ancestry, pharmacogenomics, nutrition, psychology, etc.) with terminal-style single-page HTML visualization.
 
 ### Inspirations
 


### PR DESCRIPTION
## Summary

- Adds [shmlkv/dna-claude-analysis](https://github.com/shmlkv/dna-claude-analysis) to the Community Contributors section
- Personal genome analysis toolkit built with Claude Code
- Analyzes raw DNA data across 17 categories (health risks, ancestry, pharmacogenomics, nutrition, psychology, longevity, sleep, immunity, etc.)
- Generates a terminal-style single-page HTML visualization from Python-produced markdown reports

## Project Details

**Repository**: https://github.com/shmlkv/dna-claude-analysis  
**License**: MIT  
**Stack**: Python analysis scripts + single-file HTML output (no external dependencies except Google Fonts)

The project demonstrates a complete agentic workflow: raw data in → analysis scripts → markdown reports → rendered visualization, all driven by Claude Code skills.