### PR TITLE
Add The Graph subgraph skills (dev, optimization, testing)

### DIFF
--- a/skills/the-graph-subgraph-dev/SKILL.md
+++ b/skills/the-graph-subgraph-dev/SKILL.md
@@ -1,0 +1,117 @@
+---
+name: the-graph-subgraph-dev
+description: "Use when developing, building, or deploying a subgraph on The Graph. Covers schema design, subgraph.yaml manifests, AssemblyScript mappings, and event handlers."
+risk: low
+source: "PaulieB14/subgraphs-skills (MIT)"
+date_added: "2026-03-01"
+---
+
+# The Graph — Subgraph Development
+
+You're an expert in building subgraphs on The Graph protocol. You've indexed dozens of DeFi, NFT, and DAO protocols. You know every schema pattern, every AssemblyScript gotcha, and every deployment workflow.
+
+Your hard-won lessons: The team that didn't use `@derivedFrom` had unbounded arrays that killed query performance. The team that used String IDs instead of Bytes wasted 2x storage. The team that skipped `try_` on contract calls had subgraphs crashing on reverts. You've learned to design schemas around query patterns first.
+
+## When to Use
+
+Use when the user asks to:
+- Create or build a new subgraph
+- Design a GraphQL schema for blockchain data
+- Write AssemblyScript mapping handlers
+- Configure `subgraph.yaml` manifests
+- Handle events, calls, or block triggers
+- Use factory patterns / data source templates
+- Deploy to Subgraph Studio or The Graph Network
+
+## Quick Start
+
+```bash
+npm install -g @graphprotocol/graph-cli
+graph init --product subgraph-studio
+graph codegen && graph build
+graph auth --studio <DEPLOY_KEY>
+graph deploy --studio <SUBGRAPH_SLUG>
+```
+
+## Key Patterns
+
+### Schema — always use Bytes IDs and @derivedFrom
+
+```graphql
+type Pool @entity {
+  id: Bytes!
+  swaps: [Swap!]! @derivedFrom(field: "pool")  # Never store arrays directly
+}
+
+type Swap @entity(immutable: true) {  # immutable = 28% faster queries
+  id: Bytes!
+  pool: Pool!
+  amountIn: BigInt!
+  amountOut: BigInt!
+  timestamp: BigInt!
+}
+```
+
+### Mapping — safe null handling
+
+```typescript
+import { Transfer } from "../generated/ERC20/ERC20"
+import { Token } from "../generated/schema"
+
+export function handleTransfer(event: Transfer): void {
+  let token = Token.load(event.address)
+  if (token == null) {
+    token = new Token(event.address)
+    token.totalSupply = BigInt.zero()
+  }
+  // Use concatI32 for unique Bytes IDs
+  let id = event.transaction.hash.concatI32(event.logIndex.toI32())
+  token.save()
+}
+```
+
+### Manifest — subgraph.yaml essentials
+
+```yaml
+specVersion: 1.3.0
+schema:
+  file: ./schema.graphql
+indexerHints:
+  prune: auto          # Always enable unless time-travel queries needed
+dataSources:
+  - kind: ethereum/contract
+    name: ERC20
+    network: mainnet
+    source:
+      address: "0x..."
+      abi: ERC20
+      startBlock: 12345678
+    mapping:
+      kind: ethereum/events
+      apiVersion: 0.0.9
+      language: wasm/assemblyscript
+      entities: [Token, Transfer]
+      abis:
+        - name: ERC20
+          file: ./abis/ERC20.json
+      eventHandlers:
+        - event: Transfer(indexed address,indexed address,uint256)
+          handler: handleTransfer
+      file: ./src/mapping.ts
+```
+
+## Usage Examples
+
+```
+"Create a subgraph schema for tracking Uniswap V3 swaps"
+"Write an AssemblyScript handler for ERC20 Transfer events"
+"How do I use data source templates for a factory pattern?"
+"Configure subgraph.yaml for a multi-contract protocol"
+"Deploy my subgraph to The Graph Network"
+```
+
+## References
+
+- [The Graph Docs](https://thegraph.com/docs/)
+- [AssemblyScript API](https://thegraph.com/docs/en/subgraphs/developing/creating/assemblyscript-api/)
+- [Subgraph Studio](https://thegraph.com/studio/)

--- a/skills/the-graph-subgraph-optimization/SKILL.md
+++ b/skills/the-graph-subgraph-optimization/SKILL.md
@@ -1,0 +1,141 @@
+---
+name: the-graph-subgraph-optimization
+description: "Use when optimizing a subgraph on The Graph for faster indexing or queries. Covers pruning, @derivedFrom, immutable entities, avoiding eth_calls, and grafting."
+risk: low
+source: "PaulieB14/subgraphs-skills (MIT)"
+date_added: "2026-03-01"
+---
+
+# The Graph — Subgraph Optimization
+
+You're an expert in subgraph performance. You've seen slow subgraphs take days to sync and fast ones finish in hours. You know every optimization The Graph team has shipped and when to apply each one.
+
+Your hard-won lessons: The team with unbounded arrays in their schema had queries timing out. The team making eth_calls on every event was 10x slower than the team that read from events. The team that skipped immutable entities lost 28% query speed for no reason.
+
+## When to Use
+
+Use when the user asks to:
+- Speed up subgraph indexing or sync time
+- Improve GraphQL query performance
+- Reduce database size
+- Apply pruning, immutable entities, or Bytes IDs
+- Avoid eth_calls
+- Use timeseries aggregations
+- Deploy a hotfix without re-indexing (grafting)
+
+## The 6 Core Optimizations
+
+### 1. Pruning (biggest win — add this first)
+
+```yaml
+# subgraph.yaml
+indexerHints:
+  prune: auto   # Removes old history, dramatically reduces DB size
+```
+
+### 2. @derivedFrom (never store arrays directly)
+
+```graphql
+# BAD — array grows unbounded, kills performance
+type Pool @entity { swaps: [Swap!]! }
+
+# GOOD — stored on child, derived on parent
+type Pool @entity { swaps: [Swap!]! @derivedFrom(field: "pool") }
+type Swap @entity { pool: Pool! }
+```
+
+### 3. Immutable Entities + Bytes IDs (~28% faster queries, ~48% faster indexing)
+
+```graphql
+type Transfer @entity(immutable: true) {  # Never updated after creation
+  id: Bytes!                              # Bytes not String — half the storage
+  from: Bytes!
+  value: BigInt!
+}
+```
+
+```typescript
+// Bytes ID — always use concatI32, never toHex() + string concat
+let id = event.transaction.hash.concatI32(event.logIndex.toI32())
+```
+
+### 4. Avoid eth_calls — emit data in events instead
+
+```solidity
+// BAD — forces subgraph to call contract
+event Swap(address pool, uint256 amountIn, uint256 amountOut);
+
+// GOOD — all data in event, no call needed
+event Swap(address pool, address tokenIn, address tokenOut,
+           uint256 amountIn, uint256 amountOut, uint256 reserve0, uint256 reserve1);
+```
+
+If eth_calls are unavoidable, cache on first use:
+```typescript
+let pool = Pool.load(address)
+if (pool == null) {
+  pool = new Pool(address)
+  let contract = PoolContract.bind(address)
+  pool.token0 = contract.token0()  // Only call once, ever
+  pool.save()
+}
+```
+
+### 5. Timeseries Aggregations (database-level, not mapping-level)
+
+```graphql
+type TokenHourData @entity(timeseries: true) {
+  id: Int8!
+  timestamp: Timestamp!
+  token: Token!
+  priceUSD: BigDecimal!
+  volumeUSD: BigDecimal!
+}
+
+type TokenDayData @aggregation(intervals: ["hour", "day"], source: "TokenHourData") {
+  id: Int8!
+  timestamp: Timestamp!
+  token: Token!
+  totalVolume: BigDecimal! @aggregate(fn: "sum", arg: "volumeUSD")
+  avgPrice: BigDecimal! @aggregate(fn: "avg", arg: "priceUSD")
+}
+```
+
+### 6. Grafting (hotfix without re-indexing)
+
+```yaml
+features:
+  - grafting
+graft:
+  base: QmExistingDeploymentId
+  block: 18000000
+```
+
+## Performance Checklist
+
+```
+✅ indexerHints.prune: auto enabled
+✅ No bare arrays in schema (use @derivedFrom)
+✅ Event-derived entities marked immutable
+✅ Bytes IDs (not String)
+✅ eth_calls minimized / cached
+✅ Timeseries for time-based aggregations
+```
+
+## Usage Examples
+
+```
+"My subgraph is taking too long to index, how do I speed it up?"
+"How do I use pruning in my subgraph?"
+"Should I use immutable entities for my Transfer events?"
+"How do I avoid eth_calls in my mapping?"
+"I need to deploy a bug fix without losing indexed data"
+```
+
+## References
+
+- [Pruning](https://thegraph.com/docs/en/subgraphs/best-practices/pruning/)
+- [Immutable Entities](https://thegraph.com/docs/en/subgraphs/best-practices/immutable-entities-bytes-as-ids/)
+- [Avoiding eth_calls](https://thegraph.com/docs/en/subgraphs/best-practices/avoid-eth-calls/)
+- [Timeseries](https://thegraph.com/docs/en/subgraphs/best-practices/timeseries/)
+- [Grafting](https://thegraph.com/docs/en/subgraphs/best-practices/grafting-hotfix/)

--- a/skills/the-graph-subgraph-testing/SKILL.md
+++ b/skills/the-graph-subgraph-testing/SKILL.md
@@ -1,0 +1,165 @@
+---
+name: the-graph-subgraph-testing
+description: "Use when testing a subgraph on The Graph with Matchstick unit tests, Subgraph Linter static analysis, or CI/CD pipelines. Covers mock events, entity assertions, and contract mocks."
+risk: low
+source: "PaulieB14/subgraphs-skills (MIT)"
+date_added: "2026-03-01"
+---
+
+# The Graph — Subgraph Testing
+
+You're an expert in subgraph quality assurance. You've caught division-by-zero bugs with the linter before they crashed production. You've written Matchstick tests that found entity overwrite bugs that would have corrupted data silently for months.
+
+Your hard-won lessons: The team that skipped linting had a subgraph crash on mainnet from a force-unwrapped null. The team that didn't test their handlers shipped broken P&L calculations for weeks. Static analysis + unit tests catch 90% of issues before deployment.
+
+## When to Use
+
+Use when the user asks to:
+- Write unit tests for subgraph mapping handlers
+- Use Matchstick testing framework
+- Run Subgraph Linter static analysis
+- Mock blockchain events or contract calls
+- Assert entity field values in tests
+- Set up CI/CD for a subgraph project
+- Catch null pointer, division-by-zero, or entity overwrite bugs
+
+## Quick Start
+
+```bash
+npm install --save-dev matchstick-as
+graph test                    # Run all tests
+graph test mapping            # Run specific test file
+graph test -c                 # With coverage
+```
+
+## Subgraph Linter (run this first)
+
+Catches runtime bugs at compile time — run before every commit.
+
+```bash
+git clone https://github.com/graphprotocol/subgraph-linter.git
+cd subgraph-linter && npm install && npm run build
+npm run check -- --manifest ../your-subgraph/subgraph.yaml
+```
+
+Key checks it catches:
+
+| Bug | Pattern |
+|-----|---------|
+| Null crash | `Entity.load(id)!` without null check |
+| Entity overwrite | Helper saves entity, then caller saves stale copy |
+| Division by zero | `a.div(b)` where b could be zero |
+| Undeclared eth_call | Contract call not in manifest `calls:` block |
+
+```typescript
+// BAD — crashes if entity doesn't exist
+let token = Token.load(address)!
+
+// GOOD — explicit null check
+let token = Token.load(address)
+if (token == null) {
+  token = new Token(address)
+  token.totalSupply = BigInt.zero()
+}
+```
+
+## Matchstick Unit Tests
+
+### Basic test structure
+
+```typescript
+import { describe, test, afterEach, clearStore, assert } from "matchstick-as"
+import { handleTransfer } from "../src/mapping"
+
+describe("Transfer Handler", () => {
+  afterEach(() => { clearStore() })  // Always clear between tests
+
+  test("creates Transfer entity", () => {
+    let event = createTransferEvent(from, to, BigInt.fromI32(1000))
+    handleTransfer(event)
+    assert.entityCount("TransferEvent", 1)
+    assert.fieldEquals("TransferEvent", id, "value", "1000")
+  })
+})
+```
+
+### Creating mock events
+
+```typescript
+import { newMockEvent } from "matchstick-as"
+import { ethereum, Address, BigInt } from "@graphprotocol/graph-ts"
+import { Transfer } from "../generated/ERC20/ERC20"
+
+export function createTransferEvent(from: Address, to: Address, value: BigInt): Transfer {
+  let event = changetype<Transfer>(newMockEvent())
+  event.parameters = [
+    new ethereum.EventParam("from", ethereum.Value.fromAddress(from)),
+    new ethereum.EventParam("to", ethereum.Value.fromAddress(to)),
+    new ethereum.EventParam("value", ethereum.Value.fromUnsignedBigInt(value))
+  ]
+  event.block.timestamp = BigInt.fromI32(1640000000)
+  event.transaction.hash = Bytes.fromHexString("0xabc123...")
+  return event
+}
+```
+
+### Mocking contract calls
+
+```typescript
+import { createMockedFunction } from "matchstick-as"
+
+createMockedFunction(contractAddress, "name", "name():(string)")
+  .returns([ethereum.Value.fromString("My Token")])
+
+createMockedFunction(contractAddress, "decimals", "decimals():(uint8)")
+  .returns([ethereum.Value.fromI32(18)])
+
+// Mock a revert
+createMockedFunction(contractAddress, "name", "name():(string)").reverts()
+```
+
+### Assertions
+
+```typescript
+assert.entityCount("Token", 1)
+assert.fieldEquals("Token", tokenId, "name", "My Token")
+assert.fieldEquals("Token", tokenId, "decimals", "18")
+assert.fieldEquals("Transfer", id, "value", "1000000000000000000")
+assert.notInStore("Token", "nonexistent-id")
+```
+
+## CI/CD Pipeline
+
+```yaml
+# .github/workflows/test.yml
+name: Test Subgraph
+on: [push, pull_request]
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with: { node-version: '18' }
+      - run: npm ci
+      - run: npm run codegen
+      - run: npm run check -- --manifest subgraph.yaml  # Linter
+      - run: npm test                                    # Matchstick
+      - run: npm run build
+```
+
+## Usage Examples
+
+```
+"Write Matchstick tests for my Transfer event handler"
+"Run the Subgraph Linter on my project"
+"How do I mock a contract call in my tests?"
+"Set up CI/CD for my subgraph with GitHub Actions"
+"My subgraph crashes with a null error, how do I find it?"
+```
+
+## References
+
+- [Matchstick Docs](https://thegraph.com/docs/en/subgraphs/developing/creating/unit-testing-framework/)
+- [Subgraph Linter](https://thegraph.com/docs/en/subgraphs/developing/subgraph-linter/)
+- [Subgraph Uncrashable](https://thegraph.com/docs/en/subgraphs/developing/subgraph-uncrashable/)


### PR DESCRIPTION
## New Skills

Adds three skills for working with [The Graph](https://thegraph.com/) protocol subgraphs — the decentralized indexing protocol used by Uniswap, Aave, ENS, and 15,000+ other protocols.

| Skill | Triggers |
|-------|---------|
| `the-graph-subgraph-dev` | Building subgraphs, schema design, AssemblyScript mappings, subgraph.yaml, deployment |
| `the-graph-subgraph-optimization` | Pruning, @derivedFrom, immutable entities, avoiding eth_calls, grafting |
| `the-graph-subgraph-testing` | Matchstick unit tests, Subgraph Linter static analysis, CI/CD |

## Quality Check

- [x] Metadata: name matches folder, description under 200 chars, trigger-focused
- [x] Safety: no harmful commands, risk: low
- [x] Clarity: "When to Use" section in each skill
- [x] Examples: copy-paste usage prompts in each skill
- [x] Actions: concrete code examples and CLI commands

## Source

MIT licensed. Based on [PaulieB14/subgraphs-skills](https://github.com/PaulieB14/subgraphs-skills).

🤖 Generated with [Claude Code](https://claude.ai/claude-code)