### PR TITLE
docs: add jonathimer/devmarketing-skills to Community Contributors

### DIFF
--- a/README.md
+++ b/README.md
@@ -490,6 +490,7 @@ This collection would not be possible without the incredible work of the Claude 
 - **[zircote/.claude](https://github.com/zircote/.claude)**: Shopify development skill reference.
 - **[vibeforge1111/vibeship-spawner-skills](https://github.com/vibeforge1111/vibeship-spawner-skills)**: AI Agents, Integrations, Maker Tools (57 skills, Apache 2.0).
 - **[coreyhaines31/marketingskills](https://github.com/coreyhaines31/marketingskills)**: Marketing skills for CRO, copywriting, SEO, paid ads, and growth (23 skills, MIT).
+- **[jonathimer/devmarketing-skills](https://github.com/jonathimer/devmarketing-skills)**: Developer marketing skills — HN strategy, technical tutorials, docs-as-marketing, Reddit engagement, developer onboarding, and more (33 skills, MIT).
 - **[Silverov/yandex-direct-skill](https://github.com/Silverov/yandex-direct-skill)**: Yandex Direct (API v5) advertising audit skill — 55 automated checks, A-F scoring, campaign/ad/keyword analysis for the Russian PPC market (MIT).
 - **[vudovn/antigravity-kit](https://github.com/vudovn/antigravity-kit)**: AI Agent templates with Skills, Agents, and Workflows (33 skills, MIT).
 - **[affaan-m/everything-claude-code](https://github.com/affaan-m/everything-claude-code)**: Complete Claude Code configuration collection from Anthropic hackathon winner - skills only (8 skills, MIT).


### PR DESCRIPTION
## Summary

Adding [jonathimer/devmarketing-skills](https://github.com/jonathimer/devmarketing-skills) to the Community Contributors section.

**What it is:** 33 AI agent skills for developer marketing — specifically built for marketing to developers, who skip landing pages and go straight to docs/GitHub.

**Skills include:**
- Hacker News strategy (what works vs what gets flagged)
- Technical tutorials
- Docs-as-marketing
- Reddit engagement
- Developer onboarding
- Developer newsletters
- SEO for devtools
- Community building
- And more

**License:** MIT

**Install:** `npx add-skill jonathimer/devmarketing-skills`

Works with Claude Code, Cursor, Windsurf, and other AI coding assistants.