### PR TITLE
Add Production Grade skill — 14-agent orchestrator pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -503,6 +503,7 @@ This collection would not be possible without the incredible work of the Claude 
 - **[MojoAuth/skills](https://github.com/MojoAuth/skills)**: Production-ready MojoAuth guides and examples for popular frameworks like Node.js, Next.js, React, Java, .NET Core, Go, iOS, and Android.
 - **[Xquik-dev/x-twitter-scraper](https://github.com/Xquik-dev/x-twitter-scraper)**: X (Twitter) data platform — tweet search, user lookup, follower extraction, engagement metrics, giveaway draws, monitoring, webhooks, 19 extraction tools, MCP server.
 - **[shmlkv/dna-claude-analysis](https://github.com/shmlkv/dna-claude-analysis)**: Personal genome analysis toolkit — Python scripts analyzing raw DNA data across 17 categories (health risks, ancestry, pharmacogenomics, nutrition, psychology, etc.) with terminal-style single-page HTML visualization.
+- **[nagisanzenin/claude-code-production-grade-plugin](https://github.com/nagisanzenin/claude-code-production-grade-plugin)**: Production Grade — 14-agent autonomous pipeline for full-project delivery. Requirements, architecture, backend, frontend, testing, security, code review, infrastructure, SRE, documentation. Two-wave parallel execution (MIT).
 
 ### Inspirations
 


### PR DESCRIPTION
## Summary

- Adds **[Production Grade](https://github.com/nagisanzenin/claude-code-production-grade-plugin)** to the Community Contributors section in README.md.
- 14-agent autonomous pipeline for full-project delivery: requirements, architecture, backend, frontend, testing, security, code review, infrastructure, SRE, and documentation.
- Two-wave parallel execution. MIT licensed.

## Details

Entry added to the **Community Contributors** section following the existing format (`- **[user/repo](url)**: Description (license).`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)