### PR TITLE
Add debug-skill: interactive debugger for AI agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,6 +238,7 @@ This collection would not be possible without the incredible work of the Claude 
 - **[MojoAuth/skills](https://github.com/MojoAuth/skills)**: Production-ready MojoAuth guides and examples for popular frameworks like Node.js, Next.js, React, Java, .NET Core, Go, iOS, and Android.
 - **[Xquik-dev/x-twitter-scraper](https://github.com/Xquik-dev/x-twitter-scraper)**: X (Twitter) data platform — tweet search, user lookup, follower extraction, engagement metrics, giveaway draws, monitoring, webhooks, 19 extraction tools, MCP server.
 - **[shmlkv/dna-claude-analysis](https://github.com/shmlkv/dna-claude-analysis)**: Personal genome analysis toolkit — Python scripts analyzing raw DNA data across 17 categories (health risks, ancestry, pharmacogenomics, nutrition, psychology, etc.) with terminal-style single-page HTML visualization.
+- **[AlmogBaku/debug-skill](https://github.com/AlmogBaku/debug-skill)**: Interactive debugger skill for AI agents — breakpoints, stepping, variable inspection, and stack traces via the `dap` CLI. Supports Python, Go, Node.js/TypeScript, Rust, and C/C++.
 
 ### Inspirations
 


### PR DESCRIPTION
## What is this?

[`debugging-code`](https://github.com/AlmogBaku/debug-skill) is a skill that gives AI agents access to a real interactive debugger via the `dap` CLI.

Instead of print-statement debugging, the agent can:
- Set breakpoints and step through code line by line
- Inspect live variable values and the call stack
- Evaluate expressions against the running process

**Supported languages:** Python · Go · Node.js/TypeScript · Rust · C/C++

**GitHub:** https://github.com/AlmogBaku/debug-skill