### PR TITLE
fix: restore author: zebbern attribution to 29 security skills

### DIFF
--- a/skills/active-directory-attacks/SKILL.md
+++ b/skills/active-directory-attacks/SKILL.md
@@ -3,6 +3,7 @@ name: active-directory-attacks
 description: "This skill should be used when the user asks to \"attack Active Directory\", \"exploit AD\", \"Kerberoasting\", \"DCSync\", \"pass-the-hash\", \"BloodHound enumeration\", \"Golden Ticket\", ..."
 risk: unknown
 source: community
+author: zebbern
 date_added: "2026-02-27"
 ---
 

--- a/skills/api-fuzzing-bug-bounty/SKILL.md
+++ b/skills/api-fuzzing-bug-bounty/SKILL.md
@@ -3,6 +3,7 @@ name: api-fuzzing-bug-bounty
 description: "This skill should be used when the user asks to \"test API security\", \"fuzz APIs\", \"find IDOR vulnerabilities\", \"test REST API\", \"test GraphQL\", \"API penetration testing\", \"bug b..."
 risk: unknown
 source: community
+author: zebbern
 date_added: "2026-02-27"
 ---
 

--- a/skills/aws-penetration-testing/SKILL.md
+++ b/skills/aws-penetration-testing/SKILL.md
@@ -3,6 +3,7 @@ name: aws-penetration-testing
 description: "This skill should be used when the user asks to \"pentest AWS\", \"test AWS security\", \"enumerate IAM\", \"exploit cloud infrastructure\", \"AWS privilege escalation\", \"S3 bucket testing..."
 risk: unknown
 source: community
+author: zebbern
 date_added: "2026-02-27"
 ---
 

--- a/skills/broken-authentication/SKILL.md
+++ b/skills/broken-authentication/SKILL.md
@@ -3,6 +3,7 @@ name: broken-authentication
 description: "This skill should be used when the user asks to \"test for broken authentication vulnerabilities\", \"assess session management security\", \"perform credential stuffing tests\", \"evaluate ..."
 risk: unknown
 source: community
+author: zebbern
 date_added: "2026-02-27"
 ---
 

--- a/skills/burp-suite-testing/SKILL.md
+++ b/skills/burp-suite-testing/SKILL.md
@@ -3,6 +3,7 @@ name: burp-suite-testing
 description: "This skill should be used when the user asks to \"intercept HTTP traffic\", \"modify web requests\", \"use Burp Suite for testing\", \"perform web vulnerability scanning\", \"test with Burp ..."
 risk: unknown
 source: community
+author: zebbern
 date_added: "2026-02-27"
 ---
 

--- a/skills/cloud-penetration-testing/SKILL.md
+++ b/skills/cloud-penetration-testing/SKILL.md
@@ -3,6 +3,7 @@ name: cloud-penetration-testing
 description: "This skill should be used when the user asks to \"perform cloud penetration testing\", \"assess Azure or AWS or GCP security\", \"enumerate cloud resources\", \"exploit cloud misconfiguratio..."
 risk: unknown
 source: community
+author: zebbern
 date_added: "2026-02-27"
 ---
 

--- a/skills/ethical-hacking-methodology/SKILL.md
+++ b/skills/ethical-hacking-methodology/SKILL.md
@@ -3,6 +3,7 @@ name: ethical-hacking-methodology
 description: "This skill should be used when the user asks to \"learn ethical hacking\", \"understand penetration testing lifecycle\", \"perform reconnaissance\", \"conduct security scanning\", \"exploit ..."
 risk: unknown
 source: community
+author: zebbern
 date_added: "2026-02-27"
 ---
 

--- a/skills/file-path-traversal/SKILL.md
+++ b/skills/file-path-traversal/SKILL.md
@@ -3,6 +3,7 @@ name: file-path-traversal
 description: "This skill should be used when the user asks to \"test for directory traversal\", \"exploit path traversal vulnerabilities\", \"read arbitrary files through web applications\", \"find LFI vu..."
 risk: unknown
 source: community
+author: zebbern
 date_added: "2026-02-27"
 ---
 

--- a/skills/html-injection-testing/SKILL.md
+++ b/skills/html-injection-testing/SKILL.md
@@ -3,6 +3,7 @@ name: html-injection-testing
 description: "This skill should be used when the user asks to \"test for HTML injection\", \"inject HTML into web pages\", \"perform HTML injection attacks\", \"deface web applications\", or \"test conten..."
 risk: unknown
 source: community
+author: zebbern
 date_added: "2026-02-27"
 ---
 

--- a/skills/idor-testing/SKILL.md
+++ b/skills/idor-testing/SKILL.md
@@ -3,6 +3,7 @@ name: idor-testing
 description: "This skill should be used when the user asks to \"test for insecure direct object references,\" \"find IDOR vulnerabilities,\" \"exploit broken access control,\" \"enumerate user IDs or obje..."
 risk: unknown
 source: community
+author: zebbern
 date_added: "2026-02-27"
 ---
 

--- a/skills/linux-privilege-escalation/SKILL.md
+++ b/skills/linux-privilege-escalation/SKILL.md
@@ -3,6 +3,7 @@ name: linux-privilege-escalation
 description: "This skill should be used when the user asks to \"escalate privileges on Linux\", \"find privesc vectors on Linux systems\", \"exploit sudo misconfigurations\", \"abuse SUID binaries\", \"ex..."
 risk: unknown
 source: community
+author: zebbern
 date_added: "2026-02-27"
 ---
 

--- a/skills/linux-shell-scripting/SKILL.md
+++ b/skills/linux-shell-scripting/SKILL.md
@@ -3,6 +3,7 @@ name: linux-shell-scripting
 description: "This skill should be used when the user asks to \"create bash scripts\", \"automate Linux tasks\", \"monitor system resources\", \"backup files\", \"manage users\", or \"write production she..."
 risk: unknown
 source: community
+author: zebbern
 date_added: "2026-02-27"
 ---
 

--- a/skills/metasploit-framework/SKILL.md
+++ b/skills/metasploit-framework/SKILL.md
@@ -3,6 +3,7 @@ name: metasploit-framework
 description: "This skill should be used when the user asks to \"use Metasploit for penetration testing\", \"exploit vulnerabilities with msfconsole\", \"create payloads with msfvenom\", \"perform post-exp..."
 risk: unknown
 source: community
+author: zebbern
 date_added: "2026-02-27"
 ---
 

--- a/skills/network-101/SKILL.md
+++ b/skills/network-101/SKILL.md
@@ -3,6 +3,7 @@ name: network-101
 description: "This skill should be used when the user asks to \"set up a web server\", \"configure HTTP or HTTPS\", \"perform SNMP enumeration\", \"configure SMB shares\", \"test network services\", or ne..."
 risk: unknown
 source: community
+author: zebbern
 date_added: "2026-02-27"
 ---
 

--- a/skills/pentest-checklist/SKILL.md
+++ b/skills/pentest-checklist/SKILL.md
@@ -3,6 +3,7 @@ name: pentest-checklist
 description: "This skill should be used when the user asks to \"plan a penetration test\", \"create a security assessment checklist\", \"prepare for penetration testing\", \"define pentest scope\", \"foll..."
 risk: unknown
 source: community
+author: zebbern
 date_added: "2026-02-27"
 ---
 

--- a/skills/pentest-commands/SKILL.md
+++ b/skills/pentest-commands/SKILL.md
@@ -3,6 +3,7 @@ name: pentest-commands
 description: "This skill should be used when the user asks to \"run pentest commands\", \"scan with nmap\", \"use metasploit exploits\", \"crack passwords with hydra or john\", \"scan web vulnerabilities ..."
 risk: unknown
 source: community
+author: zebbern
 date_added: "2026-02-27"
 ---
 

--- a/skills/privilege-escalation-methods/SKILL.md
+++ b/skills/privilege-escalation-methods/SKILL.md
@@ -3,6 +3,7 @@ name: privilege-escalation-methods
 description: "This skill should be used when the user asks to \"escalate privileges\", \"get root access\", \"become administrator\", \"privesc techniques\", \"abuse sudo\", \"exploit SUID binaries\", \"K..."
 risk: unknown
 source: community
+author: zebbern
 date_added: "2026-02-27"
 ---
 

--- a/skills/red-team-tools/SKILL.md
+++ b/skills/red-team-tools/SKILL.md
@@ -3,6 +3,7 @@ name: red-team-tools
 description: "This skill should be used when the user asks to \"follow red team methodology\", \"perform bug bounty hunting\", \"automate reconnaissance\", \"hunt for XSS vulnerabilities\", \"enumerate su..."
 risk: unknown
 source: community
+author: zebbern
 date_added: "2026-02-27"
 ---
 

--- a/skills/scanning-tools/SKILL.md
+++ b/skills/scanning-tools/SKILL.md
@@ -3,6 +3,7 @@ name: scanning-tools
 description: "This skill should be used when the user asks to \"perform vulnerability scanning\", \"scan networks for open ports\", \"assess web application security\", \"scan wireless networks\", \"detec..."
 risk: unknown
 source: community
+author: zebbern
 date_added: "2026-02-27"
 ---
 

--- a/skills/shodan-reconnaissance/SKILL.md
+++ b/skills/shodan-reconnaissance/SKILL.md
@@ -3,6 +3,7 @@ name: shodan-reconnaissance
 description: "This skill should be used when the user asks to \"search for exposed devices on the internet,\" \"perform Shodan reconnaissance,\" \"find vulnerable services using Shodan,\" \"scan IP ranges..."
 risk: unknown
 source: community
+author: zebbern
 date_added: "2026-02-27"
 ---
 

--- a/skills/smtp-penetration-testing/SKILL.md
+++ b/skills/smtp-penetration-testing/SKILL.md
@@ -3,6 +3,7 @@ name: smtp-penetration-testing
 description: "This skill should be used when the user asks to \"perform SMTP penetration testing\", \"enumerate email users\", \"test for open mail relays\", \"grab SMTP banners\", \"brute force email cre..."
 risk: unknown
 source: community
+author: zebbern
 date_added: "2026-02-27"
 ---
 

--- a/skills/sql-injection-testing/SKILL.md
+++ b/skills/sql-injection-testing/SKILL.md
@@ -3,6 +3,7 @@ name: sql-injection-testing
 description: "This skill should be used when the user asks to \"test for SQL injection vulnerabilities\", \"perform SQLi attacks\", \"bypass authentication using SQL injection\", \"extract database inform..."
 risk: unknown
 source: community
+author: zebbern
 date_added: "2026-02-27"
 ---
 

--- a/skills/sqlmap-database-pentesting/SKILL.md
+++ b/skills/sqlmap-database-pentesting/SKILL.md
@@ -3,6 +3,7 @@ name: sqlmap-database-pentesting
 description: "This skill should be used when the user asks to \"automate SQL injection testing,\" \"enumerate database structure,\" \"extract database credentials using sqlmap,\" \"dump tables and columns..."
 risk: unknown
 source: community
+author: zebbern
 date_added: "2026-02-27"
 ---
 

--- a/skills/ssh-penetration-testing/SKILL.md
+++ b/skills/ssh-penetration-testing/SKILL.md
@@ -3,6 +3,7 @@ name: ssh-penetration-testing
 description: "This skill should be used when the user asks to \"pentest SSH services\", \"enumerate SSH configurations\", \"brute force SSH credentials\", \"exploit SSH vulnerabilities\", \"perform SSH tu..."
 risk: unknown
 source: community
+author: zebbern
 date_added: "2026-02-27"
 ---
 

--- a/skills/top-web-vulnerabilities/SKILL.md
+++ b/skills/top-web-vulnerabilities/SKILL.md
@@ -3,6 +3,7 @@ name: top-web-vulnerabilities
 description: "This skill should be used when the user asks to \"identify web application vulnerabilities\", \"explain common security flaws\", \"understand vulnerability categories\", \"learn about inject..."
 risk: unknown
 source: community
+author: zebbern
 date_added: "2026-02-27"
 ---
 

--- a/skills/windows-privilege-escalation/SKILL.md
+++ b/skills/windows-privilege-escalation/SKILL.md
@@ -3,6 +3,7 @@ name: windows-privilege-escalation
 description: "This skill should be used when the user asks to \"escalate privileges on Windows,\" \"find Windows privesc vectors,\" \"enumerate Windows for privilege escalation,\" \"exploit Windows miscon..."
 risk: unknown
 source: community
+author: zebbern
 date_added: "2026-02-27"
 ---
 

--- a/skills/wireshark-analysis/SKILL.md
+++ b/skills/wireshark-analysis/SKILL.md
@@ -3,6 +3,7 @@ name: wireshark-analysis
 description: "This skill should be used when the user asks to \"analyze network traffic with Wireshark\", \"capture packets for troubleshooting\", \"filter PCAP files\", \"follow TCP/UDP streams\", \"dete..."
 risk: unknown
 source: community
+author: zebbern
 date_added: "2026-02-27"
 ---
 

--- a/skills/wordpress-penetration-testing/SKILL.md
+++ b/skills/wordpress-penetration-testing/SKILL.md
@@ -3,6 +3,7 @@ name: wordpress-penetration-testing
 description: "This skill should be used when the user asks to \"pentest WordPress sites\", \"scan WordPress for vulnerabilities\", \"enumerate WordPress users, themes, or plugins\", \"exploit WordPress vu..."
 risk: unknown
 source: community
+author: zebbern
 date_added: "2026-02-27"
 ---
 

--- a/skills/xss-html-injection/SKILL.md
+++ b/skills/xss-html-injection/SKILL.md
@@ -3,6 +3,7 @@ name: xss-html-injection
 description: "This skill should be used when the user asks to \"test for XSS vulnerabilities\", \"perform cross-site scripting attacks\", \"identify HTML injection flaws\", \"exploit client-side injection..."
 risk: unknown
 source: community
+author: zebbern
 date_added: "2026-02-27"
 ---
 


### PR DESCRIPTION
# Pull Request Description

Restores `author: zebbern` attribution to the YAML frontmatter of all 29 security skills originally contributed from [zebbern/claude-code-guide](https://github.com/zebbern/claude-code-guide).

## Context

The `author: zebbern` metadata was added in PR #8 (merged Jan 20, 2026), but was inadvertently removed during subsequent bulk frontmatter rewrites:

- `e36d6fd` — feat: add apple hig skills and strict validation v5.9.0
- `f40869d` — fix(yaml): correctly quote description fields
- `70ed8b2` — fix: resolve SKILL.md validation errors
- `aa71e76` — chore: release 6.5.0

## Quality Bar Checklist ✅

- [x] **Standards**: I have read `docs/contributors/quality-bar.md` and `docs/contributors/security-guardrails.md`.
- [x] **Metadata**: The `SKILL.md` frontmatter is valid (checked with `npm run validate`).
- [x] **Risk Label**: I have assigned the correct `risk:` tag (`none`, `safe`, `critical`, `offensive`, or `unknown` for legacy/unclassified content).
- [x] **Triggers**: The "When to use" section is clear and specific.
- [x] **Security**: If this is an _offensive_ skill, I included the "Authorized Use Only" disclaimer.
- [x] **Local Test**: I have verified the skill works locally.
- [x] **Repo Checks**: I ran `npm run validate:references` if my change affected docs, bundles, workflows, or generated artifacts.
- [x] **Credits**: I have added the source credit in `README.md` (if applicable).

## Type of Change

- [ ] New Skill (Feature)
- [x] Documentation Update
- [ ] Infrastructure

## Changes

Adds `author: zebbern` back to the frontmatter of 29 skills:

active-directory-attacks, api-fuzzing-bug-bounty, aws-penetration-testing, broken-authentication, burp-suite-testing, cloud-penetration-testing, ethical-hacking-methodology, file-path-traversal, html-injection-testing, idor-testing, linux-privilege-escalation, linux-shell-scripting, metasploit-framework, network-101, pentest-checklist, pentest-commands, privilege-escalation-methods, red-team-tools, scanning-tools, shodan-reconnaissance, smtp-penetration-testing, sql-injection-testing, sqlmap-database-pentesting, ssh-penetration-testing, top-web-vulnerabilities, windows-privilege-escalation, wireshark-analysis, wordpress-penetration-testing, xss-html-injection

## CI Note

The "Check for Uncommitted Drift" step will fail because the generated registry files need regenerating after the frontmatter change. The auto-sync bot (`chore: sync generated registry files [ci skip]`) handles this on merge to main.

Fixes #237