### PR TITLE
docs: add NoizAI/skills to community contributors

### DIFF
--- a/README.md
+++ b/README.md
@@ -377,6 +377,7 @@ This collection would not be possible without the incredible work of the Claude 
 - **[alirezarezvani/claude-skills](https://github.com/alirezarezvani/claude-skills)**: Senior Engineering and PM toolkit.
 - **[karanb192/awesome-claude-skills](https://github.com/karanb192/awesome-claude-skills)**: A massive list of verified skills for Claude Code.
 - **[VoltAgent/awesome-agent-skills](https://github.com/VoltAgent/awesome-agent-skills)**: Curated collection of 61 high-quality skills including official team skills from Sentry, Trail of Bits, Expo, Hugging Face, and comprehensive context engineering suite (v4.3.0 integration).
+- **[NoizAI/skills](https://github.com/NoizAI/skills)**: Human-like TTS workflow skills with local/cloud backends, voice style controls, and app delivery scripts.
 - **[zircote/.claude](https://github.com/zircote/.claude)**: Shopify development skill reference.
 - **[vibeforge1111/vibeship-spawner-skills](https://github.com/vibeforge1111/vibeship-spawner-skills)**: AI Agents, Integrations, Maker Tools (57 skills, Apache 2.0).
 - **[coreyhaines31/marketingskills](https://github.com/coreyhaines31/marketingskills)**: Marketing skills for CRO, copywriting, SEO, paid ads, and growth (23 skills, MIT).


### PR DESCRIPTION
## Summary
- add `NoizAI/skills` to the Community Contributors source list in README
- keep description concise and factual

## Why
- include a practical TTS-focused skill collection that is actively used in real voice workflow scenarios

Made with [Cursor](https://cursor.com)