### PR TITLE
feat: add interview-coach skill for full job search lifecycle coaching

### DIFF
--- a/skills/interview-coach/SKILL.md
+++ b/skills/interview-coach/SKILL.md
@@ -12,9 +12,12 @@ tools: [claude]
 
 # Interview Coach
 
+## Overview
+
 A persistent, adaptive coaching system for the full job search lifecycle.
 Not a question bank — an opinionated system that tracks your patterns,
-scores your answers, and gets sharper the more you use it.
+scores your answers, and gets sharper the more you use it. State persists
+in `coaching_state.md` across sessions so you always pick up where you left off.
 
 ## Install
 
@@ -23,6 +26,14 @@ npx skills add dbhat93/job-search-os
 ```
 
 Then type `/coach` → `kickoff`.
+
+## When to Use This Skill
+
+- Use when starting a job search and need a structured system
+- Use when preparing for a specific interview (company research, mock, hype)
+- Use when you want to analyze a past interview transcript
+- Use when negotiating an offer or handling comp questions on recruiter screens
+- Use when building or maintaining a storybank of interview-ready stories
 
 ## What It Covers
 
@@ -34,11 +45,48 @@ Then type `/coach` → `kickoff`.
 - **Comp + negotiation** — pre-offer scripting, offer analysis, exact negotiation scripts
 - **23 total commands** across the full search lifecycle
 
-## How It Works
+## Examples
 
-State persists in `coaching_state.md` across sessions. The coach tracks
-your scores, patterns, drill progression, and interview outcomes — and
-adapts coaching to your specific gaps over time.
+### Example 1: Start your job search
+
+```
+/coach
+kickoff
+```
+
+The coach asks for your resume, target role, and timeline — then builds
+your profile and gives you a prioritized action plan.
+
+### Example 2: Prep for a specific company
+
+```
+/coach
+prep Stripe Senior PM
+```
+
+Runs company research, generates a role-specific prep brief, and queues
+up mock interview questions tailored to Stripe's process.
+
+### Example 3: Analyze an interview transcript
+
+```
+/coach
+analyze
+```
+
+Paste a raw transcript from Otter, Zoom, or any tool. The coach
+auto-detects the format, scores each answer across five dimensions,
+and gives you a drill plan targeting your specific gaps.
+
+### Example 4: Handle a comp question
+
+```
+/coach
+salary
+```
+
+Coaches you through the recruiter screen "what are your salary
+expectations?" moment with a defensible range and exact scripts.
 
 ## Source
 


### PR DESCRIPTION
## Summary
- add `interview-coach`, a persistent coaching system for the full job search lifecycle
- covers JD decoding, resume review, storybank building, mock interviews, transcript analysis, and negotiation support

## Quality Bar Checklist ✅
- [x] **Standards**: I have read `docs/contributors/quality-bar.md` and `docs/contributors/security-guardrails.md`.
- [x] **Metadata**: The `SKILL.md` frontmatter is valid (checked with `npm run validate`).
- [x] **Risk Label**: I assigned the correct `risk:` tag.
- [x] **Triggers**: The "When to use" section is clear and specific.
- [x] **Security**: This is not an offensive skill.
- [x] **Local Test**: I verified the skill locally.
- [x] **Repo Checks**: I ran the validation chain and catalog sync required for skills changes.
- [x] **Credits**: Source attribution is included in the skill.

## Type of Change
- [x] New Skill (Feature)
- [ ] Documentation Update
- [ ] Infrastructure

## Source
- https://github.com/dbhat93/job-search-os

## Verification
- `npm run validate`
- `npm run chain`
- `npm run catalog`