### PR TITLE
feat: add latex-paper-conversion skill

### DIFF
--- a/skills/latex-paper-conversion/SKILL.md
+++ b/skills/latex-paper-conversion/SKILL.md
@@ -29,12 +29,12 @@ Create a Python script (e.g., `convert_format.py`) to parse the source LaTeX fil
 ### Step 3: Systematic Fixing
 Perform generic fixes on the extracted body text before writing the final file, or in subsequent calls:
 - Convert math environment cases (e.g., `\begin{theorem}` to `\begin{Theorem}`).
-- Convert aggressive float placements like `[!t]` or `[h!]` to `[H]`.
+- Adjust aggressive float placements (e.g., `[!t]` or `[h!]`) to template-supported options. Avoid forcing `[H]` unless the `float` package is explicitly loaded.
 - Ensure `\includegraphics` paths are relative to the new `.tex` file location.
 - Convert `\begin{tabular}` to `\begin{tabularx}{\textwidth}` or use `\resizebox` if moving to a double-column layout.
 
 ### Step 4: Compilation & Debugging
-Run a build cycle (`pdflatex` -> `bibtex` -> `pdflatex`). Check the `.log` file using `grep_search` to systematically fix any packages conflicts, undefined commands, or compilation halts.
+Run a build cycle (`pdflatex` -> `bibtex` -> `pdflatex`). Check the `.log` file using `grep` or `rg` to systematically fix any packages conflicts, undefined commands, or compilation halts.
 
 ## Examples
 


### PR DESCRIPTION
# Pull Request Description

Adds a new skill: `latex-paper-conversion`. This skill assists AI models in properly formatting and structuring text into LaTeX code, which is especially useful for streamlining academic research papers and journal submissions.

## Change Classification

- [x] Skill PR
- [ ] Docs PR
- [ ] Infra PR

## Issue Link (Optional)

*(Left blank as there is no linked issue)*

## Quality Bar Checklist ✅

**All items must be checked before merging.**

- [x] **Standards**: I have read `docs/contributors/quality-bar.md` and `docs/contributors/security-guardrails.md`.
- [x] **Metadata**: The `SKILL.md` frontmatter is valid (checked with `npm run validate`).
- [x] **Risk Label**: I have assigned the correct `risk:` tag (`none`, `safe`, `critical`, `offensive`, or `unknown` for legacy/unclassified content).
- [x] **Triggers**: The "When to use" section is clear and specific.
- [x] **Security**: If this is an _offensive_ skill, I included the "Authorized Use Only" disclaimer. *(N/A for this safe skill)*
- [x] **Local Test**: I have verified the skill works locally.
- [x] **Repo Checks**: I ran `npm run validate:references` if my change affected docs, workflows, or infrastructure. *(N/A for skill-only PR)*
- [x] **Source-Only PR**: I did not manually include generated registry artifacts (`CATALOG.md`, `skills_index.json`, `data/*.json`) in this PR.
- [x] **Credits**: I have added the source credit in `README.md` (if applicable).
- [x] **Maintainer Edits**: I enabled **Allow edits from maintainers** on the PR.

## Screenshots (if applicable)
*(N/A)*