### PR TITLE
fix: remove Windows symlink workaround for git clone

### DIFF
--- a/tools/bin/install.js
+++ b/tools/bin/install.js
@@ -244,11 +244,7 @@ function main() {
 
   try {
     console.log("Cloning repository…");
-    if (process.platform === "win32") {
-      run("git", ["-c", "core.symlinks=true", "clone", REPO, tempDir]);
-    } else {
-      run("git", ["clone", REPO, tempDir]);
-    }
+    run("git", ["clone", REPO, tempDir]);
 
     const ref =
       tagArg ||


### PR DESCRIPTION
# Pull Request Description

Removes the Windows-only `git -c core.symlinks=true clone ...` path from the installer so non-admin Windows users can install without symlink checkout failures.

Risk tag: safe

## Change Classification

- [ ] Skill PR
- [ ] Docs PR
- [x] Infra PR

## Issue Link (Optional)

Fixes #286

## Quality Bar Checklist ✅

**All items must be checked before merging.**

- [x] **Standards**: I have read `docs/contributors/quality-bar.md` and `docs/contributors/security-guardrails.md`.
- [x] **Metadata**: No `SKILL.md` frontmatter was changed in this infrastructure fix.
- [x] **Risk Label**: No offensive or destructive capability was added.
- [x] **Triggers**: Not applicable; no skill trigger behavior changed.
- [x] **Security**: Not applicable; this is an installer fix.
- [x] **Local Test**: I verified the installer script remains syntactically valid and no longer references `core.symlinks=true`.
- [x] **Repo Checks**: `npm run validate:references` was not required because docs/workflows/infrastructure references were not changed.
- [x] **Source-Only PR**: I did not manually include generated registry artifacts (`CATALOG.md`, `skills_index.json`, `data/*.json`) in this PR.
- [x] **Credits**: Not applicable; no external source content was added.
- [x] **Maintainer Edits**: I enabled **Allow edits from maintainers** on the PR.

## Screenshots (if applicable)

N/A
