### PR TITLE
Fixes #300 : Removed `Optional` and `List` from `typing` as they were not used in …

### DIFF
--- a/skills/notebooklm/scripts/browser_utils.py
+++ b/skills/notebooklm/scripts/browser_utils.py
@@ -6,7 +6,6 @@ Handles browser launching, stealth features, and common interactions
 import json
 import time
 import random
-from typing import Optional, List
 
 from patchright.sync_api import Playwright, BrowserContext, Page
 from config import BROWSER_PROFILE_DIR, STATE_FILE, BROWSER_ARGS, USER_AGENT


### PR DESCRIPTION
# Pull Request Description

Removes two unused imports (`Optional`, `List`) from `skills/notebooklm/scripts/browser_utils.py` to keep the NotebookLM browser helper clean and avoid dead imports.

Risk tag: safe

## Change Classification

- [x] Skill PR
- [ ] Docs PR
- [ ] Infra PR

## Issue Link (Optional)

Closes #300

## Quality Bar Checklist ✅

**All items must be checked before merging.**

- [x] **Standards**: I have read `docs/contributors/quality-bar.md` and `docs/contributors/security-guardrails.md`.
- [x] **Metadata**: The existing `SKILL.md` frontmatter remains valid; no frontmatter changes were needed for this fix.
- [x] **Risk Label**: The skill remains correctly labeled as non-offensive / safe.
- [x] **Triggers**: The existing "When to use" guidance for the skill remains clear and specific.
- [x] **Security**: Not applicable; this change does not add offensive capabilities.
- [x] **Local Test**: I verified the module still compiles after removing the unused imports.
- [x] **Repo Checks**: `npm run validate:references` was not required because docs/workflows/infrastructure were not changed.
- [x] **Source-Only PR**: I did not manually include generated registry artifacts (`CATALOG.md`, `skills_index.json`, `data/*.json`) in this PR.
- [x] **Credits**: Not applicable; no external source content was added.
- [x] **Maintainer Edits**: I enabled **Allow edits from maintainers** on the PR.

## Screenshots (if applicable)

N/A
