### PR TITLE
feat: add claude code marketplace manifests

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,33 @@
+{
+  "name": "antigravity-awesome-skills",
+  "owner": {
+    "name": "sickn33 and contributors",
+    "url": "https://github.com/sickn33/antigravity-awesome-skills"
+  },
+  "metadata": {
+    "description": "Single-plugin Claude Code marketplace entry for the Antigravity Awesome Skills library.",
+    "version": "7.7.0"
+  },
+  "plugins": [
+    {
+      "name": "antigravity-awesome-skills",
+      "version": "7.7.0",
+      "description": "Expose the repository's curated `skills/` tree to Claude Code through a single plugin marketplace entry.",
+      "author": {
+        "name": "sickn33 and contributors",
+        "url": "https://github.com/sickn33/antigravity-awesome-skills"
+      },
+      "homepage": "https://github.com/sickn33/antigravity-awesome-skills",
+      "repository": "https://github.com/sickn33/antigravity-awesome-skills",
+      "license": "MIT",
+      "keywords": [
+        "claude-code",
+        "skills",
+        "agentic-skills",
+        "plugin",
+        "marketplace"
+      ],
+      "source": "."
+    }
+  ]
+}

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,0 +1,19 @@
+{
+  "name": "antigravity-awesome-skills",
+  "version": "7.7.0",
+  "description": "Universal agentic skill library for Claude Code with 1,254+ reusable skills across coding, security, design, product, and operations workflows.",
+  "author": {
+    "name": "sickn33 and contributors",
+    "url": "https://github.com/sickn33/antigravity-awesome-skills"
+  },
+  "homepage": "https://github.com/sickn33/antigravity-awesome-skills",
+  "repository": "https://github.com/sickn33/antigravity-awesome-skills",
+  "license": "MIT",
+  "keywords": [
+    "claude-code",
+    "skills",
+    "agentic-skills",
+    "ai-coding",
+    "productivity"
+  ]
+}

--- a/README.md
+++ b/README.md
@@ -144,11 +144,22 @@ Use @brainstorming to plan a SaaS MVP.
 
 4. Browse starter collections in [`docs/users/bundles.md`](docs/users/bundles.md) and execution playbooks in [`docs/users/workflows.md`](docs/users/workflows.md).
 
+### Option B: Claude Code plugin marketplace
+
+If you use Claude Code and prefer the plugin marketplace flow, this repository now ships a root `.claude-plugin/marketplace.json`:
+
+```text
+/plugin marketplace add sickn33/antigravity-awesome-skills
+/plugin install antigravity-awesome-skills
+```
+
+This installs the same repository-backed skill library through Claude Code's plugin marketplace entrypoint.
+
 ## Choose Your Tool
 
 | Tool           | Install                                                | First Use                                            |
 | -------------- | ------------------------------------------------------ | ---------------------------------------------------- |
-| Claude Code    | `npx antigravity-awesome-skills --claude`              | `>> /brainstorming help me plan a feature`           |
+| Claude Code    | `npx antigravity-awesome-skills --claude` or Claude plugin marketplace | `>> /brainstorming help me plan a feature` |
 | Cursor         | `npx antigravity-awesome-skills --cursor`              | `@brainstorming help me plan a feature`              |
 | Gemini CLI     | `npx antigravity-awesome-skills --gemini`              | `Use brainstorming to plan a feature`                |
 | Codex CLI      | `npx antigravity-awesome-skills --codex`               | `Use brainstorming to plan a feature`                |

--- a/docs/users/faq.md
+++ b/docs/users/faq.md
@@ -105,6 +105,15 @@ git clone https://github.com/sickn33/antigravity-awesome-skills.git .agent/skill
 - Codex CLI: `.codex/skills/`
 - Cursor: `.cursor/skills/` or project root
 
+**Claude Code plugin marketplace alternative:**
+
+```text
+/plugin marketplace add sickn33/antigravity-awesome-skills
+/plugin install antigravity-awesome-skills
+```
+
+This repository now includes `.claude-plugin/marketplace.json` and `.claude-plugin/plugin.json` so Claude Code can install the same skill tree through the plugin marketplace.
+
 ### Does this work with Windows?
 
 **Yes**, but some "Official" skills use **symlinks** which Windows handles poorly by default.

--- a/docs/users/getting-started.md
+++ b/docs/users/getting-started.md
@@ -97,7 +97,7 @@ Once installed, just talk to your AI naturally.
 
 | Tool            | Status          | Path                                                                  |
 | :-------------- | :-------------- | :-------------------------------------------------------------------- |
-| **Claude Code** | ✅ Full Support | `.claude/skills/`                                                     |
+| **Claude Code** | ✅ Full Support | `.claude/skills/` or install via `/plugin marketplace add sickn33/antigravity-awesome-skills` |
 | **Gemini CLI**  | ✅ Full Support | `.gemini/skills/`                                                     |
 | **Codex CLI**   | ✅ Full Support | `.codex/skills/`                                                      |
 | **Kiro CLI**    | ✅ Full Support | Global: `~/.kiro/skills/` · Workspace: `.kiro/skills/`                |
@@ -123,6 +123,13 @@ _Check the [Skill Catalog](../../CATALOG.md) for the full list._
 ---
 
 ## FAQ
+
+If you prefer Claude Code's plugin marketplace flow instead of copying into `.claude/skills/`, use:
+
+```text
+/plugin marketplace add sickn33/antigravity-awesome-skills
+/plugin install antigravity-awesome-skills
+```
 
 **Q: Do I need to install all 1,254+ skills?**
 A: You clone the whole repo once; your AI only _reads_ the skills you invoke (or that are relevant), so it stays lightweight. **Starter Packs** in [bundles.md](bundles.md) are curated lists to help you discover the right skills for your role—they don't change how you install.

--- a/walkthrough.md
+++ b/walkthrough.md
@@ -28,3 +28,8 @@
 - Added scripted workflow entrypoints: `npm run pr:preflight`, `npm run release:preflight`, `npm run release:prepare -- X.Y.Z`, and `npm run release:publish -- X.Y.Z`.
 - Split PR CI into `pr-policy`, `source-validation`, and `artifact-preview` so PRs stay source-only, policy failures are explicit, and generated drift is previewed separately from source validation.
 - Updated `CONTRIBUTING.md` and `.github/PULL_REQUEST_TEMPLATE.md` so contributors are told not to commit derived files and to enable `Allow edits from maintainers`.
+
+# Maintenance Walkthrough - 2026-03-14
+
+- Added root Claude Code plugin marketplace support via `.claude-plugin/plugin.json` and `.claude-plugin/marketplace.json`, exposing the repository as a single plugin entry that points at the existing `skills/` tree.
+- Updated the user onboarding trinity (`README.md`, `docs/users/getting-started.md`, `docs/users/faq.md`) so Claude Code users can install via `/plugin marketplace add sickn33/antigravity-awesome-skills` in addition to the existing `npx` installer flow.


### PR DESCRIPTION
# Pull Request Description

Adds root Claude Code plugin marketplace support for this repository.

## Summary

- adds `.claude-plugin/plugin.json`
- adds `.claude-plugin/marketplace.json`
- exposes the existing repository as a **single-plugin marketplace entry** named `antigravity-awesome-skills`
- updates the onboarding trinity so Claude Code users can install via `/plugin marketplace add sickn33/antigravity-awesome-skills`

Risk tag: safe

## Change Classification

- [ ] Skill PR
- [x] Docs PR
- [x] Infra PR

## Issue Link (Optional)

Closes #288

## Quality Bar Checklist ✅

**All items must be checked before merging.**

- [x] **Standards**: I have read `docs/contributors/quality-bar.md` and `docs/contributors/security-guardrails.md`.
- [x] **Metadata**: The new plugin manifest metadata is valid JSON and internally consistent with the repository identity.
- [x] **Risk Label**: No offensive or destructive capability was added.
- [x] **Triggers**: Not applicable; this change does not alter skill trigger behavior.
- [x] **Security**: Not applicable; this is packaging/onboarding support.
- [x] **Local Test**: I verified both JSON manifests parse successfully, the marketplace `source` resolves to the repository `skills/` tree, and references/docs validation still passes.
- [x] **Repo Checks**: I ran `npm run validate:references` because user-facing docs were updated.
- [x] **Source-Only PR**: I did not manually include generated registry artifacts (`CATALOG.md`, `skills_index.json`, `data/*.json`) in this PR.
- [x] **Credits**: Not applicable; no external source content was imported.
- [x] **Maintainer Edits**: Maintainer-authored PR.

## Screenshots (if applicable)

N/A
