### PR TITLE
Add web-architect: 4-agent design-to-code orchestrator skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -433,6 +433,7 @@ This collection would not be possible without the incredible work of the Claude 
 - **[uberSKILLS](https://github.com/uberskillsdev/uberSKILLS)**: Design, test, and deploy Claude Code Agent Skills through a visual, AI-assisted workflow.
 - **[christopherlhammer11-ai/tool-use-guardian](https://github.com/christopherlhammer11-ai/tool-use-guardian)**: Source for the Tool Use Guardian skill — tool-call reliability wrapper with retries, recovery, and failure classification.
 - **[christopherlhammer11-ai/recallmax](https://github.com/christopherlhammer11-ai/recallmax)**: Source for the RecallMax skill — long-context memory, summarization, and conversation compression for agents.
+- **[choppawave-beep/web-architect](https://github.com/choppawave-beep/web-architect)**: 4-agent design-to-code orchestrator skill — full design-to-code pipelines with Constrained Generation, 8 project profiles, and 5-dimension quality scoring (MIT).
 
 ### Inspirations
 


### PR DESCRIPTION
## Summary

Adds [choppawave-beep/web-architect](https://github.com/choppawave-beep/web-architect) to the **Community Contributors** section in README.md.

**web-architect** is a 4-agent design-to-code orchestrator skill for Claude Code that runs full design-to-code pipelines with Constrained Generation, 8 project profiles, and 5-dimension quality scoring.

- **Repo**: https://github.com/choppawave-beep/web-architect
- **License**: MIT
- **Install**: `npx skills add choppawave-beep/web-architect`
- **Category**: Web Development / Design / Frontend

## Changes

- Added one line to the Community Contributors section in `README.md`, matching the existing entry format
- No generated registry artifacts modified

## Checklist

- [x] Entry follows existing format (`- **[owner/repo](url)**: Description (License).`)
- [x] No generated files modified (CATALOG.md, skills_index.json, data/*.json)
- [x] Allow edits from maintainers enabled