### PR TITLE
Add web-architect skill: 4-agent design-to-code orchestrator

### DIFF
--- a/skills/web-architect/SKILL.md
+++ b/skills/web-architect/SKILL.md
@@ -1,0 +1,42 @@
+---
+name: web-architect
+description: >
+  4-agent orchestrator for full design-to-code pipelines. Conducts Designer, Architect,
+  Builder, and Reviewer agents through Constrained Generation for unique design systems.
+  8 project profiles, 5-dimension quality scoring, self-learning loop.
+tags:
+  - web-development
+  - design-system
+  - frontend
+  - multi-agent
+  - orchestrator
+  - accessibility
+  - react
+  - nextjs
+  - tailwindcss
+source: https://github.com/choppawave-beep/web-architect
+---
+
+# Web Architect
+
+One command, four agents, zero generic output.
+
+Orchestrates a full design-to-code pipeline for any web project via 4 specialized subagents:
+
+1. **Designer** — Constrained Generation for unique palettes, font pairings, motion tokens
+2. **Architect** — Component tree, file structure, data flow planning
+3. **Builder** — Implementation using design tokens, no hardcoded values
+4. **Reviewer** — 5-dimension quality scoring (design, a11y, perf, code, architecture)
+
+## Install
+
+```bash
+npx skills add choppawave-beep/web-architect
+```
+
+## Commands
+
+- `/wa:design [desc]` — Full pipeline
+- `/wa:build [desc]` — Build with existing design system
+- `/wa:review` — Quality audit
+- `/wa:profile [type]` — Set project type (landing|saas|dashboard|ecommerce|crm|portfolio|blog|desktop)


### PR DESCRIPTION
## New Skill: web-architect

Added `skills/web-architect/SKILL.md` following the contributor template.

### What it does

4-agent orchestrator for full design-to-code pipelines:

- **Designer** — Constrained Generation (unique palettes, banned generic fonts, WCAG 4.5:1)
- **Architect** — Component tree, file structure, data flows
- **Builder** — Implementation using design tokens
- **Reviewer** — 5-dimension quality scoring with auto-fix loop

### Features
- 8 project profiles (landing, saas, dashboard, ecommerce, crm, portfolio, blog, desktop)
- Self-learning from user feedback
- Works with Claude Code, Cursor, Amp, Codex CLI, Gemini CLI, Copilot, Windsurf

### Install
```bash
npx skills add choppawave-beep/web-architect
```

Source: https://github.com/choppawave-beep/web-architect