### PR TITLE
feat: add progressive-web-app skill

### DIFF
--- a/skills/progressive-web-app/SKILL.md
+++ b/skills/progressive-web-app/SKILL.md
@@ -34,6 +34,7 @@ Every PWA implementation must include these files at minimum:
 - [ ] `manifest.json` — Full app metadata and icon set
 - [ ] `sw.js` — Service worker with install, activate, and fetch handlers
 - [ ] `app.js` — Main app logic with SW registration and install prompt handling
+- [ ] `offline.html` — Fallback page shown when navigation fails offline (required — missing file will cause install to fail)
 
 ---
 
@@ -139,24 +140,25 @@ if ('serviceWorker' in navigator) {
 
 // ─── Install Prompt (Add to Home Screen) ───────────────────────────────────
 let deferredPrompt;
-const installBtn = document.getElementById('install-btn');
+const installBtn = document.getElementById('install-btn'); // may be null if omitted
 
 // Capture the browser's install prompt — it fires before the browser's own UI
 window.addEventListener('beforeinstallprompt', (e) => {
   e.preventDefault(); // Stop automatic mini-infobar on mobile
   deferredPrompt = e;
-  installBtn.hidden = false; // Show your custom install button
+  if (installBtn) installBtn.hidden = false; // Show your custom install button
 });
 
-installBtn.addEventListener('click', async () => {
-  if (!deferredPrompt) return;
-  deferredPrompt.prompt();
-  const { outcome } = await deferredPrompt.userChoice;
-  console.log('[App] Install outcome:', outcome); // 'accepted' or 'dismissed'
-  deferredPrompt = null;
-  installBtn.hidden = true;
-});
-
+if (installBtn) {
+  installBtn.addEventListener('click', async () => {
+    if (!deferredPrompt) return;
+    deferredPrompt.prompt();
+    const { outcome } = await deferredPrompt.userChoice;
+    console.log('[App] Install outcome:', outcome);
+    deferredPrompt = null;
+    installBtn.hidden = true;
+  });
+}
 // Fires when the app is installed (via browser or your button)
 window.addEventListener('appinstalled', () => {
   console.log('[App] PWA installed successfully');


### PR DESCRIPTION
feat(skill): add progressive-web-app skill

Adds a new community skill for building Progressive Web Apps with offline support, installability, and caching strategies.

- Covers manifest.json, service worker lifecycle, and SW registration
- Documents Cache-First, Network-First, and Stale-While-Revalidate strategies
- Includes iOS/Safari quirks, HTTPS requirements, and cache versioning
- Adds optional Workbox integration guidance
- Includes pre-ship Lighthouse checklist

## Change Classification

- [x] Skill PR
- [ ] Docs PR
- [ ] Infra PR

## Issue Link (Optional)

N/A

## Quality Bar Checklist ✅

- [x] Standards: I have read the contributor quality and security guides.
- [x] Metadata: The SKILL.md frontmatter is valid.
- [x] Risk Label: Assigned appropriately for this skill.
- [x] Triggers: The When to use section is clear and specific.
- [x] Security: No offensive or destructive guidance added beyond documented safe usage.
- [x] Safety scan: Command and network guidance reviewed.
- [x] Automated Skill Review: The skill-review result was reviewed.
- [x] Local Test: Validation was run locally before submission.
- [x] Repo Checks: No workflow or infra changes beyond the skill file.
- [x] Source-Only PR: No derived registry artifacts included.
- [x] Credits: Not applicable.
- [x] Maintainer Edits: Allow edits from maintainers is enabled.
