### PR TITLE
docs: align FAQ risk labels with frontmatter values and add skill-rev…

### DIFF
--- a/docs/users/faq.md
+++ b/docs/users/faq.md
@@ -71,11 +71,13 @@ The skill files themselves are stored locally on your computer, but your AI assi
 
 ### What do the Risk Labels mean?
 
-We classify skills so you know what you're running:
+We classify skills so you know what you're running. These values map directly to the `risk:` field in every `SKILL.md` frontmatter:
 
-- ⚪ **Safe (White/Blue)**: Read-only, planning, or benign skills.
-- 🔴 **Risk (Red)**: Skills that modify files (delete), use network scanners, or perform destructive actions. **Use with caution.**
-- 🟣 **Official (Purple)**: Maintained by trusted vendors (Anthropic, DeepMind, etc.).
+- 🔵 **`none`**: Pure reference or planning content — no shell commands, no mutations, no network access.
+- ⚪ **`safe`**: Community skills that are non-destructive (read-only, planning, code review, analysis).
+- 🔴 **`critical`**: Skills that modify files, drop data, use network scanners, or perform destructive actions. **Use with caution.**
+- 🟣 **`offensive`**: Security-focused offensive techniques (pentesting, exploitation). **Authorized use only** — always confirm the target is in scope.
+- ⬜ **`unknown`**: Legacy or unclassified content. Review the skill manually before use.
 
 ### Can these skills hack my computer?
 
@@ -236,6 +238,18 @@ Common fixes:
 ```markdown
 <!-- security-allowlist: reason and scope -->
 ```
+
+### My PR triggered the `skill-review` automated check. What is it?
+
+Since v8.0.0, GitHub automatically runs a `skill-review` workflow on any PR that adds or modifies a `SKILL.md` file. It reviews your skill against the quality bar and flags common issues — missing sections, weak triggers, or risky command patterns.
+
+**If it reports findings:**
+
+1. Open the **Checks** tab on your PR and read the `skill-review` job output.
+2. Address any **actionable** findings (missing "When to Use", unclear triggers, blocked security patterns).
+3. Push a new commit to the same branch — the check reruns automatically.
+
+You do not need to close and reopen the PR. Informational or style-only findings do not block merging.
 
 ### Can I update an "Official" skill?
 

--- a/docs/users/getting-started.md
+++ b/docs/users/getting-started.md
@@ -1,4 +1,4 @@
-# Getting Started with Antigravity Awesome Skills (V7.9.1)
+# Getting Started with Antigravity Awesome Skills (V8.0.0)
 
 **New here? This guide will help you supercharge your AI Agent in 5 minutes.**
 


### PR DESCRIPTION
Three small but impactful docs corrections following the v8.0.0 release:

1. **`getting-started.md`** — version header still read "V7.9.1"; updated to "V8.0.0" to match the current release.

2. **`faq.md` — Risk Labels** — the "What do the Risk Labels mean?" section described three legacy visual categories. It now maps directly to the five `risk:` frontmatter values (`none`, `safe`, `critical`, `offensive`, `unknown`) that validators and contributors actually use, eliminating confusion between docs and the quality bar.

3. **`faq.md` — skill-review action** — the `skill-review` GitHub Actions workflow was introduced in v8.0.0 (PR #322) and is referenced in `CONTRIBUTING.md`, but the FAQ had no troubleshooting entry for it. Added a clear "My PR triggered the skill-review check — what is it?" entry so first-time contributors know what to do when the check runs.

## Change Classification

- [ ] Skill PR
- [x] Docs PR
- [ ] Infra PR

## Issue Link (Optional)

N/A

## Quality Bar Checklist ✅

- [x] **Standards**: I have read `docs/contributors/quality-bar.md` and `docs/contributors/security-guardrails.md`.
- [x] **Metadata**: N/A — docs-only PR, no `SKILL.md` frontmatter changed.
- [x] **Risk Label**: N/A — no skill files modified.
- [x] **Triggers**: N/A.
- [x] **Security**: No shell commands, credentials, or network examples added.
- [x] **Safety scan**: N/A — no `SKILL.md` command guidance modified.
- [x] **Automated Skill Review**: N/A — no `SKILL.md` files changed; `skill-review` workflow will not trigger.
- [x] **Local Test**: Validated locally with `validate_skills.py` — zero errors.
- [x] **Repo Checks**: Docs-only change; no workflows or infrastructure affected.
- [x] **Source-Only PR**: No generated registry artifacts included.
- [x] **Credits**: N/A.
- [x] **Maintainer Edits**: I have enabled **Allow edits from maintainers** on this PR.
