### PR TITLE
fix: remove broken reference to missing implementation-playbook.md

### DIFF
--- a/skills/data-scientist/SKILL.md
+++ b/skills/data-scientist/SKILL.md
@@ -21,7 +21,6 @@ date_added: '2026-02-27'
 - Clarify goals, constraints, and required inputs.
 - Apply relevant best practices and validate outcomes.
 - Provide actionable steps and verification.
-- If detailed examples are required, open `resources/implementation-playbook.md`.
 
 You are a data scientist specializing in advanced analytics, machine learning, statistical modeling, and data-driven business insights.
 


### PR DESCRIPTION
- Removes a broken file reference in `skills/data-scientist/SKILL.md` (line 24)
- The instruction `open resources/implementation-playbook.md` pointed to a file that does not exist in the `data-scientist` skill directory (other skills have their own copy; `data-scientist` never had one)
- Any AI agent following this instruction — or a user reading the skill — would hit a dead end

## Root Cause

The `resources/implementation-playbook.md` file was referenced but never created under `skills/data-scientist/`. The pattern exists in many other skills, but was apparently copy-pasted into this skill without the accompanying resource file being added.

## Fix

Removed the one-line reference. The skill's Instructions section remains fully functional without it — all three existing bullet points are self-contained.

Closes #327

## Test plan

- [x] Validate skill passes `npm run validate` — `All skills passed validation!`
- [x] Confirm `resources/implementation-playbook.md` does not exist under `skills/data-scientist/` — no `resources/` folder exists there
- [x] Confirm `skills/data-scientist/SKILL.md` loads and reads cleanly without the broken reference

## Change Classification

- [x] Skill PR
- [ ] Docs PR
- [ ] Infra PR

## Issue Link (Optional)

Closes #327

## Quality Bar Checklist ✅

- [x] Standards: I have read the contributor quality and security guides.
- [x] Metadata: The SKILL.md frontmatter is valid.
- [x] Risk Label: Existing risk classification preserved.
- [x] Triggers: The skill remains clear and specific after the broken reference removal.
- [x] Security: No offensive or destructive guidance added.
- [x] Safety scan: Not applicable beyond the one-line documentation fix.
- [x] Automated Skill Review: The skill-review result was reviewed.
- [x] Local Test: Validation was run locally before submission.
- [x] Repo Checks: No workflow or infra changes beyond the skill file.
- [x] Source-Only PR: No derived registry artifacts included.
- [x] Credits: Not applicable.
- [x] Maintainer Edits: Allow edits from maintainers is enabled.
