### PR TITLE
fix(skills): remove malformed nested code fences in browser-extension…

### DIFF
--- a/skills/browser-extension-builder/SKILL.md
+++ b/skills/browser-extension-builder/SKILL.md
@@ -34,9 +34,6 @@ Structure for modern browser extensions
 
 **When to use**: When starting a new extension
 
-```javascript
-## Extension Architecture
-
 ### Project Structure
 ```
 extension/
@@ -91,16 +88,12 @@ Popup ←→ Background (Service Worker) ←→ Content Script
               ↓
         chrome.storage
 ```
-```
 
 ### Content Scripts
 
 Code that runs on web pages
 
 **When to use**: When modifying or reading page content
-
-```javascript
-## Content Scripts
 
 ### Basic Content Script
 ```javascript
@@ -159,16 +152,12 @@ injectUI();
   }]
 }
 ```
-```
 
 ### Storage and State
 
 Persisting extension data
 
 **When to use**: When saving user settings or data
-
-```javascript
-## Storage and State
 
 ### Chrome Storage API
 ```javascript
@@ -217,7 +206,6 @@ async function setStorage(data) {
 // Usage
 const { settings } = await getStorage(['settings']);
 await setStorage({ settings: { ...settings, theme: 'dark' } });
-```
 ```
 
 ## Anti-Patterns


### PR DESCRIPTION
# Pull Request Description

- Fixes three malformed code block sections in `skills/browser-extension-builder/SKILL.md` as reported in issue #335
- Three sections (`Extension Architecture`, `Content Scripts`, `Storage and State`) had their entire markdown content — including sub-headings, tables, and inner code blocks — incorrectly wrapped inside an outer ` ```javascript ` fence
- This caused rendered output to show raw markdown syntax (headings, nested fences) as literal text instead of formatted content
- Fix: removed the 3 erroneous outer opening fences and their duplicate section headings, and the 3 dangling closing fences — 12 lines deleted, no content changed

## Root Cause

The pattern sections used a ```` ```javascript ```` block as a wrapper around what should be free markdown, likely from a copy-paste formatting error in the original skill. Markdown renderers do not support nested code fences.

## Change Classification

- [x] Skill PR
- [ ] Docs PR
- [ ] Infra PR

## Issue Link

Closes #335

## Quality Bar Checklist

**All items must be checked before merging.**

- [x] **Standards**: I have read `docs/contributors/quality-bar.md` and `docs/contributors/security-guardrails.md`.
- [x] **Metadata**: Frontmatter unchanged and valid — confirmed with `npm run validate` (`✨ All skills passed validation!`).
- [x] **Risk Label**: No change to `risk:` — existing `unknown` label retained as-is.
- [x] **Triggers**: "When to Use" section unchanged.
- [x] **Security**: No commands or network examples added.
- [x] **Safety scan**: `npm run security:docs` N/A — only fence formatting lines removed.
- [x] **Automated Skill Review**: SKILL.md edited — automated `skill-review` check will run on this PR.
- [x] **Local Test**: Verified all 16 code fences are balanced in pairs after the fix.
- [x] **Repo Checks**: `npm run validate` passes cleanly.
- [x] **Source-Only PR**: No generated registry artifacts included.
- [x] **Credits**: N/A — bug fix only.
- [x] **Maintainer Edits**: I have enabled Allow edits from maintainers on the PR.
