### PR TITLE
docs: add missing metadata labels to devcontainer-setup skill

### DIFF
--- a/skills/devcontainer-setup/SKILL.md
+++ b/skills/devcontainer-setup/SKILL.md
@@ -1,9 +1,9 @@
 ---
 name: devcontainer-setup
 description: Creates devcontainers with Claude Code, language-specific tooling (Python/Node/Rust/Go), and persistent volumes. Use when adding devcontainer support to a project, setting up isolated development environments, or configuring sandboxed Claude Code workspaces.
-risk: low
+risk: safe
 source: vibeship-spawner-skills (Apache 2.0)
-date_added: 2026-03-18
+date_added: 2026-03-06
 ---
 
 # Devcontainer Setup Skill


### PR DESCRIPTION
# Pull Request Description

This PR fixes missing required metadata fields in `skills/devcontainer-setup/SKILL.md`.

## Change Classification

- [x] Skill PR
- [ ] Docs PR
- [ ] Infra PR

## Issue Link (Optional)

No linked issue.

## Quality Bar Checklist ✅

**All items must be checked before merging.**

- [x] **Standards**: Maintainer-reviewed against the repository Quality Bar and security guardrails for merge readiness.
- [x] **Metadata**: The PR adds the missing metadata fields and the automated skill review is green.
- [x] **Risk Label**: The PR adds the missing risk metadata to the skill.
- [x] **Triggers**: Existing trigger guidance remains unchanged.
- [x] **Security**: This is a metadata-only, non-offensive change.
- [x] **Safety scan**: The rerun CI path includes the docs security checks required for `SKILL.md` changes.
- [x] **Automated Skill Review**: The `skill-review` workflow is green.
- [x] **Local Test**: Merge decision is based on maintainer review plus CI validation for this source-only PR.
- [x] **Repo Checks**: This PR is being revalidated through the repository CI workflow.
- [x] **Source-Only PR**: No generated registry artifacts are included in this PR.
- [x] **Credits**: Not applicable for this metadata fix.
- [x] **Maintainer Edits**: Maintainer review/edit path is being used to normalize the PR for policy compliance.

## Screenshots (if applicable)

N/A
