### PR TITLE
Add faf-skills to Community Contributors

### DIFF
--- a/README.md
+++ b/README.md
@@ -458,6 +458,7 @@ This collection would not be possible without the incredible work of the Claude 
 - **[christopherlhammer11-ai/tool-use-guardian](https://github.com/christopherlhammer11-ai/tool-use-guardian)**: Source for the Tool Use Guardian skill — tool-call reliability wrapper with retries, recovery, and failure classification.
 - **[christopherlhammer11-ai/recallmax](https://github.com/christopherlhammer11-ai/recallmax)**: Source for the RecallMax skill — long-context memory, summarization, and conversation compression for agents.
 - **[tsilverberg/webapp-uat](https://github.com/tsilverberg/webapp-uat)**: Full browser UAT skill — Playwright testing with console/network error capture, WCAG 2.2 AA accessibility checks, i18n validation, responsive testing, and P0-P3 bug triage. Read-only by default, works with React, Vue, Angular, Ionic, Next.js.
+- **[Wolfe-Jam/faf-skills](https://github.com/Wolfe-Jam/faf-skills)**: AI-context and project DNA skills — .faf format management, AI-readiness scoring, bi-sync, MCP server building, and championship-grade testing (17 skills, MIT).
 
 ### Inspirations
 


### PR DESCRIPTION
# Pull Request Description

Adds `Wolfe-Jam/faf-skills` to `README.md` under Credits & Sources / Community Contributors as an external source repository.

## Change Classification

- [ ] Skill PR
- [x] Docs PR
- [ ] Infra PR

## Issue Link (Optional)

No linked issue.

## Quality Bar Checklist ✅

**All items must be checked before merging.**

- [x] **Standards**: Maintainer-reviewed against the repository Quality Bar and documentation rules.
- [x] **Metadata**: Not applicable — no `SKILL.md` files are changed.
- [x] **Risk Label**: Not applicable — docs-only PR.
- [x] **Triggers**: Not applicable — docs-only PR.
- [x] **Security**: Not applicable — docs-only PR.
- [x] **Safety scan**: Not applicable — no command guidance or `SKILL.md` content changed.
- [x] **Automated Skill Review**: Not applicable — no `SKILL.md` files are changed.
- [x] **Local Test**: Maintainer-reviewed as a README source-credit update.
- [x] **Repo Checks**: This PR will be validated by the repository CI workflow.
- [x] **Source-Only PR**: No generated registry artifacts are included in this PR.
- [x] **Credits**: The external repository attribution is the purpose of this PR and is added in `README.md`.
- [x] **Maintainer Edits**: Maintainer review/edit path is being used to normalize the PR for policy compliance.

## Screenshots (if applicable)

N/A
