### PR TITLE
feat(community): add discussion templates and routing

### DIFF
--- a/.github/DISCUSSION_TEMPLATE/announcements.yml
+++ b/.github/DISCUSSION_TEMPLATE/announcements.yml
@@ -1,0 +1,55 @@
+title: "[Announcement] "
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use this category for maintainer updates that the community should not miss.
+  - type: dropdown
+    id: announcement-type
+    attributes:
+      label: Announcement type
+      description: Pick the kind of update you are sharing.
+      options:
+        - Release
+        - Breaking change
+        - Maintenance update
+        - Community update
+        - Call for feedback
+    validations:
+      required: true
+  - type: textarea
+    id: summary
+    attributes:
+      label: Summary
+      description: Start with a short, skimmable explanation of the update.
+      placeholder: What changed, who it affects, and why it matters.
+    validations:
+      required: true
+  - type: textarea
+    id: details
+    attributes:
+      label: Details
+      description: Add rollout notes, migration steps, notable highlights, or caveats.
+      placeholder: Include release notes, timelines, affected folders, or upgrade guidance.
+    validations:
+      required: true
+  - type: textarea
+    id: links
+    attributes:
+      label: Links and references
+      description: Link the related PR, release notes, docs, or commits.
+      placeholder: |
+        - PR:
+        - Release:
+        - Docs:
+        - Commit:
+    validations:
+      required: false
+  - type: textarea
+    id: call-to-action
+    attributes:
+      label: What should the community do next?
+      description: Tell readers whether they should test something, migrate, give feedback, or just stay informed.
+      placeholder: "Example: Please try the new installer flow and report regressions in Q&A."
+    validations:
+      required: false

--- a/.github/DISCUSSION_TEMPLATE/general.yml
+++ b/.github/DISCUSSION_TEMPLATE/general.yml
@@ -1,0 +1,45 @@
+title: "[General] "
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use General for repo-wide feedback, meta discussion, introductions, or anything that does not fit Q&A, Ideas, or Show and tell.
+  - type: dropdown
+    id: topic-area
+    attributes:
+      label: Topic area
+      description: Choose the closest fit so maintainers can triage faster.
+      options:
+        - Repo feedback
+        - Documentation
+        - Bundles and workflows
+        - Web app
+        - Community and collaboration
+        - Other
+    validations:
+      required: true
+  - type: textarea
+    id: discussion
+    attributes:
+      label: What would you like to discuss?
+      description: Share context, background, and what kind of feedback or conversation you want.
+      placeholder: Tell us what prompted this discussion and what outcome would be helpful.
+    validations:
+      required: true
+  - type: textarea
+    id: context
+    attributes:
+      label: Relevant links or examples
+      description: Link docs, issues, skills, PRs, screenshots, or outside references if they help.
+      placeholder: |
+        - Related skill:
+        - Related doc:
+        - Related PR or issue:
+    validations:
+      required: false
+  - type: checkboxes
+    attributes:
+      label: Before posting
+      options:
+        - label: I checked whether this would fit better in Q&A, Ideas, or Show and tell.
+          required: true

--- a/.github/DISCUSSION_TEMPLATE/ideas.yml
+++ b/.github/DISCUSSION_TEMPLATE/ideas.yml
@@ -1,0 +1,62 @@
+title: "[Idea] "
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use Ideas for new skills, bundles, workflows, docs improvements, or repo-wide experiments that still need shaping.
+  - type: input
+    id: problem
+    attributes:
+      label: What problem are you trying to solve?
+      description: Start with the user or maintainer problem, not the implementation.
+      placeholder: "Example: There is no reliable skill for triaging large CI failures across multiple workflows."
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed idea
+      description: Describe the skill, feature, or change you would like to see.
+      placeholder: Explain the proposed capability and what it should help people do.
+    validations:
+      required: true
+  - type: textarea
+    id: use-cases
+    attributes:
+      label: Real use cases
+      description: Give concrete scenarios, prompts, or workflows this would unlock.
+      placeholder: |
+        - Who needs this?
+        - What task are they doing?
+        - What does success look like?
+    validations:
+      required: true
+  - type: textarea
+    id: prior-art
+    attributes:
+      label: Related skills, tools, or prior art
+      description: Link similar skills, docs, repos, examples, or discussions if they exist.
+      placeholder: |
+        - Similar skill:
+        - Related doc:
+        - External reference:
+    validations:
+      required: false
+  - type: dropdown
+    id: contribution-interest
+    attributes:
+      label: Are you willing to help build this?
+      options:
+        - Yes, I can open a PR
+        - Yes, but I need guidance
+        - Maybe, depending on scope
+        - No, just sharing the idea
+    validations:
+      required: true
+  - type: checkboxes
+    attributes:
+      label: Before posting
+      options:
+        - label: I searched existing discussions and issues for similar ideas.
+          required: true

--- a/.github/DISCUSSION_TEMPLATE/polls.yml
+++ b/.github/DISCUSSION_TEMPLATE/polls.yml
@@ -1,0 +1,47 @@
+title: "[Poll] "
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use Polls when you want structured community input on competing options, priorities, or tradeoffs.
+  - type: input
+    id: decision
+    attributes:
+      label: What decision or question are you polling?
+      description: Keep the poll focused on a single choice the community can react to.
+      placeholder: "Example: Which bundle should we prioritize next?"
+    validations:
+      required: true
+  - type: textarea
+    id: context
+    attributes:
+      label: Context
+      description: Explain why the poll matters and what will be done with the result.
+      placeholder: Tell people what problem is being solved and how maintainers will use the vote.
+    validations:
+      required: true
+  - type: textarea
+    id: options-rationale
+    attributes:
+      label: Option rationale
+      description: Briefly explain the options you are putting in the poll so people can vote well.
+      placeholder: |
+        - Option A:
+        - Option B:
+        - Option C:
+    validations:
+      required: false
+  - type: textarea
+    id: success-criteria
+    attributes:
+      label: What outcome are you hoping to learn?
+      description: Clarify what signal, threshold, or insight would make this poll useful.
+      placeholder: "Example: If one option clearly wins, we will turn it into an actionable issue."
+    validations:
+      required: false
+  - type: checkboxes
+    attributes:
+      label: Before posting
+      options:
+        - label: I made the poll narrow enough that voters can make an informed choice.
+          required: true

--- a/.github/DISCUSSION_TEMPLATE/q-a.yml
+++ b/.github/DISCUSSION_TEMPLATE/q-a.yml
@@ -1,0 +1,57 @@
+title: "[Q&A] "
+labels: ["question"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use Q&A for setup help, troubleshooting, choosing skills, or understanding how the repo is meant to be used.
+  - type: dropdown
+    id: question-type
+    attributes:
+      label: What kind of help do you need?
+      options:
+        - Installation or setup
+        - Choosing the right skills
+        - Troubleshooting a skill
+        - Repo structure or contribution flow
+        - Integrations or tooling
+        - Other
+    validations:
+      required: true
+  - type: textarea
+    id: question
+    attributes:
+      label: Your question
+      description: Describe the problem clearly and say what you expected instead.
+      placeholder: What are you trying to do, what happened, and what outcome are you aiming for?
+    validations:
+      required: true
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment and context
+      description: Share the tool, OS, relevant paths, versions, and any repo areas involved.
+      placeholder: |
+        - Tool:
+        - OS:
+        - Version:
+        - Relevant skill or doc:
+    validations:
+      required: false
+  - type: textarea
+    id: tried
+    attributes:
+      label: What have you already tried?
+      description: Include commands, docs, or troubleshooting steps you already checked.
+      placeholder: |
+        - Docs consulted:
+        - Commands run:
+        - Errors seen:
+    validations:
+      required: true
+  - type: checkboxes
+    attributes:
+      label: Before posting
+      options:
+        - label: I checked the README, FAQ, and relevant docs first.
+          required: true

--- a/.github/DISCUSSION_TEMPLATE/show-and-tell.yml
+++ b/.github/DISCUSSION_TEMPLATE/show-and-tell.yml
@@ -1,0 +1,61 @@
+title: "[Show and Tell] "
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Share custom skills, bundles, workflows, integrations, demos, screenshots, or wins built with this repository.
+  - type: dropdown
+    id: showcase-type
+    attributes:
+      label: What are you sharing?
+      options:
+        - Custom skill
+        - Bundle or workflow
+        - Integration
+        - Demo or screenshot
+        - Case study or win
+        - Other
+    validations:
+      required: true
+  - type: input
+    id: project-name
+    attributes:
+      label: Name or short title
+      description: Give your project, experiment, or example a concise name.
+      placeholder: "Example: CI Triage Bundle for Large Monorepos"
+    validations:
+      required: true
+  - type: textarea
+    id: shared-item
+    attributes:
+      label: What did you build or discover?
+      description: Describe the outcome and what makes it useful or interesting.
+      placeholder: Tell the community what it does and why it matters.
+    validations:
+      required: true
+  - type: textarea
+    id: how-it-works
+    attributes:
+      label: How it works
+      description: Share the setup, prompts, files, or workflow behind it.
+      placeholder: Include enough detail that others can learn from or reproduce it.
+    validations:
+      required: true
+  - type: textarea
+    id: links
+    attributes:
+      label: Links, screenshots, or references
+      description: Link a repo, gist, docs, image, or video if you have one.
+      placeholder: |
+        - Repo:
+        - Gist:
+        - Screenshot:
+        - Video:
+    validations:
+      required: false
+  - type: checkboxes
+    attributes:
+      label: Before posting
+      options:
+        - label: I removed secrets, credentials, and private data from anything I shared.
+          required: true

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,10 +1,12 @@
 ---
 name: Bug Report
-about: Create a report to help us improve the skills
+about: Report a reproducible bug in the repository, docs, tooling, or skill behavior
 title: "[BUG] "
 labels: bug
 assignees: sickn33
 ---
+
+> For setup help, troubleshooting questions, or “am I using this correctly?” discussions, please use GitHub Discussions Q&A instead of Issues.
 
 **Describe the bug**
 A clear and concise description of what the bug is.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,14 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Ask a question or get help
+    url: https://github.com/sickn33/antigravity-awesome-skills/discussions/new?category=q-a
+    about: Use Discussions Q&A for setup help, troubleshooting, and usage questions.
+  - name: Share an idea first
+    url: https://github.com/sickn33/antigravity-awesome-skills/discussions/new?category=ideas
+    about: Use Discussions Ideas for new skills, repo improvements, and early-stage proposals.
+  - name: Show what you built
+    url: https://github.com/sickn33/antigravity-awesome-skills/discussions/new?category=show-and-tell
+    about: Share custom skills, bundles, integrations, demos, and wins with the community.
+  - name: Report a security issue
+    url: https://github.com/sickn33/antigravity-awesome-skills/security/policy
+    about: Please use the security policy instead of opening a public issue for vulnerabilities.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,19 +1,24 @@
 ---
-name: Skill Request
-about: Suggest a new skill for the collection
+name: Actionable Improvement Request
+about: Request a concrete, scoped improvement once the work is clear enough for an Issue
 title: "[REQ] "
 labels: enhancement
 assignees: sickn33
 ---
 
-**Is your feature request related to a problem? Please describe.**
+> For early-stage ideas, brainstorming, and “would this be useful?” proposals, please start in GitHub Discussions Ideas. Open an Issue when the request is concrete and actionable.
+
+**What problem should this improve?**
 A clear and concise description of what the problem is. Ex: I'm always frustrated when [...]
 
-**Describe the solution you'd like**
-A description of the skill you want. What trigger should it have? What files should it effect?
+**What concrete change are you asking for?**
+A description of the skill, workflow, docs change, or repo improvement you want. What should be added or changed?
 
-**Describe alternatives you've considered**
-A clear and concise description of any alternative solutions or features you've considered.
+**What does success look like?**
+Describe the expected outcome, acceptance criteria, or user-visible result.
+
+**Related discussion or prior art**
+Link any relevant discussion, similar skill, docs, issue, or external reference.
 
 **Additional context**
 Add any other context or screenshots about the feature request here.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -50,9 +50,9 @@ You don't need to be an expert! Here are ways anyone can help:
 - Translate documentation to other languages
 
 ### 2. Report Issues
-- Found something confusing? Tell us!
-- Skill not working? Let us know!
-- Have suggestions? We want to hear them!
+- Found a reproducible bug? Open an Issue.
+- Need help, want feedback, or have an early-stage idea? Start a Discussion.
+- Skill not working? If you can reproduce it, open an Issue. If you're unsure, start in Q&A.
 
 ### 3. Create New Skills
 - Share your expertise as a skill

--- a/README.md
+++ b/README.md
@@ -381,8 +381,8 @@ That will copy the generated skill index into `apps/web-app/public/skills.json`,
 
 ## Community
 
-- [Discussions](https://github.com/sickn33/antigravity-awesome-skills/discussions) for questions and feedback.
-- [Issues](https://github.com/sickn33/antigravity-awesome-skills/issues) for bugs and improvement requests.
+- [Discussions](https://github.com/sickn33/antigravity-awesome-skills/discussions) for questions, ideas, showcase posts, and community feedback.
+- [Issues](https://github.com/sickn33/antigravity-awesome-skills/issues) for reproducible bugs and concrete, actionable improvement requests.
 - [`SECURITY.md`](SECURITY.md) for security reporting.
 
 ## Support the Project


### PR DESCRIPTION
# Pull Request Description

This PR improves the repository's GitHub Discussions setup so community traffic is routed more clearly.

## Change Classification

- [ ] Skill PR
- [x] Docs PR
- [x] Infra PR

## Issue Link (Optional)

No linked issue.

## Quality Bar Checklist ✅

**All items must be checked before merging.**

- [x] **Standards**: I have read `docs/contributors/quality-bar.md` and `docs/contributors/security-guardrails.md`.
- [x] **Metadata**: Not applicable for this PR because no `SKILL.md` files were changed.
- [x] **Risk Label**: Not applicable for this PR because no `SKILL.md` files were changed.
- [x] **Triggers**: Not applicable for this PR because no `SKILL.md` files were changed.
- [x] **Security**: Not applicable for this PR because no offensive skills were added or modified.
- [x] **Safety scan**: Not applicable for this PR because no `SKILL.md` command guidance was changed.
- [x] **Automated Skill Review**: Not applicable for this PR because no `SKILL.md` files were changed.
- [x] **Local Test**: I verified the new discussion templates parse as valid YAML and checked the repo with `npm run validate`.
- [x] **Repo Checks**: `npm run validate:references` is not required for this change set; `npm run validate` was run successfully.
- [x] **Source-Only PR**: I did not manually include generated registry artifacts (`CATALOG.md`, `skills_index.json`, `data/*.json`) in this PR.
- [x] **Credits**: Not applicable for this PR because no external source attribution changes were needed.
- [x] **Maintainer Edits**: This PR was created from a branch on the main repository.

## Screenshots (if applicable)

Not applicable.

## Summary
- add GitHub Discussions forms for the existing categories
- route support, idea intake, and showcase traffic from Issues to Discussions
- clarify the Discussions vs Issues split in README and CONTRIBUTING
- seed a few live Discussions threads directly in the repository for orientation and engagement

## Verification
- Python YAML parse for all new discussion templates
- `npm run validate`

## Notes
- live threads were created directly in GitHub Discussions
- category sections and pinned discussions still require GitHub web UI actions
