### PR TITLE
docs: add code of conduct

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,48 @@
+# Code of Conduct
+
+## Our Pledge
+
+In the interest of fostering an open and welcoming environment, we as
+contributors and maintainers pledge to make participation in our project and
+our community a harassment-free experience for everyone.
+
+## Our Standards
+
+Examples of behavior that contributes to creating a positive environment
+include:
+
+- Using welcoming and inclusive language
+- Being respectful of differing viewpoints and experiences
+- Gracefully accepting constructive criticism
+- Focusing on what is best for the community
+- Showing empathy towards other community members
+
+Examples of unacceptable behavior by participants include:
+
+- The use of sexualized language or imagery and unwelcome sexual attention or
+  advances
+- Trolling, insulting or derogatory comments, and personal or political attacks
+- Public or private harassment
+- Publishing others' private information without explicit permission
+- Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Scope
+
+This Code of Conduct applies within project spaces and in public spaces when an
+individual is representing the project or its community. This includes GitHub
+issues, pull requests, discussions, and other project-managed collaboration
+channels.
+
+## Enforcement
+
+Project maintainers are responsible for clarifying the standards of acceptable
+behavior and are expected to take appropriate and fair corrective action in
+response to any instances of unacceptable behavior.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.1.
+
+[homepage]: https://www.contributor-covenant.org

--- a/README.md
+++ b/README.md
@@ -383,6 +383,7 @@ That will copy the generated skill index into `apps/web-app/public/skills.json`,
 
 - [Discussions](https://github.com/sickn33/antigravity-awesome-skills/discussions) for questions, ideas, showcase posts, and community feedback.
 - [Issues](https://github.com/sickn33/antigravity-awesome-skills/issues) for reproducible bugs and concrete, actionable improvement requests.
+- [`CODE_OF_CONDUCT.md`](CODE_OF_CONDUCT.md) for community expectations and moderation standards.
 - [`SECURITY.md`](SECURITY.md) for security reporting.
 
 ## Support the Project

--- a/docs/COMMUNITY_GUIDELINES.md
+++ b/docs/COMMUNITY_GUIDELINES.md
@@ -1,3 +1,3 @@
 # Community Guidelines
 
-This document moved to [`contributors/community-guidelines.md`](contributors/community-guidelines.md).
+This document moved to [`../CODE_OF_CONDUCT.md`](../CODE_OF_CONDUCT.md).

--- a/docs/contributors/community-guidelines.md
+++ b/docs/contributors/community-guidelines.md
@@ -1,33 +1,4 @@
-# Code of Conduct
+# Community Guidelines
 
-## Our Pledge
-
-In the interest of fostering an open and welcoming environment, we as contributors and maintainers pledge to making participation in our project and our community a harassment-free experience for everyone.
-
-## Our Standards
-
-Examples of behavior that contributes to creating a positive environment include:
-
-- Using welcoming and inclusive language
-- Being respectful of differing viewpoints and experiences
-- Gracefully accepting constructive criticism
-- Focusing on what is best for the community
-- Showing empathy towards other community members
-
-Examples of unacceptable behavior by participants include:
-
-- The use of sexualized language or imagery and unwelcome sexual attention or advances
-- Trolling, insulting/derogatory comments, and personal or political attacks
-- Public or private harassment
-- Publishing others' private information without explicit permission
-- Other conduct which could reasonably be considered inappropriate in a professional setting
-
-## Enforcement
-
-Project maintainers are responsible for clarifying the standards of acceptable behavior and are expected to take appropriate and fair corrective action in response to any instances of unacceptable behavior.
-
-## Attribution
-
-This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 2.1.
-
-[homepage]: https://www.contributor-covenant.org
+The canonical project policy now lives in the repository root at
+[`CODE_OF_CONDUCT.md`](../../CODE_OF_CONDUCT.md).


### PR DESCRIPTION
## Summary
- add a repository-level CODE_OF_CONDUCT.md so GitHub detects a project code of conduct
- point the existing community guideline docs to the canonical root file
- link the policy from the README community section

## Validation
- npm run validate