### PR TITLE
docs: fix metadata for advanced-evaluation skill

### DIFF
--- a/skills/advanced-evaluation/SKILL.md
+++ b/skills/advanced-evaluation/SKILL.md
@@ -1,6 +1,9 @@
 ---
 name: advanced-evaluation
 description: This skill should be used when the user asks to "implement LLM-as-judge", "compare model outputs", "create evaluation rubrics", "mitigate evaluation bias", or mentions direct scoring, pairwise comparison, position bias, evaluation pipelines, or automated quality assessment.
+risk: safe
+source: community
+date_added: 2026-03-18
 ---
 
 # Advanced Evaluation


### PR DESCRIPTION
## Change Classification

- [ ] Skill PR
- [x] Docs PR
- [ ] Infra PR

## Issue Link (Optional)

No open issue — proactive documentation accuracy fix.

## Quality Bar Checklist ✅

**All items must be checked before merging.**

- [x] **Standards**: I have read `docs/contributors/quality-bar.md` and `docs/contributors/security-guardrails.md`.
- [x] **Metadata**: The `SKILL.md` frontmatter is valid (checked with `npm run validate`).
- [x] **Risk Label**: I have assigned the correct `risk:` tag.
- [x] **Triggers**: The "When to use" section is clear and specific.
- [x] **Security**: If this is an *offensive* skill, I included the "Authorized Use Only" disclaimer. (N/A — docs-only PR)
- [x] **Safety scan**: I ran `npm run security:docs`.
- [x] **Automated Skill Review**: I checked the `skill-review` GitHub Actions result.
- [x] **Local Test**: I have verified the skill works locally.
- [x] **Repo Checks**: I ran `npm run validate:references`.
- [x] **Source-Only PR**: I did not manually include generated registry artifacts (`CATALOG.md`, `data/*.json`).
- [x] **Credits**: I have added the source credit (N/A — docs-only).
- [x] **Maintainer Edits**: I enabled **Allow edits from maintainers** on the PR.
