### PR TITLE
Add privacy-mask skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -466,6 +466,7 @@ This collection would not be possible without the incredible work of the Claude 
 - **[christopherlhammer11-ai/recallmax](https://github.com/christopherlhammer11-ai/recallmax)**: Source for the RecallMax skill — long-context memory, summarization, and conversation compression for agents.
 - **[tsilverberg/webapp-uat](https://github.com/tsilverberg/webapp-uat)**: Full browser UAT skill — Playwright testing with console/network error capture, WCAG 2.2 AA accessibility checks, i18n validation, responsive testing, and P0-P3 bug triage. Read-only by default, works with React, Vue, Angular, Ionic, Next.js.
 - **[Wolfe-Jam/faf-skills](https://github.com/Wolfe-Jam/faf-skills)**: AI-context and project DNA skills — .faf format management, AI-readiness scoring, bi-sync, MCP server building, and championship-grade testing (17 skills, MIT).
+- **[fullstackcrew-alpha/privacy-mask](https://github.com/fullstackcrew-alpha/privacy-mask)**: Local image privacy masking for AI coding agents. Detects and redacts PII, API keys, and secrets in screenshots via OCR + 47 regex rules. Claude Code hook integration for automatic masking. Supports Tesseract and RapidOCR. 100% offline (MIT).
 
 ### Inspirations
 


### PR DESCRIPTION
# Pull Request Description

Adds [`privacy-mask`](https://github.com/fullstackcrew-alpha/privacy-mask) to the `README.md` community contributors list under `Credits & Sources`.

## Change Classification

- [ ] Skill PR
- [x] Docs PR
- [ ] Infra PR

## Issue Link (Optional)

Use this only when the PR should auto-close an issue:

`Closes #N` or `Fixes #N`

## Quality Bar Checklist ✅

**All items must be checked before merging.**

- [x] **Standards**: I have read `docs/contributors/quality-bar.md` and `docs/contributors/security-guardrails.md`.
- [x] **Metadata**: N/A (docs-only README update; no `SKILL.md` changed).
- [x] **Risk Label**: I have assigned the correct `risk:` label for this docs-only change (`safe`).
- [x] **Triggers**: N/A (no `SKILL.md` changed).
- [x] **Security**: N/A (not an offensive skill).
- [x] **Safety scan**: N/A (no command guidance or token-like content changed in `SKILL.md`).
- [x] **Automated Skill Review**: N/A (`SKILL.md` not modified).
- [x] **Local Test**: I verified the README entry and link content.
- [x] **Repo Checks**: N/A for this isolated README source-credit update.
- [x] **Source-Only PR**: I did not manually include generated registry artifacts (`CATALOG.md`, `skills_index.json`, `data/*.json`) in this PR.
- [x] **Credits**: I added the source credit in `README.md`.
- [x] **Maintainer Edits**: I enabled **Allow edits from maintainers** on the PR.

## Screenshots (if applicable)

N/A
