### PR TITLE
Add skill: moyu

### DIFF
--- a/skills/moyu/SKILL.md
+++ b/skills/moyu/SKILL.md
@@ -1,16 +1,8 @@
 ---
-name: moyu-en
+name: moyu
 description: >
-  Automatically activates when over-engineering patterns are detected:
-  (1) Modifying code or files the user did not explicitly ask to change
-  (2) Creating new abstraction layers (class, interface, factory, wrapper) without being asked
-  (3) Adding comments, documentation, JSDoc, or type annotations without being asked
-  (4) Introducing new dependencies without being asked
-  (5) Rewriting entire files instead of making minimal edits
-  (6) Diff scope significantly exceeding the user's request
-  (7) User signals like "too much", "don't change that", "only change X", "keep it simple", "stop"
-  (8) Adding error handling, validation, or defensive code for scenarios that cannot occur
-  (9) Generating tests, configuration scaffolding, or documentation without being asked
+  Anti-over-engineering guardrail that activates when an AI coding agent expands
+  scope, adds abstractions, or changes files the user did not request.
 license: MIT
 ---
 


### PR DESCRIPTION
# Pull Request Description

This PR adds the `moyu` skill to help AI coding agents avoid over-engineering and keep changes tightly scoped to the user's request.

## Change Classification

- [x] Skill PR
- [ ] Docs PR
- [ ] Infra PR

## Issue Link (Optional)

N/A

## Quality Bar Checklist ✅

**All items must be checked before merging.**

- [x] **Standards**: Reviewed against `docs/contributors/quality-bar.md` and `docs/contributors/security-guardrails.md` during maintainer cleanup.
- [x] **Metadata**: Frontmatter now validates and matches the skill directory.
- [ ] **Risk Label**: Legacy/community metadata still needs explicit `risk:` frontmatter if the contributor wants to eliminate warnings.
- [x] **Triggers**: The skill intent and activation behavior are clear in the body content.
- [ ] **Security**: N/A (not an offensive skill).
- [x] **Safety scan**: Maintainer ran `npm run security:docs` while stabilizing the PR.
- [ ] **Automated Skill Review**: Waiting on refreshed GitHub Actions runs after maintainer fixes.
- [x] **Local Test**: Maintainer ran `npm run validate` after correcting the frontmatter mismatch and description length.
- [x] **Repo Checks**: Validation passes after the maintainer fix.
- [x] **Source-Only PR**: No generated registry artifacts are included.
- [x] **Credits**: Source noted from https://github.com/uucz/moyu.
- [x] **Maintainer Edits**: Enabled.

## Screenshots (if applicable)

N/A
