### PR TITLE
Add windows-shell-reliability skill

### DIFF
--- a/skills/windows-shell-reliability/SKILL.md
+++ b/skills/windows-shell-reliability/SKILL.md
@@ -17,15 +17,19 @@ Use this skill when developing or debugging scripts and automation that run on W
 
 ## 1. Encoding & Redirection
 
-### CRITICAL: UTF-16LE Output
-Many Windows tools (like `dotnet build` or `npm`) output in UTF-16LE or other encodings that can break subsequent processing.
+### CRITICAL: Redirection Differences Across PowerShell Versions
+Older Windows PowerShell releases can rewrite native-command output in ways that break
+later processing. PowerShell 7.4+ preserves the byte stream when redirecting stdout,
+so only apply the UTF-8 conversion workaround when you are dealing with older shell
+behavior or a log file that is already unreadable.
 
 | Problem | Symptom | Solution |
 |---------|---------|----------|
-| `dotnet > log.txt` | `view_file` fails | `Get-Content log.txt | Set-Content -Encoding utf8 log_utf8.txt` |
-| `npm run > log.txt` | Encoding error | Use PowerShell piping: `npm run ... | Out-File -Encoding UTF8 log.txt` |
+| `dotnet > log.txt` | `view_file` fails in older Windows PowerShell | `Get-Content log.txt | Set-Content -Encoding utf8 log_utf8.txt` |
+| `npm run > log.txt` | Need a UTF-8 text log with errors included | `npm run ... 2>&1 | Out-File -Encoding UTF8 log.txt` |
 
-**Rule:** Always convert redirected output to UTF-8 if it needs to be read back or processed by other tools.
+**Rule:** Prefer native redirection as-is on PowerShell 7.4+, and use explicit UTF-8
+conversion only when older Windows PowerShell redirection produces an unreadable log.
 
 ---
 
@@ -71,7 +75,7 @@ In PowerShell, if an executable path starts with a quote, you MUST use the `&` o
 |---------|---------|-----|
 | Fast Iteration | `dotnet build --no-restore` | Skips redundant nuget restore. |
 | Clean Build | `dotnet build --no-incremental` | Ensures no stale artifacts. |
-| Background | `dotnet run > output.txt 2>&1` | Captures both stdout and stderr. |
+| Background | `Start-Process dotnet -ArgumentList 'run' -RedirectStandardOutput output.txt -RedirectStandardError error.txt` | Launches the app without blocking the shell and keeps logs. |
 
 ---
 
@@ -98,6 +102,6 @@ Windows has a 260-character path limit by default.
 |-------|-------------|-----|
 | `The term 'xxx' is not recognized` | Path not in $env:PATH | Use absolute path or fix PATH. |
 | `Access to the path is denied` | File in use or permissions | Stop process or run as Admin. |
-| `Encoding mismatch` | UTF-16 output | Use `Out-File -Encoding UTF8`. |
+| `Encoding mismatch` | Older shell redirection rewrote the output | Re-export the file as UTF-8 or capture with `2>&1 | Out-File -Encoding UTF8`. |
 
 ---


### PR DESCRIPTION
# Pull Request Description

This PR adds the `windows-shell-reliability` skill to the repository. This skill provides best practices for running commands on Windows via PowerShell and CMD, focusing on encoding, path handling, and common binary pitfalls.

## Change Classification

- [x] Skill PR
- [ ] Docs PR
- [ ] Infra PR

## Issue Link (Optional)

N/A

## Quality Bar Checklist ✅

**All items must be checked before merging.**

- [x] **Standards**: I have read `docs/contributors/quality-bar.md` and `docs/contributors/security-guardrails.md`.
- [x] **Metadata**: The `SKILL.md` frontmatter is valid (checked with `npm run validate`).
- [x] **Risk Label**: I have assigned the correct `risk:` tag (`safe`).
- [x] **Triggers**: The "When to use" section is clear and specific.
- [ ] **Security**: If this is an _offensive_ skill, I included the "Authorized Use Only" disclaimer. (N/A)
- [x] **Safety scan**: If this PR adds or modifies `SKILL.md` command guidance, remote/network examples, or token-like strings, I ran `npm run security:docs` and addressed any findings.
- [ ] **Automated Skill Review**: Checked local validation; GA results to be reviewed upon submission.
- [x] **Local Test**: I have verified the skill works locally.
- [x] **Repo Checks**: Ran `npm run validate` which covers skill metadata and structure.
- [x] **Source-Only PR**: I did not manually include generated registry artifacts.
- [ ] **Credits**: N/A
- [x] **Maintainer Edits**: I enabled **Allow edits from maintainers** on the PR.

## Screenshots (if applicable)

N/A
