### PR TITLE
feat: add jobgpt skill for job search automation

### DIFF
--- a/skills/jobgpt/SKILL.md
+++ b/skills/jobgpt/SKILL.md
@@ -28,13 +28,11 @@ Built by [6figr.com](https://6figr.com/jobgpt-ai), the platform supports 150+ co
 
 This skill requires the JobGPT MCP server:
 
-1. Sign up at [6figr.com/jobgpt-ai](https://6figr.com/jobgpt-ai)
-2. Go to Account → MCP Integrations → Generate API Key
-3. Add the MCP server to your AI tool:
-
-```bash
-npx jobgpt-mcp-server
-```
+1. **Create an account** — Sign up at [6figr.com/jobgpt-ai](https://6figr.com/jobgpt-ai)
+2. **Get an API key** — Go to [6figr.com/account](https://6figr.com/account), scroll to MCP Integrations, and click Generate API Key. The key starts with `mcp_`.
+3. **Add the MCP server:**
+   - Claude Code: `claude mcp add jobgpt -t http -u https://mcp.6figr.com/mcp --header "Authorization: <api-key>"`
+   - Other tools: Add `jobgpt-mcp-server` as an MCP server with env var `JOBGPT_API_KEY` set. Install via `npx jobgpt-mcp-server`.
 
 Set the `JOBGPT_API_KEY` environment variable to your API key.
 
@@ -68,7 +66,7 @@ The skill uses `import_job_by_url` to import the job from any supported platform
 
 > "Find recruiters for this job and draft an outreach email"
 
-The skill finds recruiters with `get_job_recruiters`, helps craft a personalized message, and sends it with `send_outreach`.
+The skill finds recruiters with `get_job_recruiters` and helps craft a personalized message. The draft is presented to the user for review — `send_outreach` is only called after explicit user confirmation.
 
 ### Check Application Stats
 


### PR DESCRIPTION
JobGPT connects AI assistants to 34 tools for job search, auto-apply, resume generation, application tracking, salary intelligence, and recruiter outreach via the JobGPT MCP server.

# Pull Request Description

Please include a summary of the change and which skill is added or fixed.

## Change Classification

- [ ] Skill PR
- [ ] Docs PR
- [ ] Infra PR

## Issue Link (Optional)

Use this only when the PR should auto-close an issue:

`Closes #N` or `Fixes #N`

## Quality Bar Checklist ✅

**All items must be checked before merging.**

- [ ] **Standards**: I have read `docs/contributors/quality-bar.md` and `docs/contributors/security-guardrails.md`.
- [ ] **Metadata**: The `SKILL.md` frontmatter is valid (checked with `npm run validate`).
- [ ] **Risk Label**: I have assigned the correct `risk:` tag (`none`, `safe`, `critical`, `offensive`, or `unknown` for legacy/unclassified content).
- [ ] **Triggers**: The "When to use" section is clear and specific.
- [ ] **Security**: If this is an _offensive_ skill, I included the "Authorized Use Only" disclaimer.
- [ ] **Safety scan**: If this PR adds or modifies `SKILL.md` command guidance, remote/network examples, or token-like strings, I ran `npm run security:docs` (or equivalent hardening check) and addressed any findings.
- [ ] **Automated Skill Review**: If this PR changes `SKILL.md`, I checked the `skill-review` GitHub Actions result and addressed any actionable feedback.
- [ ] **Local Test**: I have verified the skill works locally.
- [ ] **Repo Checks**: I ran `npm run validate:references` if my change affected docs, workflows, or infrastructure.
- [ ] **Source-Only PR**: I did not manually include generated registry artifacts (`CATALOG.md`, `skills_index.json`, `data/*.json`) in this PR.
- [ ] **Credits**: I have added the source credit in `README.md` (if applicable).
- [ ] **Maintainer Edits**: I enabled **Allow edits from maintainers** on the PR.

## Screenshots (if applicable)
