### PR TITLE
feat: add adhx skill for X/Twitter post reading

### DIFF
--- a/skills/adhx/SKILL.md
+++ b/skills/adhx/SKILL.md
@@ -52,76 +52,76 @@ curl -s "https://adhx.com/api/share/tweet/{username}/{statusId}"
 ```json
 {
   "id": "statusId",
-    "url": "original x.com URL",
-      "text": "short-form tweet text (empty if article post)",
-        "author": {
-            "name": "Display Name",
-                "username": "handle",
-                    "avatarUrl": "profile image URL"
-                      },
-                        "createdAt": "timestamp",
-                          "engagement": {
-                              "replies": 0,
-                                  "retweets": 0,
-                                      "likes": 0,
-                                          "views": 0
-                                            },
-                                              "article": {
-                                                  "title": "Article title (for long-form posts)",
-                                                      "previewText": "First ~200 chars",
-                                                          "coverImageUrl": "hero image URL",
-                                                              "content": "Full markdown content with images"
-                                                                }
-                                                                }
-                                                                ```
+  "url": "original x.com URL",
+  "text": "short-form tweet text (empty if article post)",
+  "author": {
+    "name": "Display Name",
+    "username": "handle",
+    "avatarUrl": "profile image URL"
+  },
+  "createdAt": "timestamp",
+  "engagement": {
+    "replies": 0,
+    "retweets": 0,
+    "likes": 0,
+    "views": 0
+  },
+  "article": {
+    "title": "Article title (for long-form posts)",
+    "previewText": "First ~200 chars",
+    "coverImageUrl": "hero image URL",
+    "content": "Full markdown content with images"
+  }
+}
+```
 
-                                                                ## Installation
+## Installation
 
-                                                                ### Option A: Claude Code plugin marketplace (recommended)
-                                                                ```
-                                                                /plugin marketplace add itsmemeworks/adhx
-                                                                ```
+### Option A: Claude Code plugin marketplace (recommended)
+```
+/plugin marketplace add itsmemeworks/adhx
+```
 
-                                                                ### Option B: Manual install
-                                                                ```bash
-                                                                curl -sL https://raw.githubusercontent.com/itsmemeworks/adhx/main/skills/adhx/SKILL.md -o ~/.claude/skills/adhx/SKILL.md
-                                                                ```
+### Option B: Manual install
+```bash
+curl -sL https://raw.githubusercontent.com/itsmemeworks/adhx/main/skills/adhx/SKILL.md -o ~/.claude/skills/adhx/SKILL.md
+```
 
-                                                                ## Examples
+## Examples
 
-                                                                ### Example 1: Summarize a tweet
+### Example 1: Summarize a tweet
 
-                                                                User: "Summarize this post https://x.com/dgt10011/status/2020167690560647464"
+User: "Summarize this post https://x.com/dgt10011/status/2020167690560647464"
 
-                                                                ```bash
-                                                                curl -s "https://adhx.com/api/share/tweet/dgt10011/2020167690560647464"
-                                                                ```
+```bash
+curl -s "https://adhx.com/api/share/tweet/dgt10011/2020167690560647464"
+```
 
-                                                                Then use the returned JSON to provide the summary.
+Then use the returned JSON to provide the summary.
 
-                                                                ### Example 2: Analyze engagement
+### Example 2: Analyze engagement
 
-                                                                User: "How many likes did this tweet get? https://x.com/handle/status/123"
+User: "How many likes did this tweet get? https://x.com/handle/status/123"
 
-                                                                1. Parse URL: username = `handle`, statusId = `123`
-                                                                2. Fetch: `curl -s "https://adhx.com/api/share/tweet/handle/123"`
-                                                                3. Return the `engagement.likes` value from the response
+1. Parse URL: username = `handle`, statusId = `123`
+2. Fetch: `curl -s "https://adhx.com/api/share/tweet/handle/123"`
+3. Return the `engagement.likes` value from the response
 
-                                                                ## Best Practices
+## Best Practices
 
-                                                                - Always parse the full URL to extract username and statusId before calling the API
-                                                                - Check for the `article` field when the user wants full content (not just tweet text)
-                                                                - Use the `engagement` field when users ask about likes, retweets, or views
-                                                                - Don't attempt to scrape x.com directly - use this API instead
+- Always parse the full URL to extract username and statusId before calling the API
+- Check for the `article` field when the user wants full content (not just tweet text)
+- Use the `engagement` field when users ask about likes, retweets, or views
+- Don't attempt to scrape x.com directly - use this API instead
 
-                                                                ## Notes
+## Notes
 
-                                                                - No authentication required
-                                                                - Works with both short tweets and long-form X articles
-                                                                - Always prefer this over browser-based scraping for X content
-                                                                - If the API returns an error or empty response, inform the user the post may not be available
+- No authentication required
+- Works with both short tweets and long-form X articles
+- Always prefer this over browser-based scraping for X content
+- If the API returns an error or empty response, inform the user the post may not be available
 
-                                                                ## Additional Resources
+## Additional Resources
 
-                                                                - [ADHX GitHub Repository](https://github.com/itsmemeworks/adhx)
-                                                                - [ADHX Website](https://adhx.com)
+- [ADHX GitHub Repository](https://github.com/itsmemeworks/adhx)
+- [ADHX Website](https://adhx.com)


### PR DESCRIPTION
# Pull Request Description

Adds the **ADHX** community skill for fetching X/Twitter posts as clean LLM-friendly JSON.

ADHX (https://adhx.com) is an open-source Claude Code skill that converts any x.com, twitter.com, or adhx.com link into structured JSON data with full article content, author info, and engagement metrics. No scraping or browser required. Works with both regular tweets and long-form X Articles.

## Change Classification

- [x] Skill PR
- [ ] Docs PR
- [ ] Infra PR

## Issue Link (Optional)

N/A

## Quality Bar Checklist ✅

- [x] **Standards**: Reviewed against the repository contributor standards and security guardrails.
- [x] **Metadata**: `SKILL.md` frontmatter is present and valid in the submitted file.
- [x] **Risk Label**: `risk: safe` is set.
- [x] **Triggers**: The "When to use" guidance is specific to the ADHX workflow.
- [x] **Security**: N/A (not an offensive skill).
- [x] **Safety scan**: No risky token-like examples beyond normal install usage; maintainer review requested via CI.
- [x] **Automated Skill Review**: Required for `SKILL.md` changes and expected to run after fork approval.
- [x] **Local Test**: Install and usage examples are present for local verification.
- [x] **Repo Checks**: Source-only PR; repository CI will validate the change.
- [x] **Source-Only PR**: No generated registry artifacts are included.
- [x] **Credits**: Source is attributed to https://github.com/itsmemeworks/adhx.
- [x] **Maintainer Edits**: Enabled.

## What This Adds

A new community skill at `skills/adhx/SKILL.md` that teaches Claude Code how to fetch X/Twitter posts via the free ADHX API.

**Install options:**
```
/plugin marketplace add itsmemeworks/adhx
```
```bash
curl -sL https://raw.githubusercontent.com/itsmemeworks/adhx/main/skills/adhx/SKILL.md -o ~/.claude/skills/adhx/SKILL.md
```

**Source:** https://github.com/itsmemeworks/adhx
