### PR TITLE
feat: add tutor-skills to community contributed skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,6 +243,7 @@ These skills are continuously reviewed and hardened, but the collection is not "
 - [DevOps Agent](https://github.com/fullstackcrew-alpha/skill-devops-agent) - One-click deploy, monitoring setup, scheduled backups, fault diagnosis with safety-first design.
 - [CN Content Matrix](https://github.com/fullstackcrew-alpha/skill-cn-content-matrix) - Chinese multi-platform content generator for Xiaohongshu, WeChat, Douyin, Bilibili with true style transfer.
 - [Smart PR Review](https://github.com/fullstackcrew-alpha/skill-smart-pr-review) - Opinionated AI code reviewer with 6-layer deep review, Devil's Advocate mode, MUST FIX/SHOULD FIX/SUGGESTION output.
+- [Tutor Skills](https://github.com/RoundTable02/tutor-skills) - Transform PDFs, docs, and codebases into Obsidian study vaults with interactive quiz-based learning and proficiency tracking.
 
 ## Three Real Examples
 


### PR DESCRIPTION
# Pull Request Description

**Summary:** Adds [Tutor Skills](https://github.com/RoundTable02/tutor-skills) (⭐ 538 stars) to the Community Contributed Skills section in README. This skill transforms PDFs, docs, and codebases into Obsidian study vaults with interactive quiz-based learning and proficiency tracking.

### What Tutor Skills provides

- **tutor-setup** — Generates an Obsidian StudyVault from documents (PDF, MD, HTML, EPUB) or source code projects with auto-detected mode
- **tutor** — Interactive quiz tutor that tracks per-concept proficiency, presents quiz rounds, grades answers, and updates progress
- Installable via `npx skills add RoundTable02/tutor-skills`

## Change Classification

- [ ] Skill PR
- [x] Docs PR
- [ ] Infra PR

## Issue Link (Optional)

N/A

## Quality Bar Checklist ✅

- [x] **Standards**: I have read `docs/contributors/quality-bar.md` and `docs/contributors/security-guardrails.md`.
- [x] **Metadata**: N/A (README community link only, no `SKILL.md` added).
- [x] **Risk Label**: N/A (external link addition only).
- [x] **Triggers**: N/A.
- [x] **Security**: N/A (no offensive content).
- [x] **Safety scan**: N/A (no command guidance or token-like strings added).
- [x] **Automated Skill Review**: N/A (no `SKILL.md` changes).
- [x] **Local Test**: Verified the linked repository is publicly accessible and skill works locally.
- [x] **Repo Checks**: N/A (README-only change).
- [x] **Source-Only PR**: No generated registry artifacts included.
- [x] **Credits**: Source: https://github.com/RoundTable02/tutor-skills
- [x] **Maintainer Edits**: Enabled.