### PR TITLE
feat(odoo-edi): Implement Idempotency and Secure Handling

### DIFF
--- a/skills/odoo-edi-connector/SKILL.md
+++ b/skills/odoo-edi-connector/SKILL.md
@@ -56,8 +56,8 @@ models = xmlrpc.client.ServerProxy(f"{odoo_url}/xmlrpc/2/object")
 def process_850(edi_file_path):
     """Parse X12 850 Purchase Order and create Odoo Sale Order"""
     with x12file.X12File(edi_file_path) as f:
-                    for transaction in f.get_transaction_sets():
-                        # Extract header info (BEG segment)                     
+        for transaction in f.get_transaction_sets():
+            # Extract header info (BEG segment)                     
             po_number = transaction['BEG'][3]    # Purchase Order Number                                                    
             po_date   = transaction['BEG'][5]    # Purchase Order Date 
 


### PR DESCRIPTION
# Pull Request Description

This PR refactors the `odoo-edi-connector` skill to production-grade standards. It moves the implementation from a basic script to a resilient integration by addressing critical "silent signs" of technical debt: hardcoded secrets, lack of idempotency, and runtime errors in EDI generation.

**Key Technical Improvements:**
* **Idempotency & Resource Governance**: Added a search check before `sale.order` creation to ensure the same EDI 850 doesn't create duplicate records.
* **Security Hardening**: Replaced hardcoded connection strings with `os.getenv` for all Odoo credentials (`URL`, `DB`, `API_KEY`).
* **Resilience**: Implemented a partner verification check to gracefully skip and log errors when a trading partner is not found, preventing script crashes.
* **EDI Compliance**: Fixed a `NameError` in the 997 generator by importing `datetime` and dynamically calculating the required date stamps to match X12 standards.

## Change Classification

- [x] Skill PR
- [ ] Docs PR
- [ ] Infra PR

## Issue Link (Optional)

Use this only when the PR should auto-close an issue:

`Closes #N` or `Fixes #N`

## Quality Bar Checklist ✅

**All items must be checked before merging.**

- [x] **Standards**: I have read `docs/contributors/quality-bar.md` and `docs/contributors/security-guardrails.md`.
- [x] **Metadata**: The `SKILL.md` frontmatter is valid (checked with `npm run validate`).
- [x] **Risk Label**: I have assigned the correct `risk:` tag (`safe`).
- [x] **Triggers**: The "When to use" section is clear and specific.
- [ ] **Security**: If this is an _offensive_ skill, I included the "Authorized Use Only" disclaimer.
- [x] **Safety scan**: If this PR adds or modifies `SKILL.md` command guidance, remote/network examples, or token-like strings, I ran `npm run security:docs` (or equivalent hardening check) and addressed any findings.
- [x] **Automated Skill Review**: If this PR changes `SKILL.md`, I checked the `skill-review` GitHub Actions result and addressed any actionable feedback.
- [x] **Local Test**: I have verified the skill works locally. **Verified via 4 distinct mock tests in Termux (Security, Idempotency, Partner Handling, and Date Generation).**
- [x] **Repo Checks**: I ran `npm run validate:references` if my change affected docs, workflows, or infrastructure.
- [x] **Source-Only PR**: I did not manually include generated registry artifacts (`CATALOG.md`, `skills_index.json`, `data/*.json`) in this PR.
- [ ] **Credits**: I have added the source credit in `README.md` (if applicable).
- [x] **Maintainer Edits**: Enabled 
