### PR TITLE
docs(skill-anatomy): replace \` with `

### DIFF
--- a/docs/contributors/skill-anatomy.md
+++ b/docs/contributors/skill-anatomy.md
@@ -145,19 +145,19 @@ More instructions...
 **This is the heart of your skill** - clear, actionable steps
 
 #### 5. Examples
-```markdown
+````markdown
 ## Examples
 
 ### Example 1: [Use Case]
-\`\`\`javascript
+```javascript
 // Example code
-\`\`\`
+```
 
 ### Example 2: [Another Use Case]
-\`\`\`javascript
+```javascript
 // More code
-\`\`\`
 ```
+````
 
 **Why examples matter:** They show the AI exactly what good output looks like
 
@@ -264,12 +264,12 @@ scripts/
 ```
 
 **Reference them in SKILL.md:**
-```markdown
+````markdown
 Run the setup script:
-\`\`\`bash
+```bash
 bash scripts/setup.sh
-\`\`\`
 ```
+````
 
 ### Examples Directory
 
@@ -296,12 +296,12 @@ templates/
 ```
 
 **Reference in SKILL.md:**
-```markdown
+````markdown
 Use this template as a starting point:
-\`\`\`typescript
+```typescript
 {{#include templates/component.tsx}}
-\`\`\`
 ```
+````
 
 ### References Directory
 
@@ -344,11 +344,11 @@ references/
 
 #### Code Blocks
 Always specify the language:
-```markdown
-\`\`\`javascript
+````markdown
+```javascript
 const example = "code";
-\`\`\`
 ```
+````
 
 #### Lists
 Use consistent formatting:


### PR DESCRIPTION
# Pull Request Description

I replaced the \` with `, and I replaced the cells that had three backticks with four backticks.

## Change Classification

- [ ] Skill PR
- [X] Docs PR
- [ ] Infra PR

## Quality Bar Checklist ✅

**All applicable items must be checked before merging.**

- [X] **Standards**: I have read `docs/contributors/quality-bar.md` and `docs/contributors/security-guardrails.md`.
- [ ] ~~**Metadata**: The `SKILL.md` frontmatter is valid (checked with `npm run validate`).~~
- [ ] ~~**Risk Label**: I have assigned the correct `risk:` tag (`none`, `safe`, `critical`, `offensive`, or `unknown` for legacy/unclassified content).~~
- [ ] ~~**Triggers**: The "When to use" section is clear and specific.~~
- [ ] ~~**Security**: If this is an _offensive_ skill, I included the "Authorized Use Only" disclaimer.~~
- [ ] ~~**Safety scan**: If this PR adds or modifies `SKILL.md` command guidance, remote/network examples, or token-like strings, I ran `npm run security:docs` (or equivalent hardening check) and addressed any findings.~~
- [ ] ~~**Automated Skill Review**: If this PR changes `SKILL.md`, I checked the `skill-review` GitHub Actions result and addressed any actionable feedback.~~
- [ ] ~~**Manual Logic Review**: If this PR changes `SKILL.md` or risky guidance, I manually reviewed the logic, safety, failure modes, and `risk:` label instead of relying on automated checks alone.~~
- [ ] ~~**Local Test**: I have verified the skill works locally.~~
- [ ] ~~**Repo Checks**: I ran `npm run validate:references` if my change affected docs, workflows, or infrastructure.~~
- [ ] ~~**Source-Only PR**: I did not manually include generated registry artifacts (`CATALOG.md`, `skills_index.json`, `data/*.json`) in this PR.~~
- [ ] ~~**Credits**: I have added the source credit in `README.md` (if applicable).~~
- [X] **Maintainer Edits**: I enabled **Allow edits from maintainers** on the PR.

## Screenshots (if applicable)

### Before

<img width="439" height="278" alt="Captura de pantalla 2026-03-29 a la(s) 7 54 59 p m" src="https://github.com/user-attachments/assets/b4f96594-cf08-42e5-a834-70f0ec524f5a" />

### After

<img width="333" height="272" alt="Captura de pantalla 2026-03-29 a la(s) 7 56 11 p m" src="https://github.com/user-attachments/assets/c397015f-3e50-454b-93af-b04209c79fff" />
