### PR TITLE
Add ru-text: Russian text quality skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -330,6 +330,7 @@ These skills are continuously reviewed and hardened, but the collection is not "
 - [HubSpot Admin Skills](https://github.com/TomGranot/hubspot-admin-skills) - 32 Claude Code skills for auditing, cleaning, enriching, and automating HubSpot CRM. Includes Python scripts, Breeze AI workflow prompts, and a full audit → plan → execute → maintain flow.
 - [Tutor Skills](https://github.com/RoundTable02/tutor-skills) - Transform PDFs, docs, and codebases into Obsidian study vaults with interactive quiz-based learning and proficiency tracking.
 - [CoinPaprika & DexPaprika Skills](https://github.com/coinpaprika/skills) - Two crypto data skills: CoinPaprika (12K+ coins, 350+ exchanges, OHLCV, tickers) and DexPaprika (34 chains, 30M+ DEX pools, real-time streaming). Free, no API key. Install: `npx skills add github.com/coinpaprika/skills`
+- [ru-text](https://github.com/talkstream/ru-text) - Russian text quality: ~1,040 rules for typography, info-style, editorial, UX writing, business correspondence. Cross-platform.
 
 ## Three Real Examples
 


### PR DESCRIPTION
## Summary

- Add [ru-text](https://github.com/talkstream/ru-text) to the Community Contributed Skills section
- ~1,040 rules covering typography, info-style, editorial, UX writing, and business correspondence
- Cross-platform skill (Claude Code, Cursor, Windsurf, Cline, Copilot)

## Test plan

- [ ] Verify the new entry renders correctly in the README
- [ ] Confirm alphabetical placement within the Community Contributed Skills list
- [ ] Check that the link resolves to the correct repository