### PR TITLE
fix(web-app): stabilize skill card hover state

### DIFF
--- a/apps/web-app/src/components/SkillCard.tsx
+++ b/apps/web-app/src/components/SkillCard.tsx
@@ -22,7 +22,7 @@ export const SkillCard = React.memo(({ skill, starCount }: SkillCardProps) => {
         >
             <Link
                 to={`/skill/${skill.id}`}
-                className="group flex flex-col h-full rounded-lg border border-slate-200 bg-white p-6 shadow-sm transition-all hover:bg-slate-50 hover:shadow-md dark:border-slate-800 dark:bg-slate-900 dark:hover:border-indigo-500/50"
+                className="group flex flex-col h-full rounded-lg border border-slate-200 bg-white p-6 shadow-sm transition-all hover:-translate-y-0.5 hover:border-indigo-200 hover:shadow-md dark:border-slate-800 dark:bg-slate-900 dark:hover:border-indigo-500/50"
             >
                 <div className="flex items-center justify-between mb-4">
                     <div className="flex items-center space-x-2">
@@ -40,7 +40,7 @@ export const SkillCard = React.memo(({ skill, starCount }: SkillCardProps) => {
                     />
                 </div>
 
-                <h3 className="text-lg font-bold text-slate-900 dark:text-slate-50 group-hover:text-indigo-600 dark:group-hover:text-indigo-400 transition-colors mb-2 line-clamp-1">
+                <h3 className="text-lg font-bold text-slate-900 dark:text-slate-50 mb-2 line-clamp-1">
                     @{skill.name}
                 </h3>
 


### PR DESCRIPTION
## Summary
- keep the home page `SkillCard` palette stable on hover instead of shifting the card background and text colors
- use a lighter hover signal through subtle lift, border emphasis, and shadow so the card remains readable
- limit the change to `apps/web-app/src/components/SkillCard.tsx`

## Test Plan
- [x] `npm run app:test`

# Pull Request Description

Please include a summary of the change and which skill is added or fixed.

## Change Classification

- [ ] Skill PR
- [ ] Docs PR
- [x] Infra PR

## Issue Link (Optional)

Use this only when the PR should auto-close an issue:

`Closes #N` or `Fixes #N`

## Quality Bar Checklist ✅

**All applicable items must be checked before merging.**

- [ ] **Standards**: I have read `docs/contributors/quality-bar.md` and `docs/contributors/security-guardrails.md`.
- [ ] **Metadata**: The `SKILL.md` frontmatter is valid (checked with `npm run validate`).
- [ ] **Risk Label**: I have assigned the correct `risk:` tag (`none`, `safe`, `critical`, `offensive`, or `unknown` for legacy/unclassified content).
- [ ] **Triggers**: The "When to use" section is clear and specific.
- [ ] **Security**: If this is an _offensive_ skill, I included the "Authorized Use Only" disclaimer.
- [ ] **Safety scan**: If this PR adds or modifies `SKILL.md` command guidance, remote/network examples, or token-like strings, I ran `npm run security:docs` (or equivalent hardening check) and addressed any findings.
- [ ] **Automated Skill Review**: If this PR changes `SKILL.md`, I checked the `skill-review` GitHub Actions result and addressed any actionable feedback.
- [ ] **Manual Logic Review**: If this PR changes `SKILL.md` or risky guidance, I manually reviewed the logic, safety, failure modes, and `risk:` label instead of relying on automated checks alone.
- [ ] **Local Test**: I have verified the skill works locally.
- [ ] **Repo Checks**: I ran `npm run validate:references` if my change affected docs, workflows, or infrastructure.
- [ ] **Source-Only PR**: I did not manually include generated registry artifacts (`CATALOG.md`, `skills_index.json`, `data/*.json`) in this PR.
- [ ] **Credits**: I have added the source credit in `README.md` (if applicable).
- [ ] **Maintainer Edits**: I enabled **Allow edits from maintainers** on the PR.

## Screenshots (if applicable)