### PR TITLE
fix: stabilize validation and tests on Windows

### DIFF
--- a/skills/project-skill-audit/SKILL.md
+++ b/skills/project-skill-audit/SKILL.md
@@ -187,4 +187,4 @@ Return a compact audit with:
 
 ## Follow-up
 
-If the user asks to actually create or update one of the recommended skills, switch to [$skill-creator](/Users/dimillian/.codex/skills/.system/skill-creator/SKILL.md) and implement the chosen skill rather than continuing the audit.
+If the user asks to actually create or update one of the recommended skills, switch to `$skill-creator` and implement the chosen skill rather than continuing the audit.

--- a/skills/site-architecture/SKILL.md
+++ b/skills/site-architecture/SKILL.md
@@ -272,7 +272,7 @@ graph TD
 | Type | Purpose | Example |
 |------|---------|---------|
 | Navigational | Move between sections | Header, footer, sidebar links |
-| Contextual | Related content within text | "Learn more about [analytics](/features/analytics)" |
+| Contextual | Related content within text | "Learn more about analytics at `/features/analytics`" |
 | Hub-and-spoke | Connect cluster content to hub | Blog posts linking to pillar page |
 | Cross-section | Connect related pages across sections | Feature page linking to related case study |
 

--- a/tools/lib/skill-utils.js
+++ b/tools/lib/skill-utils.js
@@ -204,7 +204,7 @@ function listSkillIdsRecursive(skillsDir, baseDir = skillsDir, acc = []) {
       if (!isSafeDirectory(dirPath)) continue;
 
       const skillPath = path.join(dirPath, 'SKILL.md');
-      const relPath = path.relative(skillsDir, dirPath);
+      const relPath = path.relative(skillsDir, dirPath).split(path.sep).join('/');
       if (isSafeSkillFile(skillPath)) {
         acc.push(relPath);
       }

--- a/tools/scripts/sync_microsoft_skills.py
+++ b/tools/scripts/sync_microsoft_skills.py
@@ -10,7 +10,7 @@ import shutil
 import subprocess
 import tempfile
 import json
-from pathlib import Path
+from pathlib import Path, PurePosixPath
 
 MS_REPO = "https://github.com/microsoft/skills.git"
 REPO_ROOT = Path(__file__).parent.parent
@@ -182,7 +182,7 @@ def find_skills_in_directory(source_dir: Path):
             continue
 
         try:
-            relative_path = item.relative_to(skills_source)
+            relative_path = PurePosixPath(item.relative_to(skills_source).as_posix())
         except ValueError:
             continue
 
@@ -212,7 +212,7 @@ def find_plugin_skills(source_dir: Path, already_synced_names: set):
 
         if skill_name not in already_synced_names:
             results.append({
-                "relative_path": Path("plugins") / skill_name,
+                "relative_path": PurePosixPath("plugins") / skill_name,
                 "skill_md": skill_file,
                 "source_dir": skill_dir,
             })
@@ -238,7 +238,7 @@ def find_github_skills(source_dir: Path, already_synced_names: set):
 
         if skill_dir.name not in already_synced_names:
             results.append({
-                "relative_path": Path(".github/skills") / skill_dir.name,
+                "relative_path": PurePosixPath(".github/skills") / skill_dir.name,
                 "skill_md": skill_md,
                 "source_dir": skill_dir,
             })

--- a/tools/scripts/sync_repo_metadata.py
+++ b/tools/scripts/sync_repo_metadata.py
@@ -116,7 +116,7 @@ def sync_github_about(
     runner(topic_command, dry_run=dry_run)
 
     if not dry_run:
-        print(f"✅ Synced GitHub About settings for {repo}")
+        print(f"[ok] Synced GitHub About settings for {repo}")
 
 
 def replace_if_present(content: str, pattern: re.Pattern[str], replacement: str) -> tuple[str, bool]:
@@ -241,7 +241,7 @@ def update_text_file(path: Path, transform, metadata: dict, dry_run: bool) -> bo
         return True
 
     path.write_text(updated, encoding="utf-8", newline="\n")
-    print(f"✅ Updated {path}")
+    print(f"[ok] Updated {path}")
     return True
 
 
@@ -353,7 +353,7 @@ def update_package_description(base_dir: str, metadata: dict, dry_run: bool) -> 
 
     with open(package_path, "w", encoding="utf-8", newline="\n") as file:
         file.write(updated_content)
-    print(f"✅ Updated package description in {package_path}")
+    print(f"[ok] Updated package description in {package_path}")
     return True
 
 

--- a/tools/scripts/tests/activate_skills_shell.test.js
+++ b/tools/scripts/tests/activate_skills_shell.test.js
@@ -1,13 +1,17 @@
 const assert = require("assert");
 const fs = require("fs");
-const os = require("os");
 const path = require("path");
 const { spawnSync } = require("child_process");
 
-const repoRoot = path.resolve(__dirname, "../..", "..");
-const scriptPath = path.join(repoRoot, "scripts", "activate-skills.sh");
+if (process.platform === "win32") {
+  console.log("Skipping activate-skills.sh smoke test on Windows; use the batch-script coverage instead.");
+  process.exit(0);
+}
 
-const root = fs.mkdtempSync(path.join(os.tmpdir(), "activate-skills-shell-"));
+const repoRoot = path.resolve(__dirname, "../..", "..");
+const scriptPath = path.posix.join("scripts", "activate-skills.sh");
+
+const root = fs.mkdtempSync(path.join(repoRoot, ".tmp-activate-skills-shell-"));
 const baseDir = path.join(root, "antigravity");
 const repoSkills = path.join(root, "repo-skills");
 const outsideDir = path.join(root, "outside-skill-root");
@@ -37,8 +41,8 @@ try {
       cwd: repoRoot,
       env: {
         ...process.env,
-        AG_BASE_DIR: baseDir,
-        AG_REPO_SKILLS_DIR: repoSkills,
+        AG_BASE_DIR: path.relative(repoRoot, baseDir).split(path.sep).join("/"),
+        AG_REPO_SKILLS_DIR: path.relative(repoRoot, repoSkills).split(path.sep).join("/"),
         AG_PYTHON_BIN: "python3",
       },
       encoding: "utf8",

--- a/tools/scripts/tests/npm_package_contents.test.js
+++ b/tools/scripts/tests/npm_package_contents.test.js
@@ -10,6 +10,7 @@ function runNpmPackDryRunJson() {
   const result = spawnSync(npmCommand, ["pack", "--dry-run", "--json"], {
     cwd: repoRoot,
     encoding: "utf8",
+    shell: process.platform === "win32",
   });
 
   if (result.error) {

--- a/tools/scripts/tests/plugin_directories.test.js
+++ b/tools/scripts/tests/plugin_directories.test.js
@@ -3,6 +3,10 @@ const fs = require("fs");
 const path = require("path");
 const { findProjectRoot } = require("../../lib/project-root");
 
+function normalizeRelativePath(value) {
+  return value.replace(/\\/g, "/").replace(/^\.\//, "");
+}
+
 const projectRoot = findProjectRoot(__dirname);
 const pluginsRoot = path.join(projectRoot, "plugins");
 const claudeMarketplace = JSON.parse(
@@ -13,10 +17,10 @@ const codexMarketplace = JSON.parse(
 );
 
 const claudePluginPaths = new Set(
-  claudeMarketplace.plugins.map((plugin) => plugin.source.replace(/^\.\//, "")),
+  claudeMarketplace.plugins.map((plugin) => normalizeRelativePath(plugin.source)),
 );
 const codexPluginPaths = new Set(
-  codexMarketplace.plugins.map((plugin) => plugin.source.path.replace(/^\.\//, "")),
+  codexMarketplace.plugins.map((plugin) => normalizeRelativePath(plugin.source.path)),
 );
 const knownPluginPaths = new Set([...claudePluginPaths, ...codexPluginPaths]);
 
@@ -69,7 +73,7 @@ for (const entry of fs.readdirSync(pluginsRoot, { withFileTypes: true })) {
     continue;
   }
 
-  const relativePluginPath = path.join("plugins", entry.name);
+  const relativePluginPath = normalizeRelativePath(path.join("plugins", entry.name));
   if (entry.name.startsWith("antigravity-bundle-") || entry.name === "antigravity-awesome-skills" || entry.name === "antigravity-awesome-skills-claude") {
     assert.ok(
       knownPluginPaths.has(relativePluginPath),

--- a/tools/scripts/tests/test_editorial_bundles.py
+++ b/tools/scripts/tests/test_editorial_bundles.py
@@ -33,6 +33,10 @@ get_bundle_skills = load_module(
 )
 
 
+def relative_posix(path: pathlib.Path, root: pathlib.Path) -> str:
+    return path.relative_to(root).as_posix()
+
+
 class EditorialBundlesTests(unittest.TestCase):
     def setUp(self):
         self.manifest_bundles = editorial_bundles.load_editorial_bundles(REPO_ROOT)
@@ -79,7 +83,7 @@ class EditorialBundlesTests(unittest.TestCase):
             for skill in next(bundle for bundle in self.manifest_bundles if bundle["id"] == "essentials")["skills"]
         }
         actual_ids = {
-            str(path.relative_to(essentials_plugin))
+            relative_posix(path, essentials_plugin)
             for path in essentials_plugin.rglob("SKILL.md")
         }
         self.assertEqual(actual_ids, {f"{skill_id}/SKILL.md" for skill_id in expected_ids})
@@ -140,12 +144,12 @@ class EditorialBundlesTests(unittest.TestCase):
             self.assertTrue(copied_dir.is_dir(), f'copied skill dir missing for {skill["id"]}')
 
             source_files = sorted(
-                str(path.relative_to(source_dir))
+                relative_posix(path, source_dir)
                 for path in source_dir.rglob("*")
                 if path.is_file()
             )
             copied_files = sorted(
-                str(path.relative_to(copied_dir))
+                relative_posix(path, copied_dir)
                 for path in copied_dir.rglob("*")
                 if path.is_file()
             )

--- a/tools/scripts/tests/test_plugin_compatibility.py
+++ b/tools/scripts/tests/test_plugin_compatibility.py
@@ -133,10 +133,15 @@ class PluginCompatibilityTests(unittest.TestCase):
         report = plugin_compatibility.build_report(REPO_ROOT / "skills")
         entries = plugin_compatibility.compatibility_by_skill_id(report)
 
-        for skill_id in ("project-skill-audit", "molykit", "claude-code-expert"):
+        for skill_id in ("molykit", "claude-code-expert"):
             self.assertEqual(entries[skill_id]["targets"]["codex"], "blocked")
             self.assertEqual(entries[skill_id]["targets"]["claude"], "blocked")
             self.assertIn("absolute_host_path", entries[skill_id]["reasons"])
+
+        self.assertEqual(entries["project-skill-audit"]["targets"]["codex"], "supported")
+        self.assertEqual(entries["project-skill-audit"]["targets"]["claude"], "blocked")
+        self.assertNotIn("absolute_host_path", entries["project-skill-audit"]["reasons"])
+        self.assertIn("target_specific_home_path", entries["project-skill-audit"]["blocked_reasons"]["claude"])
 
         self.assertEqual(entries["playwright-skill"]["targets"]["codex"], "supported")
         self.assertEqual(entries["playwright-skill"]["targets"]["claude"], "supported")

--- a/tools/scripts/validate_references.py
+++ b/tools/scripts/validate_references.py
@@ -19,7 +19,7 @@ def collect_skill_ids(skills_dir):
     for root, dirs, files in os.walk(skills_dir):
         dirs[:] = [d for d in dirs if not d.startswith(".")]
         if "SKILL.md" in files:
-            rel = os.path.relpath(root, skills_dir)
+            rel = os.path.relpath(root, skills_dir).replace(os.sep, "/")
             ids.add(rel)
     return ids
 


### PR DESCRIPTION
## Summary
- fix broken skill links that were failing validation
- normalize tool and test paths for Windows compatibility
- stabilize Windows test behavior and Python metadata sync output

## Verification
- npm run validate
- npm run validate:references
- npm run test
- npm run app:test:coverage
- npm run app:build