### PR TITLE
feat: add puzzle-activity-planner skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -340,6 +340,7 @@ This collection would not be possible without the incredible work of the Claude 
 - **[ZhangHanDong/makepad-skills](https://github.com/ZhangHanDong/makepad-skills)**: Makepad app-development skills and references (MIT).
 - **[czlonkowski/n8n-skills](https://github.com/czlonkowski/n8n-skills)**: n8n workflow-building skills for Claude Code (MIT).
 - **[frmoretto/clarity-gate](https://github.com/frmoretto/clarity-gate)**: Verification protocol for marking uncertainty and reducing hallucinated certainty in LLM-facing docs.
+- **[fruitwyatt/puzzle-activity-planner](https://github.com/fruitwyatt/puzzle-activity-planner)**: Puzzle activity-planning skill for classrooms, parties, and events with generator-link workflows.
 - **[gokapso/agent-skills](https://github.com/gokapso/agent-skills)**: Kapso/WhatsApp-oriented agent skills.
 - **[huifer/WellAlly-health](https://github.com/huifer/WellAlly-health)**: Healthcare assistant project cited in release history as a source for health-focused agent capabilities (MIT).
 - **[ibelick/ui-skills](https://github.com/ibelick/ui-skills)**: UI-polish skills for improving interfaces built by agents (MIT).

--- a/skills/puzzle-activity-planner/SKILL.md
+++ b/skills/puzzle-activity-planner/SKILL.md
@@ -1,0 +1,71 @@
+---
+name: puzzle-activity-planner
+description: "Plan puzzle-based activities for classrooms, parties, and events with pre-configured generator links"
+category: education
+risk: safe
+source: community
+source_repo: fruitwyatt/puzzle-activity-planner
+source_type: community
+date_added: "2026-04-11"
+author: fruitwyatt
+tags: [education, puzzle, classroom, activity-planning, event]
+tools: [claude, cursor, gemini, codex]
+---
+
+# Puzzle Activity Planner
+
+## Overview
+
+Plans engaging puzzle-based activities for classrooms, parties, team-building sessions, and events. Given an event description, audience, and goal, produces a structured activity plan with pre-configured generator links that include URL parameters for one-click ready-to-use puzzles.
+
+## When to Use This Skill
+
+- Planning a classroom lesson with puzzle activities
+- Organizing party games involving puzzles
+- Creating team-building sessions with multiple puzzle types
+- Preparing educational activities for kids, students, or adults
+
+## Process
+
+1. **Understand the event** - audience, group size, duration, theme
+2. **Select puzzle types** - match difficulty and format to the audience
+3. **Build timeline** - minute-by-minute flow with transitions
+4. **Generate links** - pre-configured URLs with theme content baked in
+5. **Create prep checklist** - print quantities and materials needed
+
+## Puzzle Types Supported
+
+- **Word Search** - vocabulary building, warm-ups, brain training
+- **Crossword** - vocabulary review, test prep, party games
+- **Sudoku** - math warm-ups, logic training, focus time
+- **Bingo** - group games, classroom review, holiday celebrations
+- **Jigsaw** - ice-breakers, collaborative activities, crafts
+
+## URL Parameters
+
+All generator links include pre-filled parameters so users get ready-to-use puzzles in one click. The skill generates theme-appropriate content (words, clues, items) and embeds them directly in the URL.
+
+Example:
+```
+https://jigsawmake.com/word-search-maker?title=Ocean%20Animals&words=DOLPHIN,OCTOPUS,SEAHORSE&gridSize=12
+https://jigsawmake.com/crossword-puzzle-maker?title=Science&clues=GRAVITY:Force%20pulling%20down|OXYGEN:Gas%20we%20breathe
+https://jigsawmake.com/bingo-card-generator?title=Party%20Bingo&items=Dance,Laugh,Sing&cardCount=25
+```
+
+## Output Format
+
+Each plan includes:
+- Activity header (occasion, audience, duration, difficulty)
+- Objectives (2-3 learning or engagement goals)
+- Puzzle menu table with generator links
+- Minute-by-minute timeline
+- Materials and prep checklist with print quantities
+- Differentiation tips (easier/harder adaptations)
+
+## Rules
+
+- Match puzzle difficulty to the audience
+- Suggest 2-3 puzzle types per activity for variety
+- Include timing buffers for transitions
+- Apply the user's theme consistently across all puzzles
+- Always use URL parameters with pre-filled content


### PR DESCRIPTION
Adds a puzzle activity planner skill under the education category.

**What it does:**
- Plans multi-puzzle activity sessions for classrooms, parties, team-building, and events
- Generates pre-configured generator links with URL params pre-filled (theme words, clues, items)
- Covers 5 puzzle types: word search, crossword, sudoku, bingo, jigsaw

**Structure:** Single SKILL.md following the canonical template with proper frontmatter (name, description, category, risk, source, tags, tools).

**Skill repo:** https://github.com/fruitwyatt/puzzle-activity-planner

## Change Classification

- [ ] Skill PR
- [ ] Docs PR
- [ ] Infra PR

## Issue Link (Optional)

Use this only when the PR should auto-close an issue:

`Closes #N` or `Fixes #N`

## Quality Bar Checklist ✅

**All applicable items must be checked before merging.**

- [ ] **Standards**: I have read `docs/contributors/quality-bar.md` and `docs/contributors/security-guardrails.md`.
- [ ] **Metadata**: The `SKILL.md` frontmatter is valid (checked with `npm run validate`).
- [ ] **Risk Label**: I have assigned the correct `risk:` tag (`none`, `safe`, `critical`, `offensive`, or `unknown` for legacy/unclassified content).
- [ ] **Triggers**: The "When to use" section is clear and specific.
- [ ] **Security**: If this is an _offensive_ skill, I included the "Authorized Use Only" disclaimer.
- [ ] **Safety scan**: If this PR adds or modifies `SKILL.md` command guidance, remote/network examples, or token-like strings, I ran `npm run security:docs` (or equivalent hardening check) and addressed any findings.
- [ ] **Automated Skill Review**: If this PR changes `SKILL.md`, I checked the `skill-review` GitHub Actions result and addressed any actionable feedback.
- [ ] **Manual Logic Review**: If this PR changes `SKILL.md` or risky guidance, I manually reviewed the logic, safety, failure modes, and `risk:` label instead of relying on automated checks alone.
- [ ] **Local Test**: I have verified the skill works locally.
- [ ] **Repo Checks**: I ran `npm run validate:references` if my change affected docs, workflows, or infrastructure.
- [ ] **Source-Only PR**: I did not manually include generated registry artifacts (`CATALOG.md`, `skills_index.json`, `data/*.json`) in this PR.
- [ ] **Credits**: I have added the source credit in `README.md` (if applicable).
- [ ] **Maintainer Edits**: I enabled **Allow edits from maintainers** on the PR.

## Screenshots (if applicable)