### PR TITLE
chore(adhx): conform frontmatter to agentskills.io spec

### DIFF
--- a/skills/adhx/SKILL.md
+++ b/skills/adhx/SKILL.md
@@ -1,9 +1,10 @@
 ---
 name: adhx
-description: "Fetch any X/Twitter post as clean LLM-friendly JSON. Converts x.com, twitter.com, or adhx.com links into structured data with full article content, author info, and engagement metrics. No scraping or browser required."
-risk: safe
-source: community
-date_added: "2026-03-25"
+description: "Fetch any X/Twitter post as clean LLM-friendly JSON. Converts x.com, twitter.com, or adhx.com links into structured data with full article content, author info, and engagement metrics. Use when a user shares an X/Twitter link and wants to read, analyze, or summarize the post. No scraping or browser required."
+metadata:
+  risk: safe
+  source: community
+  date_added: "2026-03-25"
 ---
 
 # ADHX - X/Twitter Post Reader


### PR DESCRIPTION
# Pull Request Description

Conforms the `adhx` skill frontmatter to the [agentskills.io spec](https://agentskills.io/specification) so it's portable across all 30+ skills-compatible agents (Claude Code, Cursor, Gemini CLI, OpenCode, Codex, Copilot, Goose, Kiro, etc.).

- Move `risk` / `source` / `date_added` under the optional `metadata:` map (the spec only allows `name`, `description`, `license`, `compatibility`, `metadata`, `allowed-tools` at top level).
- Add an explicit "Use when…" clause to the description (spec recommendation).

Follow-up to #396 — the body indentation fix landed there, but the spec change came afterward and missed the merge.

## Change Classification

- [x] Skill PR
- [ ] Docs PR
- [ ] Infra PR

## Issue Link (Optional)

N/A

## Quality Bar Checklist ✅

- [x] **Standards**: I have read `docs/contributors/quality-bar.md` and `docs/contributors/security-guardrails.md`.
- [x] **Metadata**: The `SKILL.md` frontmatter is valid (only spec-allowed top-level keys; `name` matches parent dir; description ≤ 1024 chars).
- [x] **Risk Label**: `risk: safe` preserved (now under `metadata:`).
- [x] **Triggers**: The description includes "Use when a user shares an X/Twitter link and wants to read, analyze, or summarize the post".
- [x] **Security**: Not an offensive skill.
- [x] **Safety scan**: No new command guidance, network examples, or token-like strings introduced (frontmatter-only change).
- [x] **Automated Skill Review**: Will address any findings from `skill-review` once it runs.
- [x] **Manual Logic Review**: Manually reviewed — body content unchanged, only frontmatter keys reorganized.
- [x] **Local Test**: Skill body, install URL, and ADHX API all verified working.
- [x] **Repo Checks**: Frontmatter validated against the agentskills.io spec.
- [x] **Source-Only PR**: No generated registry artifacts included.
- [x] **Credits**: Credit already present from #396.
- [x] **Maintainer Edits**: Enabled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)