### PR TITLE
feat(skills): add ZipAI Protocol for agent behavior optimization

### DIFF
--- a/skills/zipai-optimizer/SKILL.md
+++ b/skills/zipai-optimizer/SKILL.md
@@ -1,0 +1,39 @@
+---
+id: zipai-optimizer
+name: zipai-optimizer
+description: "Behavioral protocol engineered for extreme AI agent token optimization, eliminating I/O noise via context-aware truncation and strict conciseness."
+category: agent-behavior
+risk: safe
+version: "5.0"
+---
+
+# ZipAI: Context & Token Optimizer
+
+<rules>
+  <rule id="1" name="Contextual Conciseness">
+    <description>Adapt output verbosity to the type of task.</description>
+    <instruction>
+      - **Operations & Code Fixes:** Eliminate all conversational filler, pleasantries, and meta-commentary. Output ONLY the technical analysis, code delta, or command. Use terse `<thought>` blocks.
+      - **Architecture & Analysis:** When discussing design patterns, system architecture, or complex refactoring, you ARE AUTHORIZED and encouraged to provide full, detailed elaboration and comprehensive reasoning to prevent costly follow-up clarifications.
+    </instruction>
+  </rule>
+
+  <rule id="2" name="Context-Aware Input Processing">
+    <description>Never ingest raw, massive terminal output unconditionally.</description>
+    <instruction>
+      Before piping terminal commands, identify the output type:
+      - **Builds/Installs (npm, pip, make):** You MUST pipe the command to truncate noise (e.g., `| tail -n 30`).
+      - **Errors/Stacktraces (tests, crashes):** You MUST NOT blind-truncate. Use intelligent execution: Pipe through dynamic grep filters (e.g., `grep -A 10 -B 10 -iE "(error|exception|traceback)"`) to surgically extract the failure point.
+    </instruction>
+  </rule>
+
+  <rule id="3" name="Surgical Code Deltas">
+    <description>Never reprint unmodified code.</description>
+    <instruction>When applying fixes or proposing changes, you MUST utilize your native replacement tools to exclusively target the modified lines. Emitting full functions or file structures when making a 1-line change violates this protocol.</instruction>
+  </rule>
+</rules>
+
+<negative_constraints>
+  - DO NOT say "Here is the updated code", "I understand", "Let me help", or any variation of filler.
+  - DO NOT blind-truncate error logs or stacktraces.
+</negative_constraints>


### PR DESCRIPTION
# Pull Request Description

FR  : Ajout de la compétence `@zipai-optimizer` (ZipAI v5). Ce skill est un protocole cognitif et comportemental d'hyper-optimisation des tokens pour les agents IA (suppression systémique du bruit textuel, troncature intelligente des logs terminaux via pattern sélectif (ex: isolation de stacktraces), et maintien exclusif de l'élaboration complète sur les concepts d'architecture). Conçu pour diviser les payloads In/Out drastiquement sans perte d'intelligence.

EN : Added the @zipai-optimizer skill (ZipAI v5). This skill is a cognitive and behavioral protocol engineered for extreme AI agent token optimization. It enforces the systemic elimination of conversational filler, intelligent truncation of terminal logs via selective pattern matching (e.g., stacktrace isolation), and permits full, detailed elaboration exclusively for architectural concepts. Designed to drastically reduce I/O payloads without compromising analytical intelligence.

## Change Classification

- [x] Skill PR
- [ ] Docs PR
- [ ] Infra PR

## Issue Link (Optional)

## Quality Bar Checklist ✅

**All applicable items must be checked before merging.**

- [x] **Standards**: I have read `docs/contributors/quality-bar.md` and `docs/contributors/security-guardrails.md`.
- [x] **Metadata**: The `SKILL.md` frontmatter is valid (checked with `npm run validate`).
- [x] **Risk Label**: I have assigned the correct `risk:` tag (`safe`).
- [x] **Triggers**: The "When to use" section is clear and specific.
- [x] **Security**: If this is an _offensive_ skill, I included the "Authorized Use Only" disclaimer.
- [x] **Safety scan**: If this PR adds or modifies `SKILL.md` command guidance, remote/network examples, or token-like strings, I ran `npm run security:docs` (or equivalent hardening check) and addressed any findings.
- [x] **Automated Skill Review**: If this PR changes `SKILL.md`, I checked the `skill-review` GitHub Actions result and addressed any actionable feedback.
- [x] **Manual Logic Review**: If this PR changes `SKILL.md` or risky guidance, I manually reviewed the logic, safety, failure modes, and `risk:` label instead of relying on automated checks alone.
- [x] **Local Test**: I have verified the skill works locally.
- [x] **Repo Checks**: I ran `npm run validate:references` if my change affected docs, workflows, or infrastructure.
- [x] **Source-Only PR**: I did not manually include generated registry artifacts (`CATALOG.md`, `skills_index.json`, `data/*.json`) in this PR.
- [x] **Credits**: I have added the source credit in `README.md` (if applicable).
- [x] **Maintainer Edits**: I enabled **Allow edits from maintainers** on the PR.
