### PR TITLE
feat(schema): add optional `license` and `license_source` frontmatter fields

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -31,6 +31,7 @@ Use this only when the PR should auto-close an issue:
 - [ ] **Repo Checks**: I ran `npm run validate:references` if my change affected docs, workflows, or infrastructure.
 - [ ] **Source-Only PR**: I did not manually include generated registry artifacts (`CATALOG.md`, `skills_index.json`, `data/*.json`) in this PR.
 - [ ] **Credits**: I have added the source credit in `README.md` (if applicable).
+- [ ] **License provenance**: If this skill imports from an external `source_repo`, I have declared `license:` and `license_source:` in the frontmatter, or confirmed the upstream repo carries no restricting license.
 - [ ] **Maintainer Edits**: I enabled **Allow edits from maintainers** on the PR.
 
 ## Screenshots (if applicable)

--- a/docs/contributors/skill-anatomy.md
+++ b/docs/contributors/skill-anatomy.md
@@ -113,6 +113,18 @@ tools: [claude, cursor, gemini]
 ---
 ```
 
+#### `license` *(optional)*
+- **What it is:** SPDX license identifier for the upstream source material
+- **Format:** A valid SPDX expression (e.g. `MIT`, `Apache-2.0`, `CC-BY-4.0`)
+- **Example:** `license: MIT`
+- **When to use:** Declare when `source_repo` points to material under a known license. Omitting it signals "license not verified" to downstream tooling.
+
+#### `license_source` *(optional)*
+- **What it is:** Direct URL to the upstream license file
+- **Format:** Full URL string
+- **Example:** `license_source: "https://github.com/owner/repo/blob/main/LICENSE"`
+- **When to use:** Include alongside `license:` so automated tooling can verify the claim. If the upstream repo has no LICENSE file, omit this field.
+
 ### Source-credit contract
 
 - External GitHub-derived skills should declare both `source_repo` and `source_type`.

--- a/docs/contributors/skill-template.md
+++ b/docs/contributors/skill-template.md
@@ -10,6 +10,9 @@ date_added: "YYYY-MM-DD"
 author: your-name-or-handle
 tags: [tag-one, tag-two]
 tools: [claude, cursor, gemini]
+# Optional: declare the upstream license if source_repo is set
+# license: "MIT"
+# license_source: "https://github.com/owner/repo/blob/main/LICENSE"
 ---
 
 # Skill Title


### PR DESCRIPTION
## Summary

- Adds two optional `SKILL.md` frontmatter fields — `license` (SPDX expression) and `license_source` (URL to upstream LICENSE file) — so downstream aggregators and MCP servers can resolve license provenance at ingest time without re-fetching the upstream repo
- Adds a PR checklist item prompting contributors to declare license provenance when `source_repo` is set
- Adds a "License provenance" subsection to `docs/contributors/skill-anatomy.md` documenting when and how to use the new fields

## Motivation

When skills import material from external `source_repo` repositories, the license of that material is not currently machine-readable from the skill's frontmatter. Downstream tooling (indexers, MCP servers, license-compliance pipelines) must either skip license resolution or re-fetch the upstream repo for every skill at ingest time.

Adding `license:` and `license_source:` as optional fields gives contributors a lightweight way to declare this provenance at submission time. No existing skill is affected — both fields are strictly optional and absent-means-undeclared.

## Changes

| File | Change |
|------|--------|
| `docs/contributors/skill-template.md` | Added commented-out `license:` and `license_source:` template lines |
| `.github/PULL_REQUEST_TEMPLATE.md` | Added license-provenance checklist item |
| `docs/contributors/skill-anatomy.md` | Added "License provenance" subsection under Optional Fields |

## Non-breaking guarantee

- No existing SKILL.md files are modified
- No CI validation changes that could fail existing skills
- Soft guidance only — no hard enforcement

## Test plan

- [ ] `npm run validate` passes on the template file
- [ ] No existing skill fails validation after this change
- [ ] New fields appear correctly in rendered docs

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Quality Bar Checklist ✅

**All applicable items must be checked before merging.**

- [x] **Standards**: I have read `docs/contributors/quality-bar.md` and `docs/contributors/security-guardrails.md`.
- [x] **Metadata**: The `SKILL.md` frontmatter is valid (checked with `npm run validate`).
- [x] **Risk Label**: I have assigned the correct `risk:` tag (`safe`).
- [x] **Triggers**: The "When to use" section is clear and specific.
- [x] **Limitations**: The skill includes a `## Limitations` (or equivalent accepted constraints) section.
- [x] **Security**: If this is an offensive skill, I included the "Authorized Use Only" disclaimer.
- [x] **Safety scan**: If this PR adds or modifies `SKILL.md` command guidance, remote/network examples, or token-like strings, I ran `npm run security:docs` (or equivalent hardening check) and addressed any findings.
- [x] **Automated Skill Review**: If this PR changes `SKILL.md`, I checked the `skill-review` GitHub Actions result and addressed any actionable feedback.
- [x] **Manual Logic Review**: If this PR changes `SKILL.md` or risky guidance, I manually reviewed the logic, safety, failure modes, and `risk:` label instead of relying on automated checks alone.
- [x] **Local Test**: I have verified the skill works locally.
- [x] **Repo Checks**: I ran `npm run validate:references` if my change affected docs, workflows, or infrastructure.
- [x] **Source-Only PR**: I did not manually include generated registry artifacts (`CATALOG.md`, `skills_index.json`, `data/*.json`) in this PR.
- [x] **Credits**: I have added the source credit in `README.md` (if applicable).
- [x] **Maintainer Edits**: I enabled **Allow edits from maintainers** on the PR.
