### PR TITLE
feat(skills): add MiniMax-AI/cli as default skill tap

### DIFF
--- a/skills/mmx-cli/SKILL.md
+++ b/skills/mmx-cli/SKILL.md
@@ -183,3 +183,11 @@ mmx video download --task-id "$TASK" --out robot.mp4
 | 4 | Quota exceeded |
 | 5 | Timeout |
 | 10 | Content filter triggered |
+
+---
+
+## Limitations
+
+- Requires a configured MiniMax account and valid authentication before any API-backed command will work.
+- Media-generation tasks can be async, quota-limited, or region-constrained; agents should handle delayed completion and provider-side failures explicitly.
+- This skill documents CLI usage only and does not replace provider policy review, content-safety checks, or downstream file validation.

--- a/skills/mmx-cli/SKILL.md
+++ b/skills/mmx-cli/SKILL.md
@@ -1,0 +1,185 @@
+---
+name: mmx-cli
+description: "Use mmx to generate text, images, video, speech, and music via the MiniMax AI platform. Use when the user wants to create media content, chat with MiniMax models, perform web search, or manage MiniMax API resources from the terminal."
+risk: safe
+source: "https://github.com/MiniMax-AI/cli"
+date_added: "2026-04-14"
+---
+
+# MiniMax CLI — Agent Skill Guide
+
+Use `mmx` to generate text, images, video, speech, music, and perform web search via the MiniMax AI platform.
+
+## Prerequisites
+
+```bash
+# Install
+npm install -g mmx-cli
+
+# Auth (OAuth persists to ~/.mmx/credentials.json, API key persists to ~/.mmx/config.json)
+mmx auth login --api-key sk-xxxxx
+
+# Verify active auth source
+mmx auth status
+
+# Or pass per-call
+mmx text chat --api-key sk-xxxxx --message "Hello"
+```
+
+Region is auto-detected. Override with `--region global` or `--region cn`.
+
+---
+
+## Agent Flags
+
+Always use these flags in non-interactive (agent/CI) contexts:
+
+| Flag | Purpose |
+|---|---|
+| `--non-interactive` | Fail fast on missing args instead of prompting |
+| `--quiet` | Suppress spinners/progress; stdout is pure data |
+| `--output json` | Machine-readable JSON output |
+| `--async` | Return task ID immediately (video generation) |
+| `--dry-run` | Preview the API request without executing |
+| `--yes` | Skip confirmation prompts |
+
+---
+
+## Commands
+
+### text chat
+
+Chat completion. Default model: `MiniMax-M2.7`.
+
+```bash
+mmx text chat --message <text> [flags]
+```
+
+```bash
+# Single message
+mmx text chat --message "user:What is MiniMax?" --output json --quiet
+
+# Multi-turn with system prompt
+mmx text chat \
+  --system "You are a coding assistant." \
+  --message "user:Write fizzbuzz in Python" \
+  --output json
+
+# From file
+cat conversation.json | mmx text chat --messages-file - --output json
+```
+
+---
+
+### image generate
+
+Generate images. Model: `image-01`.
+
+```bash
+mmx image generate --prompt <text> [flags]
+```
+
+```bash
+mmx image generate --prompt "A cat in a spacesuit" --output json --quiet
+mmx image generate --prompt "Logo" --n 3 --out-dir ./gen/ --quiet
+```
+
+---
+
+### video generate
+
+Generate video. Default model: `MiniMax-Hailuo-2.3`. Async task — polls until completion by default.
+
+```bash
+mmx video generate --prompt <text> [flags]
+```
+
+```bash
+# Non-blocking: get task ID
+mmx video generate --prompt "A robot." --async --quiet
+
+# Blocking: wait and save file
+mmx video generate --prompt "Ocean waves." --download ocean.mp4 --quiet
+```
+
+---
+
+### speech synthesize
+
+Text-to-speech. Default model: `speech-2.8-hd`. Max 10k chars.
+
+```bash
+mmx speech synthesize --text <text> [flags]
+```
+
+```bash
+mmx speech synthesize --text "Hello world" --out hello.mp3 --quiet
+echo "Breaking news." | mmx speech synthesize --text-file - --out news.mp3
+```
+
+---
+
+### music generate
+
+Generate music. Model: `music-2.6-free`.
+
+```bash
+mmx music generate --prompt <text> [--lyrics <text>] [flags]
+```
+
+```bash
+# Instrumental
+mmx music generate --prompt "Cinematic orchestral, building tension" --instrumental --out bgm.mp3 --quiet
+
+# With auto-generated lyrics
+mmx music generate --prompt "Upbeat pop about summer" --lyrics-optimizer --out summer.mp3 --quiet
+```
+
+---
+
+### search query
+
+Web search via MiniMax.
+
+```bash
+mmx search query --q "MiniMax AI" --output json --quiet
+```
+
+---
+
+### vision describe
+
+Image understanding via VLM.
+
+```bash
+mmx vision describe --image photo.jpg --prompt "What breed?" --output json
+```
+
+---
+
+## Piping Patterns
+
+```bash
+# Chain: generate image → describe it
+URL=$(mmx image generate --prompt "A sunset" --quiet)
+mmx vision describe --image "$URL" --quiet
+
+# Async video workflow
+TASK=$(mmx video generate --prompt "A robot" --async --quiet | jq -r '.taskId')
+mmx video task get --task-id "$TASK" --output json
+mmx video download --task-id "$TASK" --out robot.mp4
+```
+
+---
+
+## Exit Codes
+
+| Code | Meaning |
+|---|---|
+| 0 | Success |
+| 1 | General error |
+| 2 | Usage error |
+| 3 | Authentication error |
+| 4 | Quota exceeded |
+| 5 | Timeout |
+| 10 | Content filter triggered |


### PR DESCRIPTION
## Change Classification

- [ ] Skill PR
- [ ] Docs PR
- [ ] Infra PR

## Issue Link (Optional)

Use this only when the PR should auto-close an issue:

`Closes #N` or `Fixes #N`

## Quality Bar Checklist ✅

**All applicable items must be checked before merging.**

- [ ] **Standards**: I have read `docs/contributors/quality-bar.md` and `docs/contributors/security-guardrails.md`.
- [ ] **Metadata**: The `SKILL.md` frontmatter is valid (checked with `npm run validate`).
- [ ] **Risk Label**: I have assigned the correct `risk:` tag (`none`, `safe`, `critical`, `offensive`, or `unknown` for legacy/unclassified content).
- [ ] **Triggers**: The "When to use" section is clear and specific.
- [ ] **Limitations**: The skill includes a `## Limitations` (or equivalent accepted constraints) section.
- [ ] **Security**: If this is an _offensive_ skill, I included the "Authorized Use Only" disclaimer.
- [ ] **Safety scan**: If this PR adds or modifies `SKILL.md` command guidance, remote/network examples, or token-like strings, I ran `npm run security:docs` (or equivalent hardening check) and addressed any findings.
- [ ] **Automated Skill Review**: If this PR changes `SKILL.md`, I checked the `skill-review` GitHub Actions result and addressed any actionable feedback.
- [ ] **Manual Logic Review**: If this PR changes `SKILL.md` or risky guidance, I manually reviewed the logic, safety, failure modes, and `risk:` label instead of relying on automated checks alone.
- [ ] **Local Test**: I have verified the skill works locally.
- [ ] **Repo Checks**: I ran `npm run validate:references` if my change affected docs, workflows, or infrastructure.
- [ ] **Source-Only PR**: I did not manually include generated registry artifacts (`CATALOG.md`, `skills_index.json`, `data/*.json`) in this PR.
- [ ] **Credits**: I have added the source credit in `README.md` (if applicable).
- [ ] **License provenance**: If this skill imports from an external `source_repo`, I have declared `license:` and `license_source:` in the frontmatter, or confirmed the upstream repo carries no restricting license.
- [ ] **Maintainer Edits**: I enabled **Allow edits from maintainers** on the PR.

## Screenshots (if applicable)