### PR TITLE
feat: add not-human-search-mcp and ai-dev-jobs-mcp skills

### DIFF
--- a/skills/ai-dev-jobs-mcp/SKILL.md
+++ b/skills/ai-dev-jobs-mcp/SKILL.md
@@ -1,0 +1,129 @@
+---
+name: ai-dev-jobs-mcp
+description: "Search AI and ML job listings from 289+ companies, get job details, list hiring companies, and view market stats via the AI Dev Jobs MCP server"
+category: mcp
+risk: safe
+source: "https://aidevboard.com"
+source_type: community
+date_added: "2026-04-16"
+author: unitedideas
+tags: [mcp, jobs, ai-jobs, ml-jobs, recruiting, job-search, career]
+tools: [claude, cursor, gemini]
+---
+
+# AI Dev Jobs MCP
+
+## Overview
+
+AI Dev Jobs is a remote MCP server that gives AI agents access to a live index of AI and ML job listings from 289+ companies including OpenAI, Anthropic, Google DeepMind, Meta AI, and more. Agents can search jobs by role, location, or company, retrieve full job details, list all hiring companies, and get aggregate market statistics. It is designed for AI agents that assist with job searching, recruiting, or labor market analysis.
+
+## When to Use This Skill
+
+- Use when helping a user search for AI or ML engineering jobs
+- Use when an agent needs to look up which companies are hiring for specific AI roles
+- Use when building recruiting or talent-matching workflows
+- Use when analyzing the AI job market (open positions, top companies, role distribution)
+
+## MCP Configuration
+
+Add the AI Dev Jobs MCP server to your client configuration. The endpoint uses streamable HTTP and requires no authentication.
+
+### Claude Desktop / Cursor / Windsurf
+
+```json
+{
+  "mcpServers": {
+    "ai-dev-jobs": {
+      "url": "https://aidevboard.com/mcp"
+    }
+  }
+}
+```
+
+No API key or authentication is required.
+
+## Available Tools
+
+### `search_jobs`
+
+Search the job index by keyword, location, company, or work arrangement. Returns matching listings with title, company, location, and salary information.
+
+```
+search_jobs({ query: "machine learning engineer", location: "remote" })
+```
+
+### `get_job`
+
+Retrieve full details for a specific job listing by ID, including description, requirements, salary range, and application link.
+
+```
+get_job({ id: "abc123" })
+```
+
+### `list_companies`
+
+List all companies in the index with their open position counts. Useful for discovering which companies are actively hiring.
+
+```
+list_companies({})
+```
+
+### `get_stats`
+
+Get aggregate statistics about the job market: total listings, top companies by open roles, role distribution, and location breakdown.
+
+```
+get_stats({})
+```
+
+## Examples
+
+### Example 1: Find Remote ML Jobs
+
+```text
+Use @ai-dev-jobs-mcp to find remote machine learning engineer positions.
+```
+
+The agent will call `search_jobs({ query: "machine learning engineer", location: "remote" })` and return matching listings.
+
+### Example 2: Check Which Companies Are Hiring
+
+```text
+Use @ai-dev-jobs-mcp to list all companies currently hiring for AI roles.
+```
+
+The agent will call `list_companies({})` and return companies sorted by number of open positions.
+
+### Example 3: Get Job Market Overview
+
+```text
+Use @ai-dev-jobs-mcp to show current AI job market statistics.
+```
+
+The agent will call `get_stats({})` and return aggregate data on listings, top employers, and role distribution.
+
+### Example 4: Get Full Job Details
+
+```text
+Use @ai-dev-jobs-mcp to get the full details for job ID abc123.
+```
+
+The agent will call `get_job({ id: "abc123" })` and return the complete listing with requirements and application link.
+
+## Best Practices
+
+- Use `search_jobs` with specific keywords for targeted results rather than broad queries
+- Use `list_companies` to discover companies, then `search_jobs` filtered by company name for focused searches
+- Use `get_stats` to provide users with market context before diving into specific listings
+- Combine with resume or cover letter skills to create end-to-end job application workflows
+
+## Limitations
+
+- The index covers AI and ML roles specifically; general software engineering jobs outside the AI space may not be included.
+- Job listings are refreshed regularly but may have a short delay before new postings appear.
+- Salary data is available when companies provide it; not all listings include salary information.
+
+## Related Skills
+
+- `@not-human-search-mcp` - Discover AI-ready tools and APIs via MCP
+- `@mcp-builder` - For building your own MCP servers

--- a/skills/ai-dev-jobs-mcp/SKILL.md
+++ b/skills/ai-dev-jobs-mcp/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: ai-dev-jobs-mcp
-description: "Search AI and ML job listings from 289+ companies, get job details, list hiring companies, and view market stats via the AI Dev Jobs MCP server"
+description: "Search 8,400+ AI and ML jobs across 489 companies, inspect listings and employers, match roles, and view salary and market stats via AI Dev Jobs MCP"
 category: mcp
 risk: safe
 source: "https://aidevboard.com"
@@ -15,7 +15,7 @@ tools: [claude, cursor, gemini]
 
 ## Overview
 
-AI Dev Jobs is a remote MCP server that gives AI agents access to a live index of AI and ML job listings from 289+ companies including OpenAI, Anthropic, Google DeepMind, Meta AI, and more. Agents can search jobs by role, location, or company, retrieve full job details, list all hiring companies, and get aggregate market statistics. It is designed for AI agents that assist with job searching, recruiting, or labor market analysis.
+AI Dev Jobs is a remote MCP server that gives AI agents access to a live index of AI and ML job listings. As of April 17, 2026, the live MCP stats report 8,405 active roles across 489 companies, a $213,500 median salary, and 600 new jobs this week. Agents can search jobs by role, location, or company, retrieve full job details, list hiring companies, match roles to a profile, and get salary or aggregate market statistics. It is designed for AI agents that assist with job searching, recruiting, or labor market analysis.
 
 ## When to Use This Skill
 
@@ -68,12 +68,44 @@ List all companies in the index with their open position counts. Useful for disc
 list_companies({})
 ```
 
+### `get_company`
+
+Retrieve details for a specific company, including available AI roles when exposed by the endpoint.
+
+```
+get_company({ id: "openai" })
+```
+
 ### `get_stats`
 
 Get aggregate statistics about the job market: total listings, top companies by open roles, role distribution, and location breakdown.
 
 ```
 get_stats({})
+```
+
+### `match_jobs`
+
+Match jobs against a candidate profile, skills list, or preferences.
+
+```
+match_jobs({ skills: ["python", "llm", "pytorch"], workplace: "remote" })
+```
+
+### `get_salary_data`
+
+Retrieve salary statistics for roles, tags, levels, or locations when available.
+
+```
+get_salary_data({ tag: "llm", level: "senior" })
+```
+
+### `list_tags`
+
+List indexed tags that can be used to filter searches or salary analysis.
+
+```
+list_tags({})
 ```
 
 ## Examples
@@ -110,11 +142,29 @@ Use @ai-dev-jobs-mcp to get the full details for job ID abc123.
 
 The agent will call `get_job({ id: "abc123" })` and return the complete listing with requirements and application link.
 
+### Example 5: Match Jobs to a Candidate Profile
+
+```text
+Use @ai-dev-jobs-mcp to match remote LLM roles to a senior Python and PyTorch profile.
+```
+
+The agent will call `match_jobs({ skills: ["python", "llm", "pytorch"], workplace: "remote" })` and return suitable listings.
+
+### Example 6: Compare Salary Data
+
+```text
+Use @ai-dev-jobs-mcp to compare senior LLM salary data.
+```
+
+The agent will call `get_salary_data({ tag: "llm", level: "senior" })` and summarize available compensation ranges.
+
 ## Best Practices
 
 - Use `search_jobs` with specific keywords for targeted results rather than broad queries
 - Use `list_companies` to discover companies, then `search_jobs` filtered by company name for focused searches
 - Use `get_stats` to provide users with market context before diving into specific listings
+- Use `match_jobs` when the user gives skills, seniority, location, or work arrangement preferences
+- Use `get_salary_data` only as market context; remind users that listings and compensation change quickly
 - Combine with resume or cover letter skills to create end-to-end job application workflows
 
 ## Limitations
@@ -122,6 +172,7 @@ The agent will call `get_job({ id: "abc123" })` and return the complete listing 
 - The index covers AI and ML roles specifically; general software engineering jobs outside the AI space may not be included.
 - Job listings are refreshed regularly but may have a short delay before new postings appear.
 - Salary data is available when companies provide it; not all listings include salary information.
+- Counts and salary medians are live market data and should be refreshed with `get_stats` before quoting them in user-facing output.
 
 ## Related Skills
 

--- a/skills/not-human-search-mcp/SKILL.md
+++ b/skills/not-human-search-mcp/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: not-human-search-mcp
-description: "Search and score AI-ready websites, verify MCP endpoints, and discover tools and APIs using the Not Human Search MCP server"
+description: "Search AI-ready websites, inspect indexed site details, verify MCP endpoints, and discover tools and APIs using the Not Human Search MCP server"
 category: mcp
 risk: safe
 source: "https://nothumansearch.ai"
@@ -15,7 +15,7 @@ tools: [claude, cursor, gemini]
 
 ## Overview
 
-Not Human Search is a remote MCP server that lets AI agents search a curated index of 1,750+ AI-ready websites, check individual site scores, score any URL for AI-readiness, and verify live MCP endpoints via JSON-RPC probe. It is designed for AI agents that need to discover tools, APIs, and services at runtime without relying on hardcoded lists.
+Not Human Search is a remote MCP server that lets AI agents search a curated index of 1,750+ AI-ready websites, inspect indexed site details, submit new sites for analysis, and verify live MCP endpoints via JSON-RPC probe. It is designed for AI agents that need to discover tools, APIs, and services at runtime without relying on hardcoded lists.
 
 ## When to Use This Skill
 
@@ -44,28 +44,36 @@ No API key or authentication is required.
 
 ## Available Tools
 
-### `search`
+### `search_agents`
 
 Search the index of 1,750+ AI-ready websites by keyword. Returns ranked results with scores, categories, and available endpoints.
 
 ```
-search({ query: "code review tools" })
+search_agents({ query: "code review tools", limit: 10 })
 ```
 
-### `check`
+### `get_site_details`
 
 Check a specific domain's AI-readiness score and available machine-readable endpoints.
 
 ```
-check({ url: "example.com" })
+get_site_details({ domain: "linear.app" })
 ```
 
-### `score`
+### `get_stats`
 
-Score any URL for AI-readiness. Probes for llms.txt, OpenAPI specs, MCP endpoints, robots.txt AI bot rules, and other machine-readable signals.
+Get aggregate index statistics, including total indexed sites, categories, and endpoint coverage.
 
 ```
-score({ url: "https://example.com" })
+get_stats({})
+```
+
+### `submit_site`
+
+Submit a URL for crawling and AI-readiness analysis.
+
+```
+submit_site({ url: "https://example.com" })
 ```
 
 ### `verify_mcp`
@@ -76,6 +84,30 @@ Verify whether a URL is a live MCP endpoint by sending a JSON-RPC probe and chec
 verify_mcp({ url: "https://example.com/mcp" })
 ```
 
+### `list_categories`
+
+List available discovery categories for narrowing searches.
+
+```
+list_categories({})
+```
+
+### `get_top_sites`
+
+Retrieve top-ranked indexed sites.
+
+```
+get_top_sites({ limit: 10 })
+```
+
+### `register_monitor`
+
+Register a domain monitor using a user-provided email address.
+
+```
+register_monitor({ domain: "example.com", email: "user@example.com" })
+```
+
 ## Examples
 
 ### Example 1: Discover Code Review Tools
@@ -84,7 +116,7 @@ verify_mcp({ url: "https://example.com/mcp" })
 Use @not-human-search-mcp to find code review tools that expose MCP or API endpoints.
 ```
 
-The agent will call `search({ query: "code review" })` and return ranked results with scores and endpoint details.
+The agent will call `search_agents({ query: "code review", limit: 10 })` and return ranked results with scores and endpoint details.
 
 ### Example 2: Check if a Site is AI-Ready
 
@@ -92,7 +124,7 @@ The agent will call `search({ query: "code review" })` and return ranked results
 Use @not-human-search-mcp to check the AI-readiness of linear.app.
 ```
 
-The agent will call `check({ url: "linear.app" })` and return the site's score breakdown.
+The agent will call `get_site_details({ domain: "linear.app" })` and return the site's score breakdown.
 
 ### Example 3: Verify an MCP Endpoint
 
@@ -104,8 +136,10 @@ The agent will call `verify_mcp({ url: "https://heliumtrades.com/mcp" })` and co
 
 ## Best Practices
 
-- Use `search` for broad discovery, then `check` or `score` for detailed analysis of specific results
+- Use `search_agents` for broad discovery, then `get_site_details` for detailed analysis of specific indexed results
 - Use `verify_mcp` to confirm an MCP endpoint is live before wiring it into an agent workflow
+- Use `submit_site` when a relevant site is absent from the index and the user wants it analyzed
+- Use `register_monitor` only with an email address the user explicitly provides for monitoring
 - Combine with other MCP skills to build dynamic tool-discovery pipelines
 
 ## Limitations
@@ -113,6 +147,7 @@ The agent will call `verify_mcp({ url: "https://heliumtrades.com/mcp" })` and co
 - The search index covers 1,750+ sites and is updated regularly, but may not include every site on the internet.
 - Scoring reflects machine-readable signals (llms.txt, OpenAPI, MCP, structured data) rather than content quality.
 - `verify_mcp` sends a JSON-RPC probe to the target URL; only use it on URLs you expect to be MCP endpoints.
+- `register_monitor` requires a user-provided email address and consent to receive monitoring notifications.
 
 ## Related Skills
 

--- a/skills/not-human-search-mcp/SKILL.md
+++ b/skills/not-human-search-mcp/SKILL.md
@@ -1,0 +1,120 @@
+---
+name: not-human-search-mcp
+description: "Search and score AI-ready websites, verify MCP endpoints, and discover tools and APIs using the Not Human Search MCP server"
+category: mcp
+risk: safe
+source: "https://nothumansearch.ai"
+source_type: community
+date_added: "2026-04-16"
+author: unitedideas
+tags: [mcp, search, ai-discovery, api-discovery, mcp-verification, agent-tools]
+tools: [claude, cursor, gemini]
+---
+
+# Not Human Search MCP
+
+## Overview
+
+Not Human Search is a remote MCP server that lets AI agents search a curated index of 1,750+ AI-ready websites, check individual site scores, score any URL for AI-readiness, and verify live MCP endpoints via JSON-RPC probe. It is designed for AI agents that need to discover tools, APIs, and services at runtime without relying on hardcoded lists.
+
+## When to Use This Skill
+
+- Use when an AI agent needs to discover tools, APIs, or MCP servers for a specific task
+- Use when you want to check whether a website exposes machine-readable endpoints (llms.txt, OpenAPI, MCP)
+- Use when verifying that an MCP endpoint is actually responding to JSON-RPC
+- Use when building agent workflows that need to find and connect to external services dynamically
+
+## MCP Configuration
+
+Add the Not Human Search MCP server to your client configuration. The endpoint uses streamable HTTP and requires no authentication.
+
+### Claude Desktop / Cursor / Windsurf
+
+```json
+{
+  "mcpServers": {
+    "not-human-search": {
+      "url": "https://nothumansearch.ai/mcp"
+    }
+  }
+}
+```
+
+No API key or authentication is required.
+
+## Available Tools
+
+### `search`
+
+Search the index of 1,750+ AI-ready websites by keyword. Returns ranked results with scores, categories, and available endpoints.
+
+```
+search({ query: "code review tools" })
+```
+
+### `check`
+
+Check a specific domain's AI-readiness score and available machine-readable endpoints.
+
+```
+check({ url: "example.com" })
+```
+
+### `score`
+
+Score any URL for AI-readiness. Probes for llms.txt, OpenAPI specs, MCP endpoints, robots.txt AI bot rules, and other machine-readable signals.
+
+```
+score({ url: "https://example.com" })
+```
+
+### `verify_mcp`
+
+Verify whether a URL is a live MCP endpoint by sending a JSON-RPC probe and checking for a valid response.
+
+```
+verify_mcp({ url: "https://example.com/mcp" })
+```
+
+## Examples
+
+### Example 1: Discover Code Review Tools
+
+```text
+Use @not-human-search-mcp to find code review tools that expose MCP or API endpoints.
+```
+
+The agent will call `search({ query: "code review" })` and return ranked results with scores and endpoint details.
+
+### Example 2: Check if a Site is AI-Ready
+
+```text
+Use @not-human-search-mcp to check the AI-readiness of linear.app.
+```
+
+The agent will call `check({ url: "linear.app" })` and return the site's score breakdown.
+
+### Example 3: Verify an MCP Endpoint
+
+```text
+Use @not-human-search-mcp to verify that https://heliumtrades.com/mcp is a working MCP server.
+```
+
+The agent will call `verify_mcp({ url: "https://heliumtrades.com/mcp" })` and confirm whether it responds to JSON-RPC.
+
+## Best Practices
+
+- Use `search` for broad discovery, then `check` or `score` for detailed analysis of specific results
+- Use `verify_mcp` to confirm an MCP endpoint is live before wiring it into an agent workflow
+- Combine with other MCP skills to build dynamic tool-discovery pipelines
+
+## Limitations
+
+- The search index covers 1,750+ sites and is updated regularly, but may not include every site on the internet.
+- Scoring reflects machine-readable signals (llms.txt, OpenAPI, MCP, structured data) rather than content quality.
+- `verify_mcp` sends a JSON-RPC probe to the target URL; only use it on URLs you expect to be MCP endpoints.
+
+## Related Skills
+
+- `@mcp-builder` - For building your own MCP servers
+- `@ai-dev-jobs-mcp` - Search AI/ML job listings via MCP


### PR DESCRIPTION
# Pull Request Description

Adds two remote MCP server skills for AI agent runtime discovery:

- **not-human-search-mcp** - Search a curated index of 1,750+ AI-ready websites, inspect site details, submit sites for analysis, list categories/top sites, register monitors with user-provided email, and verify live MCP endpoints. Endpoint: `https://nothumansearch.ai/mcp`.
- **ai-dev-jobs-mcp** - Search AI/ML listings, inspect jobs and companies, match jobs to candidate profiles, list tags, view salary data, and get live market stats. As of April 17, 2026, the endpoint reports 8,405 active roles across 489 companies. Endpoint: `https://aidevboard.com/mcp`.

Both servers are free, require no authentication, and use streamable HTTP transport. Maintainer edits aligned the documented tool names with live MCP `tools/list` responses before merge.

## Change Classification

- [x] Skill PR
- [ ] Docs PR
- [ ] Infra PR

## Issue Link (Optional)

N/A

## Quality Bar Checklist ✅

- [x] **Standards**: I have read `docs/contributors/quality-bar.md` and `docs/contributors/security-guardrails.md`.
- [x] **Metadata**: The `SKILL.md` frontmatter is valid (checked with `npm run validate`).
- [x] **Risk Label**: I have assigned the correct `risk:` tag (`none`, `safe`, `critical`, `offensive`, or `unknown` for legacy/unclassified content).
- [x] **Triggers**: The "When to use" section is clear and specific.
- [x] **Limitations**: The skill includes a `## Limitations` (or equivalent accepted constraints) section.
- [x] **Security**: If this is an _offensive_ skill, I included the "Authorized Use Only" disclaimer.
- [x] **Safety scan**: If this PR adds or modifies `SKILL.md` command guidance, remote/network examples, or token-like strings, I ran `npm run security:docs` (or equivalent hardening check) and addressed any findings.
- [x] **Automated Skill Review**: If this PR changes `SKILL.md`, I checked the `skill-review` GitHub Actions result and addressed any actionable feedback.
- [x] **Manual Logic Review**: If this PR changes `SKILL.md` or risky guidance, I manually reviewed the logic, safety, failure modes, and `risk:` label instead of relying on automated checks alone.
- [x] **Local Test**: I have verified the skill works locally.
- [x] **Repo Checks**: I ran `npm run validate:references` if my change affected docs, workflows, or infrastructure.
- [x] **Source-Only PR**: I did not manually include generated registry artifacts (`CATALOG.md`, `skills_index.json`, `data/*.json`) in this PR.
- [x] **Credits**: I have added the source credit in `README.md` (if applicable).
- [x] **License provenance**: If this skill imports from an external `source_repo`, I have declared `license:` and `license_source:` in the frontmatter, or confirmed the upstream repo carries no restricting license.
- [x] **Maintainer Edits**: I enabled **Allow edits from maintainers** on the PR.

## Screenshots (if applicable)

N/A
