### PR TITLE
fix(prompt-engineer): add missing Step 2 to workflow sequence

### DIFF
--- a/plugins/antigravity-awesome-skills/skills/prompt-engineer/SKILL.md
+++ b/plugins/antigravity-awesome-skills/skills/prompt-engineer/SKILL.md
@@ -53,6 +53,34 @@ Invoke this skill when:
 - **Structured tasks:** Mentions steps, phases, deliverables, stakeholders
 
 
+### Step 2: Ask Clarifying Questions (Conditional)
+
+**Objective:** Gather missing information only when it is critical to framework selection or prompt quality.
+
+**Trigger Conditions** — ask only if:
+- Task type is completely ambiguous (cannot determine coding vs. writing vs. analysis)
+- Target audience is unknown and materially affects the output
+- Scope is undefined and choosing wrong scope would invalidate the prompt
+- Requested output format conflicts or is missing and cannot be inferred
+
+**Question Limits:**
+- Maximum 3 questions per invocation
+- Combine related questions into one when possible
+- If enough context exists, skip this step entirely (most cases)
+
+**Example Clarifying Exchange:**
+
+```
+User: "help me with AI"
+
+Step 2 (triggered — task type ambiguous):
+"To craft the best prompt, I need one quick clarification:
+1. What do you want to do with AI — build something, learn about it, or use an AI tool for a task?"
+```
+
+**Critical Rule:** When in doubt, skip clarification and generate the best prompt with available context. Over-asking breaks the "magic mode" experience.
+
+
 ### Step 3: Select Framework(s)
 
 **Objective:** Map task characteristics to optimal prompting framework(s).

--- a/plugins/antigravity-awesome-skills/skills/prompt-engineer/SKILL.md
+++ b/plugins/antigravity-awesome-skills/skills/prompt-engineer/SKILL.md
@@ -53,34 +53,6 @@ Invoke this skill when:
 - **Structured tasks:** Mentions steps, phases, deliverables, stakeholders
 
 
-### Step 2: Ask Clarifying Questions (Conditional)
-
-**Objective:** Gather missing information only when it is critical to framework selection or prompt quality.
-
-**Trigger Conditions** — ask only if:
-- Task type is completely ambiguous (cannot determine coding vs. writing vs. analysis)
-- Target audience is unknown and materially affects the output
-- Scope is undefined and choosing wrong scope would invalidate the prompt
-- Requested output format conflicts or is missing and cannot be inferred
-
-**Question Limits:**
-- Maximum 3 questions per invocation
-- Combine related questions into one when possible
-- If enough context exists, skip this step entirely (most cases)
-
-**Example Clarifying Exchange:**
-
-```
-User: "help me with AI"
-
-Step 2 (triggered — task type ambiguous):
-"To craft the best prompt, I need one quick clarification:
-1. What do you want to do with AI — build something, learn about it, or use an AI tool for a task?"
-```
-
-**Critical Rule:** When in doubt, skip clarification and generate the best prompt with available context. Over-asking breaks the "magic mode" experience.
-
-
 ### Step 3: Select Framework(s)
 
 **Objective:** Map task characteristics to optimal prompting framework(s).

--- a/skills/prompt-engineer/SKILL.md
+++ b/skills/prompt-engineer/SKILL.md
@@ -53,6 +53,34 @@ Invoke this skill when:
 - **Structured tasks:** Mentions steps, phases, deliverables, stakeholders
 
 
+### Step 2: Ask Clarifying Questions (Conditional)
+
+**Objective:** Gather missing information only when it is critical to framework selection or prompt quality.
+
+**Trigger Conditions** — ask only if:
+- Task type is completely ambiguous (cannot determine coding vs. writing vs. analysis)
+- Target audience is unknown and materially affects the output
+- Scope is undefined and choosing wrong scope would invalidate the prompt
+- Requested output format conflicts or is missing and cannot be inferred
+
+**Question Limits:**
+- Maximum 3 questions per invocation
+- Combine related questions into one when possible
+- If enough context exists, skip this step entirely (most cases)
+
+**Example Clarifying Exchange:**
+
+```
+User: "help me with AI"
+
+Step 2 (triggered — task type ambiguous):
+"To craft the best prompt, I need one quick clarification:
+1. What do you want to do with AI — build something, learn about it, or use an AI tool for a task?"
+```
+
+**Critical Rule:** When in doubt, skip clarification and generate the best prompt with available context. Over-asking breaks the "magic mode" experience.
+
+
 ### Step 3: Select Framework(s)
 
 **Objective:** Map task characteristics to optimal prompting framework(s).


### PR DESCRIPTION
> **Automated audit**: This PR was generated by [NLPM](https://github.com/xiaolai/nlpm-for-claude), a natural language programming linter, running via [claude-code-action](https://github.com/anthropics/claude-code-action). Please evaluate the diff on its merits.

## Change Classification

- [ ] Skill PR
- [ ] Docs PR
- [ ] Infra PR

## Issue Link (Optional)

Use this only when the PR should auto-close an issue:

`Closes #N` or `Fixes #N`

## Quality Bar Checklist ✅

**All applicable items must be checked before merging.**

- [ ] **Standards**: I have read `docs/contributors/quality-bar.md` and `docs/contributors/security-guardrails.md`.
- [ ] **Metadata**: The `SKILL.md` frontmatter is valid (checked with `npm run validate`).
- [ ] **Risk Label**: I have assigned the correct `risk:` tag (`none`, `safe`, `critical`, `offensive`, or `unknown` for legacy/unclassified content).
- [ ] **Triggers**: The "When to use" section is clear and specific.
- [ ] **Limitations**: The skill includes a `## Limitations` (or equivalent accepted constraints) section.
- [ ] **Security**: If this is an _offensive_ skill, I included the "Authorized Use Only" disclaimer.
- [ ] **Safety scan**: If this PR adds or modifies `SKILL.md` command guidance, remote/network examples, or token-like strings, I ran `npm run security:docs` (or equivalent hardening check) and addressed any findings.
- [ ] **Automated Skill Review**: If this PR changes `SKILL.md`, I checked the `skill-review` GitHub Actions result and addressed any actionable feedback.
- [ ] **Manual Logic Review**: If this PR changes `SKILL.md` or risky guidance, I manually reviewed the logic, safety, failure modes, and `risk:` label instead of relying on automated checks alone.
- [ ] **Local Test**: I have verified the skill works locally.
- [ ] **Repo Checks**: I ran `npm run validate:references` if my change affected docs, workflows, or infrastructure.
- [ ] **Source-Only PR**: I did not manually include generated registry artifacts (`CATALOG.md`, `skills_index.json`, `data/*.json`) in this PR.
- [ ] **Credits**: I have added the source credit in `README.md` (if applicable).
- [ ] **License provenance**: If this skill imports from an external `source_repo`, I have declared `license:` and `license_source:` in the frontmatter, or confirmed the upstream repo carries no restricting license.
- [ ] **Maintainer Edits**: I enabled **Allow edits from maintainers** on the PR.

## Screenshots (if applicable)