### PR TITLE
fix(installer): flatten accidental nested skills/ install path

### DIFF
--- a/tools/bin/install.js
+++ b/tools/bin/install.js
@@ -315,7 +315,8 @@ function installSkillsIntoTarget(tempDir, target, installEntries) {
       return;
     }
     const src = path.join(repoSkills, name);
-    const dest = path.join(target, name);
+    const destName = name.startsWith("skills/") ? name.slice("skills/".length) : name;
+    const dest = path.join(target, destName);
     copyRecursiveSync(src, dest, repoSkills);
   });
 }


### PR DESCRIPTION
### Motivation
- A skill was indexed with a nested path (`skills/skills/x402-express-wrapper`) which caused the installer to place it under `target/skills/x402-express-wrapper`, making it invisible to loaders that only scan top-level skill directories.
- The change aims to remediate the packaging/install behavior with a minimal installer-side normalization while preserving how the repo is scanned.

### Description
- Normalize install destination names in `tools/bin/install.js` by stripping a leading `skills/` segment from discovered entries when present, e.g. `skills/x402-express-wrapper` -> `x402-express-wrapper` for the install target.
- Keep source lookup unchanged (`src = path.join(repoSkills, name)`), so nested repository layouts continue to be read the same way and only the target path is flattened.
- Preserve other valid nested category installs such as `game-development/2d-games` unchanged.

### Testing
- Ran `node tools/bin/install.js --help` which printed usage successfully. 
- Performed a quick path-mapping sanity check that maps `skills/x402-express-wrapper` => `/tmp/target/x402-express-wrapper`, confirming the normalization logic. 
- Ran the installer-focused test suite with `npm test -- --filter install` where the install tests passed but the overall run reported one unrelated failing baseline test in `test_audit_skills.py` (missing limitations entries under `playwright-skill/node_modules/...`), so the failure is not caused by this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e673b10c248323bfd1b4943a05b361)