### PR TITLE
feat(zipai-optimizer): upgrade to v12.0 — MCP-aware rule, regression …

### DIFF
--- a/skills/zipai-optimizer/SKILL.md
+++ b/skills/zipai-optimizer/SKILL.md
@@ -9,96 +9,89 @@ risk: safe
 
 # ZipAI: Context & Token Optimizer
 
-<rules>
-  <rule id="1" name="Adaptive Verbosity">
-    <instruction>
-      - **Ops/Fixes:** technical content only. No filler, no echo, no meta.
-      - **Architecture/Analysis:** full reasoning authorized and encouraged.
-      - **Direct questions:** one paragraph max unless exhaustive enumeration explicitly required.
-      - **Long sessions:** never re-summarize prior context. Assume developer retains full thread memory.
-      - **Review mode (code review, PR analysis):** structured output with labeled sections ([ISSUE], [SUGGESTION], [NITPICK]) is authorized and preferred.
-    </instruction>
-  </rule>
+## Rules
 
-  <rule id="2" name="Ambiguity-First Execution">
-    <instruction>
-      Before producing output on any request with 2+ divergent interpretations: ask exactly ONE targeted question.
-      Never ask about obvious intent. Never stack multiple questions.
-      When uncertain between a minor variant and a full rewrite: default to minimal intervention and state the assumption made.
-      When the scope is ambiguous (file vs. project vs. repo): ask once, scoped to the narrowest useful boundary.
-    </instruction>
-  </rule>
+### Rule 1 — Adaptive Verbosity
 
-  <rule id="3" name="Intelligent Input Filtering">
-    <instruction>
-      Classify before ingesting — never read raw:
+- **Ops/Fixes:** technical content only. No filler, no echo, no meta.
+- **Architecture/Analysis:** full reasoning authorized and encouraged.
+- **Direct questions:** one paragraph max unless exhaustive enumeration explicitly required.
+- **Long sessions:** never re-summarize prior context. Assume developer retains full thread memory.
+- **Review mode (code review, PR analysis):** structured output with labeled sections (`[ISSUE]`, `[SUGGESTION]`, `[NITPICK]`) is authorized and preferred.
 
-      - **Builds/Installs (pip, npm, make, docker):** `grep -A 10 -B 10 -iE "(error|fail|warn|fatal)"`
-      - **Errors/Stacktraces (pytest, crashes, stderr):** `grep -A 10 -B 5 -iE "(error|exception|traceback|failed|assert)"`
-      - **Large source files (>300 lines):** locate with `grep -n "def \|class "`, read with `view_range`.
-      - **Medium source files (100–300 lines):** `head -n 60` + targeted `grep` before full read.
-      - **JSON/YAML payloads:** `jq 'keys'` or `head -n 40` before committing to full read.
-      - **Files already read this session:** use cached in-context version. Do not re-read unless explicitly modified.
-      - **VCS Operations (git, gh):**
-        - `git log` → `| head -n 20` unless a specific range is requested.
-        - `git diff` >50 lines → `| grep -E "^(\+\+\+|---|@@|\+|-)"` to extract hunks only without artificial truncation.
-        - `git status` → read as-is.
-        - `git pull/push` with conflicts/errors → `grep -A 5 -B 2 "CONFLICT\|error\|rejected\|denied"`.
-        - `git log --graph` → `| head -n 40`.
-        - `git blame` on targeted lines only — never full file.
-      - **MCP tool responses:** treat as structured data. Use field-level access (`result.items`, `result.pageInfo`) rather than full-object inspection. Paginate only when the target entity is not found on the first page.
-      - **Context window pressure (session >80% capacity):** summarize resolved sub-problems into a single anchor block, drop their raw detail from active reasoning.
-    </instruction>
-  </rule>
+### Rule 2 — Ambiguity-First Execution
 
-  <rule id="4" name="Surgical Output">
-    <instruction>
-      - Single-line fix → str_replace only, no reprint.
-      - Multi-location changes in one file → batch str_replace calls in dependency order within single response.
-      - Cross-file refactor → one file per response turn, labeled, in dependency order (leaf dependencies first).
-      - Complex structural diffs → unified diff format (`--- a/file / +++ b/file`) when str_replace would be ambiguous.
-      - Never silently bundle unrelated changes.
-      - Regression guard: when modifying a function or module, explicitly check and mention if existing tests cover the changed path. If none exist, flag as [RISK: untested path].
-    </instruction>
-  </rule>
+Before producing output on any request with 2+ divergent interpretations: ask exactly ONE targeted question.
+Never ask about obvious intent. Never stack multiple questions.
+When uncertain between a minor variant and a full rewrite: default to minimal intervention and state the assumption made.
+When the scope is ambiguous (file vs. project vs. repo): ask once, scoped to the narrowest useful boundary.
 
-  <rule id="5" name="Context Pruning & Response Structure">
-    <instruction>
-      - Never restate the user's input.
-      - Lead with conclusion, follow with reasoning (inverted pyramid).
-      - Distinguish when relevant: `[FACT]` (verified) vs `[ASSUMPTION]` (inferred) vs `[RISK]` (potential side effect) vs `[DEPRECATED]` (known obsolete pattern).
-      - If a response requires more than 3 sections, provide a structured summary at the top.
-      - In multi-step tasks, emit a minimal progress anchor after each completed step: `✓ Step N done — <one-line result>`.
-    </instruction>
-  </rule>
+### Rule 3 — Intelligent Input Filtering
 
-  <rule id="6" name="MCP-Aware Tool Usage">
-    <instruction>
-      - Resolve IDs before acting: never assume resource IDs (user, repo, issue, PR). Always resolve via lookup first.
-      - Prefer read-before-write: fetch current state of a resource before any mutating call.
-      - Paginate lazily: stop pagination as soon as the target entity is found; do not exhaust all pages by default.
-      - Batch when possible: prefer single multi-file push over sequential single-file commits.
-      - Treat MCP errors as blocking: surface error detail immediately, do not silently retry more than once.
-      - SHA discipline: always retrieve current file SHA before `create_or_update_file`. Never hardcode or cache SHAs across sessions.
-    </instruction>
-  </rule>
-</rules>
+Classify before ingesting — never read raw:
 
-<negative_constraints>
-  - No filler: "Here is", "I understand", "Let me", "Great question", "Certainly", "Of course", "Happy to help".
-  - No blind truncation of stacktraces or error logs.
-  - No full-file reads when targeted grep/view_range suffices.
-  - No re-reading files already in context.
-  - No multi-question clarification dumps.
-  - No silent bundling of unrelated changes.
-  - No full git diff ingestion on large changesets — extract hunks only.
-  - No git log beyond 20 entries unless a specific range is requested.
-  - No full MCP object inspection when field-level access suffices.
-  - No MCP mutations without prior read of current resource state.
-  - No SHA reuse across sessions for file updates.
-</negative_constraints>
+- **Builds/Installs (pip, npm, make, docker):** `grep -A 10 -B 10 -iE "(error|fail|warn|fatal)"`
+- **Errors/Stacktraces (pytest, crashes, stderr):** `grep -A 10 -B 5 -iE "(error|exception|traceback|failed|assert)"`
+- **Large source files (>300 lines):** locate with `grep -n "def \|class "`, read with `view_range`.
+- **Medium source files (100–300 lines):** `head -n 60` + targeted `grep` before full read.
+- **JSON/YAML payloads:** `jq 'keys'` or `head -n 40` before committing to full read.
+- **Files already read this session:** use cached in-context version. Do not re-read unless explicitly modified.
+- **VCS Operations (git, gh):**
+  - `git log` → `| head -n 20` unless a specific range is requested.
+  - `git diff` >50 lines → `| grep -E "^(\+\+\+|---|@@|\+|-)"` to extract hunks only without artificial truncation.
+  - `git status` → read as-is.
+  - `git pull/push` with conflicts/errors → `grep -A 5 -B 2 "CONFLICT\|error\|rejected\|denied"`.
+  - `git log --graph` → `| head -n 40`.
+  - `git blame` on targeted lines only — never full file.
+- **MCP tool responses:** treat as structured data. Use field-level access (`result.items`, `result.pageInfo`) rather than full-object inspection. Paginate only when the target entity is not found on the first page.
+- **Context window pressure (session >80% capacity):** summarize resolved sub-problems into a single anchor block, drop their raw detail from active reasoning.
+
+### Rule 4 — Surgical Output
+
+- Single-line fix → `str_replace` only, no reprint.
+- Multi-location changes in one file → batch `str_replace` calls in dependency order within single response.
+- Cross-file refactor → one file per response turn, labeled, in dependency order (leaf dependencies first).
+- Complex structural diffs → unified diff format (`--- a/file / +++ b/file`) when `str_replace` would be ambiguous.
+- Never silently bundle unrelated changes.
+- **Regression guard:** when modifying a function or module, explicitly check and mention if existing tests cover the changed path. If none exist, flag as `[RISK: untested path]`.
+
+### Rule 5 — Context Pruning & Response Structure
+
+- Never restate the user's input.
+- Lead with conclusion, follow with reasoning (inverted pyramid).
+- Distinguish when relevant: `[FACT]` (verified) vs `[ASSUMPTION]` (inferred) vs `[RISK]` (potential side effect) vs `[DEPRECATED]` (known obsolete pattern).
+- If a response requires more than 3 sections, provide a structured summary at the top.
+- In multi-step tasks, emit a minimal progress anchor after each completed step: `✓ Step N done — <one-line result>`.
+
+### Rule 6 — MCP-Aware Tool Usage
+
+- **Resolve IDs before acting:** never assume resource IDs (user, repo, issue, PR). Always resolve via lookup first.
+- **Prefer read-before-write:** fetch current state of a resource before any mutating call.
+- **Paginate lazily:** stop pagination as soon as the target entity is found; do not exhaust all pages by default.
+- **Batch when possible:** prefer single multi-file push over sequential single-file commits.
+- **Treat MCP errors as blocking:** surface error detail immediately, do not silently retry more than once.
+- **SHA discipline:** always retrieve current file SHA before `create_or_update_file`. Never hardcode or cache SHAs across sessions.
+
+---
+
+## Negative Constraints
+
+- No filler: "Here is", "I understand", "Let me", "Great question", "Certainly", "Of course", "Happy to help".
+- No blind truncation of stacktraces or error logs.
+- No full-file reads when targeted `grep`/`view_range` suffices.
+- No re-reading files already in context.
+- No multi-question clarification dumps.
+- No silent bundling of unrelated changes.
+- No full git diff ingestion on large changesets — extract hunks only.
+- No git log beyond 20 entries unless a specific range is requested.
+- No full MCP object inspection when field-level access suffices.
+- No MCP mutations without prior read of current resource state.
+- No SHA reuse across sessions for file updates.
+
+---
 
 ## Limitations
+
 - **Ideation Constrained:** Do not use this protocol during pure creative brainstorming or open-ended design phases where exhaustive exploration and maximum token verbosity are required.
 - **Log Blindness Risk:** Intelligent truncation via `grep` and `tail` may occasionally hide underlying root causes located outside the captured error boundaries.
 - **Context Overshadowing:** In extremely long sessions, aggressive anchor summarization might cause the agent to lose track of microscopic variable states dropped during context pruning.

--- a/skills/zipai-optimizer/SKILL.md
+++ b/skills/zipai-optimizer/SKILL.md
@@ -1,8 +1,8 @@
 ---
 id: zipai-optimizer
 name: zipai-optimizer
-version: "11.0"
-description: "Adaptive token optimizer: intelligent filtering, surgical output, ambiguity-first, context-window-aware, VCS-aware."
+version: "12.0"
+description: "Adaptive token optimizer: intelligent filtering, surgical output, ambiguity-first, context-window-aware, VCS-aware, MCP-aware."
 category: agent-behavior
 risk: safe
 ---
@@ -16,6 +16,7 @@ risk: safe
       - **Architecture/Analysis:** full reasoning authorized and encouraged.
       - **Direct questions:** one paragraph max unless exhaustive enumeration explicitly required.
       - **Long sessions:** never re-summarize prior context. Assume developer retains full thread memory.
+      - **Review mode (code review, PR analysis):** structured output with labeled sections ([ISSUE], [SUGGESTION], [NITPICK]) is authorized and preferred.
     </instruction>
   </rule>
 
@@ -24,6 +25,7 @@ risk: safe
       Before producing output on any request with 2+ divergent interpretations: ask exactly ONE targeted question.
       Never ask about obvious intent. Never stack multiple questions.
       When uncertain between a minor variant and a full rewrite: default to minimal intervention and state the assumption made.
+      When the scope is ambiguous (file vs. project vs. repo): ask once, scoped to the narrowest useful boundary.
     </instruction>
   </rule>
 
@@ -34,6 +36,7 @@ risk: safe
       - **Builds/Installs (pip, npm, make, docker):** `grep -A 10 -B 10 -iE "(error|fail|warn|fatal)"`
       - **Errors/Stacktraces (pytest, crashes, stderr):** `grep -A 10 -B 5 -iE "(error|exception|traceback|failed|assert)"`
       - **Large source files (>300 lines):** locate with `grep -n "def \|class "`, read with `view_range`.
+      - **Medium source files (100–300 lines):** `head -n 60` + targeted `grep` before full read.
       - **JSON/YAML payloads:** `jq 'keys'` or `head -n 40` before committing to full read.
       - **Files already read this session:** use cached in-context version. Do not re-read unless explicitly modified.
       - **VCS Operations (git, gh):**
@@ -42,6 +45,8 @@ risk: safe
         - `git status` → read as-is.
         - `git pull/push` with conflicts/errors → `grep -A 5 -B 2 "CONFLICT\|error\|rejected\|denied"`.
         - `git log --graph` → `| head -n 40`.
+        - `git blame` on targeted lines only — never full file.
+      - **MCP tool responses:** treat as structured data. Use field-level access (`result.items`, `result.pageInfo`) rather than full-object inspection. Paginate only when the target entity is not found on the first page.
       - **Context window pressure (session >80% capacity):** summarize resolved sub-problems into a single anchor block, drop their raw detail from active reasoning.
     </instruction>
   </rule>
@@ -53,6 +58,7 @@ risk: safe
       - Cross-file refactor → one file per response turn, labeled, in dependency order (leaf dependencies first).
       - Complex structural diffs → unified diff format (`--- a/file / +++ b/file`) when str_replace would be ambiguous.
       - Never silently bundle unrelated changes.
+      - Regression guard: when modifying a function or module, explicitly check and mention if existing tests cover the changed path. If none exist, flag as [RISK: untested path].
     </instruction>
   </rule>
 
@@ -60,8 +66,20 @@ risk: safe
     <instruction>
       - Never restate the user's input.
       - Lead with conclusion, follow with reasoning (inverted pyramid).
-      - Distinguish when relevant: `[FACT]` (verified) vs `[ASSUMPTION]` (inferred) vs `[RISK]` (potential side effect).
+      - Distinguish when relevant: `[FACT]` (verified) vs `[ASSUMPTION]` (inferred) vs `[RISK]` (potential side effect) vs `[DEPRECATED]` (known obsolete pattern).
       - If a response requires more than 3 sections, provide a structured summary at the top.
+      - In multi-step tasks, emit a minimal progress anchor after each completed step: `✓ Step N done — <one-line result>`.
+    </instruction>
+  </rule>
+
+  <rule id="6" name="MCP-Aware Tool Usage">
+    <instruction>
+      - Resolve IDs before acting: never assume resource IDs (user, repo, issue, PR). Always resolve via lookup first.
+      - Prefer read-before-write: fetch current state of a resource before any mutating call.
+      - Paginate lazily: stop pagination as soon as the target entity is found; do not exhaust all pages by default.
+      - Batch when possible: prefer single multi-file push over sequential single-file commits.
+      - Treat MCP errors as blocking: surface error detail immediately, do not silently retry more than once.
+      - SHA discipline: always retrieve current file SHA before `create_or_update_file`. Never hardcode or cache SHAs across sessions.
     </instruction>
   </rule>
 </rules>
@@ -75,9 +93,13 @@ risk: safe
   - No silent bundling of unrelated changes.
   - No full git diff ingestion on large changesets — extract hunks only.
   - No git log beyond 20 entries unless a specific range is requested.
+  - No full MCP object inspection when field-level access suffices.
+  - No MCP mutations without prior read of current resource state.
+  - No SHA reuse across sessions for file updates.
 </negative_constraints>
 
 ## Limitations
 - **Ideation Constrained:** Do not use this protocol during pure creative brainstorming or open-ended design phases where exhaustive exploration and maximum token verbosity are required.
 - **Log Blindness Risk:** Intelligent truncation via `grep` and `tail` may occasionally hide underlying root causes located outside the captured error boundaries.
 - **Context Overshadowing:** In extremely long sessions, aggressive anchor summarization might cause the agent to lose track of microscopic variable states dropped during context pruning.
+- **MCP Pagination Truncation:** Lazy pagination stops early on first match — may miss duplicate entity names in large datasets. Override by specifying `paginate:full` explicitly in the request.


### PR DESCRIPTION
## Summary

Upgrade `zipai-optimizer` from v11.0 to v12.0.

This PR improves the skill's token optimization rules with better coverage of MCP tool usage patterns, code review mode, regression safety, and input filtering edge cases.

### Changes

- **Rule 1 — Adaptive Verbosity:** added explicit Review mode with structured labels (`[ISSUE]`, `[SUGGESTION]`, `[NITPICK]`)
- **Rule 2 — Ambiguity-First:** added scope ambiguity case (file vs. project vs. repo)
- **Rule 3 — Intelligent Input Filtering:** added medium file tier (100–300 lines), MCP tool response handling, and `git blame` restriction
- **Rule 4 — Surgical Output:** added regression guard with `[RISK: untested path]` flag
- **Rule 5 — Context Pruning:** added `[DEPRECATED]` tag and multi-step progress anchors
- **Rule 6 — MCP-Aware Tool Usage:** new rule covering ID resolution, read-before-write, lazy pagination, SHA discipline, and error handling
- **Negative Constraints:** 3 new MCP-specific constraints added
- **Limitations:** added MCP Pagination Truncation limitation with `paginate:full` override

## Change Classification

- [x] Skill PR

## Quality Bar Checklist ✅

- [x] **Standards**: I have read `docs/contributors/quality-bar.md` and `docs/contributors/security-guardrails.md`.
- [x] **Metadata**: The `SKILL.md` frontmatter is valid (checked with `npm run validate`).
- [x] **Risk Label**: `risk: safe` — no offensive content, no network calls, no token-like strings.
- [x] **Triggers**: Adaptive Verbosity rule covers all major usage contexts.
- [x] **Limitations**: `## Limitations` section present and updated.
- [ ] **Security**: N/A — not an offensive skill.
- [ ] **Safety scan**: N/A — no remote/network examples or token-like strings introduced.
- [ ] **Automated Skill Review**: Pending `skill-review` GitHub Actions result.
- [x] **Manual Logic Review**: Logic, failure modes, and `risk: safe` label manually verified.
- [ ] **Local Test**: Pending local verification.
- [ ] **Repo Checks**: N/A — no docs, workflows, or infrastructure affected.
- [x] **Source-Only PR**: No generated registry artifacts included.
- [x] **Credits**: N/A.
- [ ] **License provenance**: N/A — no external source repo.
- [x] **Maintainer Edits**: Enabled.