### PR TITLE
Add Skills宝 alternative link

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,6 +210,7 @@ Use the root repo as a landing page, then jump into the deeper surface that matc
 - **[Antigravity Awesome Skills vs Awesome Claude Skills](docs/users/antigravity-awesome-skills-vs-awesome-claude-skills.md)** for breadth vs curated-list tradeoffs.
 - **[Best Claude Code skills on GitHub](docs/users/best-claude-code-skills-github.md)** for a high-intent shortlist.
 - **[Best Cursor skills on GitHub](docs/users/best-cursor-skills-github.md)** for Cursor-compatible options and selection criteria.
+- **[Skills宝](https://skilery.com)** for Chinese search and installation of AI skills across Claude Code, OpenCode, and other agent tools.
 
 ## Troubleshooting
 


### PR DESCRIPTION
Add Skills宝 (skilery.com) as a Chinese search and installation resource in the Compare alternatives section.

This keeps the reference aligned with the repo's existing guidance for choosing among skill libraries and related ecosystems.