### PR TITLE
feat: add unslop skill for CLI-based AI writing pattern removal

### DIFF
--- a/README.md
+++ b/README.md
@@ -286,6 +286,7 @@ This collection would not be possible without the incredible work of the Claude 
 
 ### Community Contributors
 
+- **[MohamedAbdallah-14/unslop](https://github.com/MohamedAbdallah-14/unslop)**: Source for the `unslop` skill - deterministic and LLM-assisted cleanup for AI-generated prose across CLI and agent tool workflows.
 - **[monte-carlo-data/mc-agent-toolkit](https://github.com/monte-carlo-data/mc-agent-toolkit)**: Monte Carlo data observability skills — table health checks, change impact assessment, monitor creation, push ingestion, and SQL validation notebooks for dbt changes.
 - **[openclaw/skills](https://github.com/openclaw/skills)**: Source for the `daily-gift` skill - relationship-aware creative gift generation with editorial judgment, concept selection, and multi-format rendering.
 - **[umutbozdag/agent-skills-manager](https://github.com/umutbozdag/agent-skills-manager)**: Source for the `manage-skills` skill - cross-tool skill discovery, creation, editing, toggling, copying, moving, and deletion workflows across major agent coding tools.

--- a/skills/unslop/SKILL.md
+++ b/skills/unslop/SKILL.md
@@ -34,7 +34,9 @@ The `--deterministic` flag makes output reproducible — same input always produ
 Install once:
 
 ```bash
-npm install -g unslop
+pipx install unslop
+# or
+uv tool install unslop
 ```
 
 Verify:
@@ -126,10 +128,11 @@ done
 - Processes prose only — not code, JSON, or structured data
 - Does not catch factual errors or substantive writing issues
 - Some replacements may not fit every context; review the output before publishing
-- Requires Node.js and npm installed on the machine running the pipeline
+- Requires Python tooling such as `pipx` or `uv` for standalone CLI installation
 
 ## Security & Safety Notes
 
 - unslop reads from stdin and writes to stdout — no file system side effects by default
-- Does not make network requests
-- Safe to run in CI pipelines and commit hooks
+- `--deterministic` mode is local and does not make LLM API calls
+- Default LLM mode may use `ANTHROPIC_API_KEY` or the Claude CLI; use `--deterministic` for sensitive local files and CI gates
+- Safe to run in CI pipelines and commit hooks when pinned to deterministic mode

--- a/skills/unslop/SKILL.md
+++ b/skills/unslop/SKILL.md
@@ -1,0 +1,135 @@
+---
+name: unslop
+description: "Post-process AI-generated text through the unslop CLI to strip AI writing patterns before publishing"
+category: writing
+risk: safe
+source: community
+source_repo: MohamedAbdallah-14/unslop
+source_type: community
+date_added: "2026-04-25"
+author: MohamedAbdallah-14
+tags: [writing, content-quality, ai-writing, text-processing, cli, publishing]
+tools: [claude-code, cursor, gemini-cli, codex-cli, antigravity]
+license: "MIT"
+license_source: "https://github.com/MohamedAbdallah-14/unslop/blob/main/LICENSE"
+---
+
+# unslop — Strip AI Writing Patterns via CLI
+
+## Overview
+
+unslop is a CLI tool that post-processes text to remove AI writing patterns programmatically. Unlike skills that ask the agent to avoid AI-isms, unslop runs as a deterministic pipeline step: pipe text in, get clean text out. Use it as a final pass before committing docs, publishing posts, or sending any AI-generated content to production.
+
+The `--deterministic` flag makes output reproducible — same input always produces same output. The `--stdin` flag reads from stdin, enabling shell pipeline composition.
+
+## When to Use This Skill
+
+- When you have AI-generated text ready to publish and want a final cleanup pass
+- When working in a shell pipeline where text quality needs to be enforced automatically
+- When writing commit hooks or CI steps that validate content before it ships
+- When you need reproducible text normalization across multiple runs
+
+## Setup
+
+Install once:
+
+```bash
+npm install -g unslop
+```
+
+Verify:
+
+```bash
+unslop --version
+```
+
+## How It Works
+
+### Step 1: Pipe Text Through unslop
+
+Standard cleanup (may vary slightly between runs):
+
+```bash
+echo "This leverages cutting-edge AI to deliver robust solutions." | unslop --stdin
+```
+
+Deterministic cleanup (same input → same output every run):
+
+```bash
+echo "This leverages cutting-edge AI to deliver robust solutions." | unslop --stdin --deterministic
+```
+
+### Step 2: Use in Shell Pipelines
+
+Pipe the output of any command through unslop:
+
+```bash
+cat draft.md | unslop --stdin --deterministic > clean.md
+```
+
+Or chain with other tools:
+
+```bash
+cat draft.md | unslop --stdin --deterministic | pbcopy   # macOS: copy clean text to clipboard
+```
+
+### Step 3: Integrate into Commit Hooks or CI
+
+Add to a pre-commit hook or CI step to enforce quality gates on any generated content before it ships:
+
+```bash
+# In .git/hooks/pre-commit or a CI script
+CONTENT=$(cat docs/changelog.md)
+CLEANED=$(echo "$CONTENT" | unslop --stdin --deterministic)
+if [ "$CONTENT" != "$CLEANED" ]; then
+  echo "Changelog contains AI writing patterns. Run: cat docs/changelog.md | unslop --stdin --deterministic > docs/changelog.md"
+  exit 1
+fi
+```
+
+## Examples
+
+### Example 1: Clean a Draft Document
+
+```bash
+cat blog-post-draft.md | unslop --stdin --deterministic > blog-post-final.md
+```
+
+### Example 2: Inline Cleanup During Writing
+
+```bash
+# Write content, pipe through unslop, write result back
+cat README.md | unslop --stdin > README.clean.md && mv README.clean.md README.md
+```
+
+### Example 3: Validate Before Submitting a PR
+
+```bash
+# Check if any generated docs need cleanup
+for f in docs/*.md; do
+  ORIGINAL=$(cat "$f")
+  CLEANED=$(echo "$ORIGINAL" | unslop --stdin --deterministic)
+  [ "$ORIGINAL" != "$CLEANED" ] && echo "Needs cleanup: $f"
+done
+```
+
+## Best Practices
+
+- ✅ Use `--deterministic` in CI and automation to ensure reproducible output
+- ✅ Run on the final draft, not intermediate iterations
+- ✅ Combine with the `avoid-ai-writing` skill for both generation-time guidance and post-processing
+- ❌ Don't run on code files — unslop targets prose, not source code
+- ❌ Don't skip review after unslop: automated cleanup can occasionally change meaning; read the output
+
+## Limitations
+
+- Processes prose only — not code, JSON, or structured data
+- Does not catch factual errors or substantive writing issues
+- Some replacements may not fit every context; review the output before publishing
+- Requires Node.js and npm installed on the machine running the pipeline
+
+## Security & Safety Notes
+
+- unslop reads from stdin and writes to stdout — no file system side effects by default
+- Does not make network requests
+- Safe to run in CI pipelines and commit hooks


### PR DESCRIPTION
Add unslop skill for CLI-based AI writing pattern removal

**What this skill does:**
Teaches agents to post-process AI-generated text through the unslop CLI before publishing. Unlike skills that prompt the agent to avoid AI writing patterns, unslop is a deterministic pipeline step — pipe text in, get clean text out.

**Tool:** unslop
**Source repo:** https://github.com/MohamedAbdallah-14/unslop
**License:** MIT

**How it differs from the existing avoid-ai-writing skill:**
- Avoid-ai-writing guides the agent at generation time (prompting)
- Unslop processes text after generation via a CLI command (post-processing)
- The two complement each other

**Validation:** Ran npm run validate — all skills passed, no new warnings.

**Skill location:** skills/unslop/SKILL.md

## Change Classification

- [ ] Skill PR
- [ ] Docs PR
- [ ] Infra PR

## Issue Link (Optional)

Use this only when the PR should auto-close an issue:

`Closes #N` or `Fixes #N`

## Quality Bar Checklist ✅

**All applicable items must be checked before merging.**

- [ ] **Standards**: I have read `docs/contributors/quality-bar.md` and `docs/contributors/security-guardrails.md`.
- [ ] **Metadata**: The `SKILL.md` frontmatter is valid (checked with `npm run validate`).
- [ ] **Risk Label**: I have assigned the correct `risk:` tag (`none`, `safe`, `critical`, `offensive`, or `unknown` for legacy/unclassified content).
- [ ] **Triggers**: The "When to use" section is clear and specific.
- [ ] **Limitations**: The skill includes a `## Limitations` (or equivalent accepted constraints) section.
- [ ] **Security**: If this is an _offensive_ skill, I included the "Authorized Use Only" disclaimer.
- [ ] **Safety scan**: If this PR adds or modifies `SKILL.md` command guidance, remote/network examples, or token-like strings, I ran `npm run security:docs` (or equivalent hardening check) and addressed any findings.
- [ ] **Automated Skill Review**: If this PR changes `SKILL.md`, I checked the `skill-review` GitHub Actions result and addressed any actionable feedback.
- [ ] **Manual Logic Review**: If this PR changes `SKILL.md` or risky guidance, I manually reviewed the logic, safety, failure modes, and `risk:` label instead of relying on automated checks alone.
- [ ] **Local Test**: I have verified the skill works locally.
- [ ] **Repo Checks**: I ran `npm run validate:references` if my change affected docs, workflows, or infrastructure.
- [ ] **Source-Only PR**: I did not manually include generated registry artifacts (`CATALOG.md`, `skills_index.json`, `data/*.json`) in this PR.
- [ ] **Credits**: I have added the source credit in `README.md` (if applicable).
- [ ] **License provenance**: If this skill imports from an external `source_repo`, I have declared `license:` and `license_source:` in the frontmatter, or confirmed the upstream repo carries no restricting license.
- [ ] **Maintainer Edits**: I enabled **Allow edits from maintainers** on the PR.

## Screenshots (if applicable)