### PR TITLE
fix(installer): flatten accidental nested skills install path

### DIFF
--- a/tools/bin/install.js
+++ b/tools/bin/install.js
@@ -315,7 +315,8 @@ function installSkillsIntoTarget(tempDir, target, installEntries) {
       return;
     }
     const src = path.join(repoSkills, name);
-    const dest = path.join(target, name);
+    const destName = name.startsWith("skills/") ? name.slice("skills/".length) : name;
+    const dest = path.join(target, destName);
     copyRecursiveSync(src, dest, repoSkills);
   });
 }

--- a/tools/scripts/tests/installer_filters.test.js
+++ b/tools/scripts/tests/installer_filters.test.js
@@ -68,10 +68,15 @@ withTempDir((root) => {
     path.join("nested", "metadata-tags"),
     'name: metadata-tags\ncategory: backend\nrisk: none\nmetadata:\n  tags: "api,saas"',
   );
+  writeSkill(
+    repoRoot,
+    path.join("skills", "x402-express-wrapper"),
+    'name: x402-express-wrapper\ncategory: backend\nrisk: unknown\ntags: [payments]',
+  );
 
   assert.deepStrictEqual(
     installer.getInstallEntries(repoRoot, installer.buildInstallSelectors({})),
-    ["nested/metadata-tags", "offensive-tool", "safe-debugger", "docs"],
+    ["nested/metadata-tags", "offensive-tool", "safe-debugger", "skills/x402-express-wrapper", "docs"],
     "full installs should return recursive skill paths plus docs",
   );
 
@@ -95,8 +100,8 @@ withTempDir((root) => {
         tagsArg: "pentest-",
       }),
     ),
-    ["nested/metadata-tags", "safe-debugger", "docs"],
-    "exclude-only tag filters should remove matching skills",
+    ["nested/metadata-tags", "safe-debugger", "skills/x402-express-wrapper", "docs"],
+    "exclude-only tag filters should remove only matching skills",
   );
 
   assert.strictEqual(
@@ -142,5 +147,27 @@ withTempDir((root) => {
     filteredOpenCodeMessages.some((message) => message.includes("Example:")),
     false,
     "OpenCode guidance should skip the example once selectors are already active",
+  );
+
+  const installTarget = path.join(root, "target");
+  installer.installSkillsIntoTarget(repoRoot, installTarget, [
+    "nested/metadata-tags",
+    "skills/x402-express-wrapper",
+  ]);
+
+  assert.strictEqual(
+    fs.existsSync(path.join(installTarget, "nested", "metadata-tags", "SKILL.md")),
+    true,
+    "valid nested skill paths should keep their nested install destination",
+  );
+  assert.strictEqual(
+    fs.existsSync(path.join(installTarget, "x402-express-wrapper", "SKILL.md")),
+    true,
+    "accidental skills/ prefixed entries should install at the target root",
+  );
+  assert.strictEqual(
+    fs.existsSync(path.join(installTarget, "skills", "x402-express-wrapper", "SKILL.md")),
+    false,
+    "accidental skills/ prefixed entries should not create target/skills/*",
   );
 });


### PR DESCRIPTION
### Motivation
- Replaces closed PR #540, which GitHub refuses to reopen because the head branch was deleted/recreated.
- A skill can be discovered with a nested path such as `skills/x402-express-wrapper`, causing the installer to place it under `target/skills/x402-express-wrapper` instead of the loader-visible `target/x402-express-wrapper`.

### Description
- Normalize installer destination names by stripping one accidental leading `skills/` segment from install entries.
- Keep source lookup unchanged, so valid nested entries continue to be read from their repository path.
- Preserve valid nested installs such as `nested/metadata-tags`.
- Add installer test coverage for the flattened destination behavior.

### Testing
- `node tools/scripts/tests/installer_filters.test.js`
- `npm run test`

## Change Classification

- [ ] Skill PR
- [ ] Docs PR
- [x] Infra PR

## Quality Bar Checklist ✅

**All applicable items must be checked before merging.**

- [x] **Standards**: I have read `docs/contributors/quality-bar.md` and `docs/contributors/security-guardrails.md`.
- [x] **Metadata**: N/A, no `SKILL.md` frontmatter changed.
- [x] **Risk Label**: N/A, no skill risk metadata changed.
- [x] **Triggers**: N/A, no skill trigger guidance changed.
- [x] **Limitations**: N/A, no skill limitations changed.
- [x] **Security**: N/A, not an offensive skill.
- [x] **Safety scan**: N/A, no command guidance in `SKILL.md` changed.
- [x] **Automated Skill Review**: N/A, no `SKILL.md` changed.
- [x] **Manual Logic Review**: Installer destination normalization and path handling manually reviewed.
- [x] **Local Test**: Ran installer-specific test and full local test suite.
- [x] **Repo Checks**: Full local test suite passed.
- [x] **Source-Only PR**: No generated registry artifacts included.
- [x] **Credits**: N/A.
- [x] **License provenance**: N/A.
- [x] **Maintainer Edits**: Same-repository maintainer branch.

Refs #540