### PR TITLE
docs: refresh x-twitter-scraper skill

### DIFF
--- a/skills/x-twitter-scraper/SKILL.md
+++ b/skills/x-twitter-scraper/SKILL.md
@@ -1,10 +1,10 @@
 ---
 name: x-twitter-scraper
-description: "X (Twitter) API skill for tweet search, advanced Twitter search, profile tweets, follower export, media download, posting, replies, DMs, webhooks, MCP, official SDKs, and Twitter API alternative workflows."
+description: "X/Twitter automation skill for tweet search, follower export, media download, posting, replies, DMs, webhooks, MCP, SDKs, and the TweetClaw OpenClaw plugin."
 category: data
 risk: safe
 source: community
-tags: "[twitter, x-api, tweet-search, twitter-api, twitter-scraper, follower-export, automation, mcp, sdk, webhooks]"
+tags: "[twitter, x-api, tweet-search, twitter-api, twitter-scraper, follower-export, automation, mcp, sdk, webhooks, openclaw, tweetclaw]"
 date_added: "2026-02-28"
 ---
 
@@ -12,7 +12,7 @@ date_added: "2026-02-28"
 
 ## Overview
 
-Gives AI agents X (Twitter) data and automation workflows through the Xquik platform. Covers tweet search, advanced Twitter search, profile tweets, user lookup, follower export, media download, posting, replies, DMs, giveaway draws, account monitoring, webhooks, 23 bulk extraction tools, MCP, and official SDKs.
+Gives AI agents X (Twitter) data and automation workflows through the Xquik platform. Covers tweet search, advanced Twitter search, profile tweets, user lookup, follower export, media download, posting, replies, DMs, giveaway draws, account monitoring, webhooks, 23 bulk extraction tools, MCP, official SDKs, and the TweetClaw OpenClaw plugin.
 
 ## When to Use This Skill
 
@@ -27,6 +27,7 @@ Gives AI agents X (Twitter) data and automation workflows through the Xquik plat
 - User wants to run a giveaway draw from tweet replies
 - User needs real-time monitoring of an X account (new tweets, follower changes)
 - User wants webhook delivery of monitored events
+- User wants the TweetClaw OpenClaw plugin instead of direct REST or MCP setup
 - User asks about trending topics on X
 
 ## Setup
@@ -46,6 +47,16 @@ git clone https://github.com/Xquik-dev/x-twitter-scraper.git .claude/skills/x-tw
 # Cursor / Codex / Gemini CLI / Copilot
 git clone https://github.com/Xquik-dev/x-twitter-scraper.git .agents/skills/x-twitter-scraper
 ```
+
+### Use the OpenClaw Plugin
+
+For OpenClaw runtime tools, install TweetClaw. It wraps the same Xquik API with `explore` for endpoint discovery and `tweetclaw` for approved calls.
+
+```bash
+openclaw plugins install @xquik/tweetclaw
+```
+
+Use TweetClaw when the agent should search tweets, post tweets, post replies, send DMs, export followers, download media, create monitors, deliver webhooks, or run giveaway draws from OpenClaw.
 
 ### Get an API Key
 
@@ -73,6 +84,7 @@ export XQUIK_API_KEY="xq_YOUR_KEY_HERE"
 | Write Actions | Send tweets, post replies, like, repost, follow, unfollow, and send DMs after explicit approval |
 | SDKs | Official TypeScript, Python, Ruby, Go, Kotlin, Java, PHP, C#, CLI, and Terraform clients |
 | MCP Server | StreamableHTTP endpoint for AI-native integrations |
+| TweetClaw OpenClaw Plugin | Installable `@xquik/tweetclaw` runtime with `explore` and `tweetclaw` tools |
 
 ## Examples
 
@@ -137,6 +149,8 @@ export XQUIK_API_KEY="xq_YOUR_KEY_HERE"
 ## Repository
 
 https://github.com/Xquik-dev/x-twitter-scraper
+
+TweetClaw OpenClaw plugin: https://github.com/Xquik-dev/tweetclaw
 
 **Maintained By:** [Xquik](https://xquik.com)
 

--- a/skills/x-twitter-scraper/SKILL.md
+++ b/skills/x-twitter-scraper/SKILL.md
@@ -1,26 +1,29 @@
 ---
 name: x-twitter-scraper
-description: "X (Twitter) data platform skill — tweet search, user lookup, follower extraction, engagement metrics, giveaway draws, monitoring, webhooks, 19 extraction tools, MCP server."
+description: "X (Twitter) API skill for tweet search, advanced Twitter search, profile tweets, follower export, media download, posting, replies, DMs, webhooks, MCP, official SDKs, and Twitter API alternative workflows."
 category: data
 risk: safe
 source: community
-tags: "[twitter, x-api, scraping, mcp, social-media, data-extraction, giveaway, monitoring, webhooks]"
+tags: "[twitter, x-api, tweet-search, twitter-api, twitter-scraper, follower-export, automation, mcp, sdk, webhooks]"
 date_added: "2026-02-28"
 ---
 
-# X (Twitter) Scraper — Xquik
+# X (Twitter) Scraper - Xquik
 
 ## Overview
 
-Gives your AI agent full access to X (Twitter) data through the Xquik platform. Covers tweet search, user profiles, follower extraction, engagement metrics, giveaway draws, account monitoring, webhooks, and 19 bulk extraction tools — all via REST API or MCP server.
+Gives AI agents X (Twitter) data and automation workflows through the Xquik platform. Covers tweet search, advanced Twitter search, profile tweets, user lookup, follower export, media download, posting, replies, DMs, giveaway draws, account monitoring, webhooks, 23 bulk extraction tools, MCP, and official SDKs.
 
 ## When to Use This Skill
 
 - User needs to search X/Twitter for tweets by keyword, hashtag, or user
+- User asks for advanced Twitter search, profile tweets, or user timeline data
 - User wants to look up a user profile (bio, follower counts, etc.)
 - User needs engagement metrics for a specific tweet (likes, retweets, views)
 - User wants to check if one account follows another
 - User needs to extract followers, replies, retweets, quotes, or community members in bulk
+- User wants to download tweet media, export results, or connect an official SDK
+- User wants to send tweets, post replies, like, repost, follow, unfollow, or send DMs
 - User wants to run a giveaway draw from tweet replies
 - User needs real-time monitoring of an X account (new tweets, follower changes)
 - User wants webhook delivery of monitored events
@@ -58,15 +61,17 @@ export XQUIK_API_KEY="xq_YOUR_KEY_HERE"
 
 | Capability | Description |
 |---|---|
-| Tweet Search | Find tweets by keyword, hashtag, from:user, "exact phrase" |
+| Tweet Search | Find tweets by keyword, hashtag, from:user, "exact phrase", and advanced operators |
 | User Lookup | Profile info, bio, follower/following counts |
-| Tweet Lookup | Full metrics — likes, retweets, replies, quotes, views, bookmarks |
+| Tweet Lookup | Full metrics: likes, retweets, replies, quotes, views, bookmarks |
 | Follow Check | Check if A follows B (both directions) |
 | Trending Topics | Top trends by region (free, no quota) |
 | Account Monitoring | Track new tweets, replies, retweets, quotes, follower changes |
 | Webhooks | HMAC-signed real-time event delivery to your endpoint |
 | Giveaway Draws | Random winner selection from tweet replies with filters |
-| 19 Extraction Tools | Followers, following, verified followers, mentions, posts, replies, reposts, quotes, threads, articles, communities, lists, Spaces, people search |
+| 23 Extraction Tools | Followers, following, verified followers, mentions, posts, replies, reposts, quotes, threads, articles, communities, lists, Spaces, people search, media, likes, and more |
+| Write Actions | Send tweets, post replies, like, repost, follow, unfollow, and send DMs after explicit approval |
+| SDKs | Official TypeScript, Python, Ruby, Go, Kotlin, Java, PHP, C#, CLI, and Terraform clients |
 | MCP Server | StreamableHTTP endpoint for AI-native integrations |
 
 ## Examples
@@ -101,6 +106,11 @@ export XQUIK_API_KEY="xq_YOUR_KEY_HERE"
 "Extract all followers of @anthropic"
 ```
 
+**Post a reply:**
+```
+"Draft and post a reply to this tweet after I approve the final text"
+```
+
 ## API Reference
 
 | Endpoint | Method | Purpose |
@@ -116,6 +126,8 @@ export XQUIK_API_KEY="xq_YOUR_KEY_HERE"
 | `/draws` | POST | Run giveaway draw |
 | `/extractions` | POST | Start bulk extraction |
 | `/extractions/estimate` | POST | Estimate extraction cost |
+| `/drafts` | POST | Create tweet drafts |
+| `/styles` | POST | Analyze or apply tweet style |
 | `/account` | GET | Account & usage info |
 
 **Base URL:** `https://xquik.com/api/v1`


### PR DESCRIPTION
# Pull Request Description

Refreshes the existing `x-twitter-scraper` source skill so the catalog reflects the current Xquik public API surface and gives OpenClaw users the current TweetClaw plugin path.

This source-only change updates stale 19-extraction-tool wording to 23, adds high-intent workflow coverage for advanced Twitter search, profile tweets, follower export, media download, posting, replies, DMs, webhooks, MCP, official SDKs, and TweetClaw, and keeps generated registry artifacts out of the diff per `CONTRIBUTING.md`.

It also documents `openclaw plugins install @xquik/tweetclaw` for users who want an OpenClaw runtime plugin with `explore` endpoint discovery and approved `tweetclaw` calls for tweet search, posting tweets, post replies, DMs, follower export, media workflows, monitors, webhooks, and giveaway draws.

## Change Classification

- [x] Skill PR
- [ ] Docs PR
- [ ] Infra PR

## Issue Link (Optional)

No linked issue.

## Quality Bar Checklist ✅

**All applicable items must be checked before merging.**

- [x] **Standards**: I have read `docs/contributors/quality-bar.md` and `docs/contributors/security-guardrails.md`.
- [x] **Metadata**: The `SKILL.md` frontmatter is valid (checked with `npm run validate`).
- [x] **Risk Label**: I have assigned the correct `risk:` tag (`none`, `safe`, `critical`, `offensive`, or `unknown` for legacy/unclassified content).
- [x] **Triggers**: The "When to use" section is clear and specific.
- [x] **Limitations**: The skill includes a `## Limitations` (or equivalent accepted constraints) section.
- [x] **Security**: This is not an offensive skill.
- [x] **Safety scan**: This PR modifies network/API guidance, so I ran `npm run security:docs` and addressed findings.
- [x] **Automated Skill Review**: The earlier `skill-review` GitHub Actions result completed successfully; this push will rerun it for the amended skill copy.
- [x] **Manual Logic Review**: I manually reviewed the logic, safety, failure modes, and `risk:` label instead of relying on automated checks alone.
- [ ] **Local Test**: Not run. This PR refreshes existing skill documentation only.
- [ ] **Repo Checks**: Not run. This change does not affect docs, workflows, or infrastructure references.
- [x] **Source-Only PR**: I did not manually include generated registry artifacts (`CATALOG.md`, `skills_index.json`, `data/*.json`) in this PR.
- [ ] **Credits**: Not applicable. This updates an existing credited source entry.
- [ ] **License provenance**: Not applicable. This does not import a new external source repo.
- [x] **Maintainer Edits**: I enabled **Allow edits from maintainers** on the PR.

## Screenshots (if applicable)

Not applicable.

## Validation

- `npm run validate`
- `npm run security:docs`
- `git diff --check`
