### PR TITLE
feat: add tokenwise — measurement-driven model router for Claude Code

### DIFF
--- a/README.md
+++ b/README.md
@@ -377,6 +377,7 @@ This collection would not be possible without the incredible work of the Claude 
 - **[voidborne-d/lambda-lang](https://github.com/voidborne-d/lambda-lang)**: Agent-to-agent coordination language with compact atoms for multi-agent messaging, orchestration, and structured coordination logs.
 - **[LambdaTest/agent-skills](https://github.com/LambdaTest/agent-skills)**: Production-grade agent skills for test automation — 46 skills covering E2E, unit, mobile, BDD, visual, and cloud testing across 15+ languages (MIT).
 - **[flyingsquirrel0419/squirrel-skill](https://github.com/flyingsquirrel0419/squirrel-skill)**: Full-cycle software development skill — plans, builds, tests, lints, fixes bugs, and writes production-grade docs. Auto-detects project state and adapts its 8-phase pipeline. Works on 9 AI coding agent platforms (Apache 2.0).
+- **[CodeShuX/tokenwise](https://github.com/CodeShuX/tokenwise)**: Source for the `tokenwise` skill — measurement-driven Haiku/Sonnet/Opus router for Claude Code with per-task NDJSON logging, A/B test mode, and verified $-saved reports (MIT).
 
 ### Inspirations
 

--- a/skills/tokenwise/SKILL.md
+++ b/skills/tokenwise/SKILL.md
@@ -67,7 +67,7 @@ In any Claude Code session:
 
 Then run `/tokenwise:install` and follow the guided prompts.
 
-## Honest limitations
+## Limitations
 
 - Token counts approximate to ±2% vs Anthropic billing
 - A/B test mode costs extra tokens (one task × N tiers) — intentional one-time validation

--- a/skills/tokenwise/SKILL.md
+++ b/skills/tokenwise/SKILL.md
@@ -1,0 +1,81 @@
+---
+name: tokenwise
+description: "Measurement-driven model router for Claude Code. Routes Haiku/Sonnet/Opus per task class, logs every routed task with real $ numbers, and A/B tests cheaper tiers before you trust the savings."
+category: developer-tools
+risk: safe
+source: community
+source_repo: CodeShuX/tokenwise
+source_type: community
+date_added: "2026-05-12"
+author: CodeShuX
+tags: [model-routing, token-optimization, cost-reduction, anthropic, haiku, sonnet, opus, claude-code, ab-testing, measurement]
+tools: [claude]
+license: "MIT"
+license_source: "https://github.com/CodeShuX/tokenwise/blob/main/LICENSE"
+---
+
+# TokenWise — Measurement-Driven Model Router
+
+## Overview
+
+A Claude Code skill that auto-routes subtasks to the cheapest model that can handle them (Haiku for grunt work, Sonnet for scoped reasoning, Opus only for synthesis), then logs every routed task to a local NDJSON with real token + cost numbers. Includes an A/B test subcommand that runs the same task across multiple tiers and scores quality, so the routing decisions are verified against the user's real workload — not estimated.
+
+Anthropic's own bug tracker (Issue #27665) reports 93.8% of Max-subscriber Claude Code tokens flow to Opus. Existing routers (claude-router, wshobson, VoltAgent) either pin models statically or route by vibes-based heuristics with no measurement. TokenWise fills the measurement gap.
+
+## When to use
+
+- Cutting Claude Code token spend without sacrificing output quality
+- Validating whether Haiku/Sonnet is "good enough" for a specific task class before trusting auto-routing
+- Auditing where Opus tokens are actually being burned
+- Logging per-session cost data for finance or chargeback
+
+## Subcommands
+
+- `/tokenwise:install` — guided installer with diff preview, automatic backups, and `--dry-run` mode
+- `/tokenwise:report` — per-session token + cost summary vs all-Opus baseline
+- `/tokenwise:summary [--week|--month|--all]` — historical aggregate with trend
+- `/tokenwise:ab "<task>"` — A/B test the same task at multiple tiers, generates a markdown comparison
+- `/tokenwise:undo` — restore CLAUDE.md / settings.json from backup
+
+## Routing taxonomy
+
+| Tier | Model | Task class |
+|---|---|---|
+| Mechanical | Haiku 4.5 | file reads, grep, format, rename, simple edits, doc lookups |
+| Scoped reasoning | Sonnet 4.6 | single-file refactor, scoped research, test writing |
+| Synthesis | Opus 4.7 | architecture decisions, multi-file refactor, security review |
+
+Safety caps:
+- Haiku never spawns further subagents
+- Max spawn depth = 2
+- Subagents that need a smarter model return to parent — they never escalate on their own
+- Tasks under 100 chars with no file context run inline (subagent overhead > savings)
+- Subagent context >30k tokens bumps a tier
+
+## Privacy
+
+Zero telemetry. All logs in `.tokenwise/log.ndjson` local to the project. Task descriptions truncated to 80 chars and stripped of file contents before logging. No analytics endpoint exists in the source.
+
+## Install
+
+In any Claude Code session:
+
+```
+/plugin marketplace add CodeShuX/tokenwise
+/plugin install tokenwise@tokenwise
+```
+
+Then run `/tokenwise:install` and follow the guided prompts.
+
+## Honest limitations
+
+- Token counts approximate to ±2% vs Anthropic billing
+- A/B test mode costs extra tokens (one task × N tiers) — intentional one-time validation
+- Anthropic-only by design (use LiteLLM or OpenRouter for cross-vendor)
+- Subagent `model:` param has known silent-fail bugs on some Claude Code builds — skill probes for this at install and refuses to configure if routing is broken
+
+## Source
+
+- Repo: https://github.com/CodeShuX/tokenwise
+- License: MIT
+- Author: CodeShuX


### PR DESCRIPTION
# Pull Request Description

Adds [TokenWise](https://github.com/CodeShuX/tokenwise) — a Claude Code skill that auto-routes subtasks to the cheapest model that can handle them (Haiku → Sonnet → Opus), logs every routed task to a local NDJSON with real $ numbers, and includes an A/B test subcommand to verify cheaper tiers before trusting routing.

## Change Classification

- [x] Skill PR
- [ ] Docs PR
- [ ] Infra PR

## Issue Link (Optional)

N/A — new skill submission.

## Quality Bar Checklist ✅

**All applicable items must be checked before merging.**

- [x] **Standards**: I have read `docs/contributors/quality-bar.md` and `docs/contributors/security-guardrails.md`.
- [x] **Metadata**: The `SKILL.md` frontmatter is valid (checked with `npm run validate`).
- [x] **Risk Label**: I have assigned the correct `risk:` tag (`safe` — read-only routing skill that modifies user's CLAUDE.md/settings.json only with explicit per-file confirmation and automatic backups).
- [x] **Triggers**: The "When to use" section is clear and specific.
- [x] **Limitations**: The skill includes a `## Honest limitations` section covering token-count approximation, A/B-test overhead cost, Anthropic-only scope, and known Claude Code routing bugs.
- [ ] **Security**: Not an offensive skill — Authorized Use disclaimer N/A.
- [x] **Safety scan**: No remote/network examples, no token-like strings, no command guidance that hasn't already been reviewed.
- [x] **Automated Skill Review**: Reviewed the `skill-review` Actions result and addressed Codex feedback (added README credit entry for `source_repo`).
- [x] **Manual Logic Review**: Manually reviewed routing logic, safety caps (Haiku never spawns subagents, max depth 2, trivial-task floor), and failure modes (escalation returns to parent, never auto-escalates).
- [x] **Local Test**: Verified the skill works locally — full plugin install path tested (`/plugin marketplace add` → `/plugin install` → `/tokenwise:install --dry-run` invocation in fresh Claude Code session).
- [x] **Repo Checks**: Ran `npm run validate` (passes) and `npm run check:readme-credits` (passes).
- [x] **Source-Only PR**: No generated registry artifacts (`CATALOG.md`, `skills_index.json`, `data/*.json`) included.
- [x] **Credits**: Added `CodeShuX/tokenwise` to `### Community Contributors` in `README.md` (commit a7eab44a — fixes Codex review feedback).
- [x] **License provenance**: Frontmatter declares `license: "MIT"` and `license_source: https://github.com/CodeShuX/tokenwise/blob/main/LICENSE` for the external `source_repo`.
- [x] **Maintainer Edits**: Enabled **Allow edits from maintainers** on the PR.

## Summary

A Claude Code skill that auto-routes subtasks across Haiku, Sonnet, and Opus based on task class:

- **Haiku** — mechanical bulk (file reads, grep, format, rename, simple edits, doc lookups)
- **Sonnet** — scoped reasoning (single-file refactor, test writing, scoped research)
- **Opus** — synthesis only (architecture, multi-file refactor, security review)

Per Anthropic May-2026 pricing, Opus is 5× Haiku for the same token. The skill logs every routed task with verified $ saved vs an all-Opus baseline, and includes `/tokenwise:ab` to compare outputs across tiers before trusting routing decisions.

## Validation

```
$ npm run validate
✨ All skills passed validation!

$ npm run check:readme-credits
[readme-credits] Changed skill files: 1
(exit 0)
```

## Why it's different

- **claude-router / wshobson / VoltAgent** route or pin models but don't measure
- **ccusage / claude-monitor** measure but don't route
- TokenWise closes the loop: route → measure → A/B → adjust

License: MIT (upstream license referenced in frontmatter)