### PR TITLE
docs: add Hermes Tweet plugin path

### DIFF
--- a/skills/x-twitter-scraper/SKILL.md
+++ b/skills/x-twitter-scraper/SKILL.md
@@ -1,10 +1,10 @@
 ---
 name: x-twitter-scraper
-description: "X/Twitter automation skill for tweet search, follower export, media download, posting, replies, DMs, webhooks, MCP, SDKs, and the TweetClaw OpenClaw plugin."
+description: "X/Twitter automation skill for tweet search, follower export, posting, DMs, webhooks, MCP, SDKs, Hermes Tweet, and TweetClaw."
 category: data
 risk: safe
 source: community
-tags: "[twitter, x-api, tweet-search, twitter-api, twitter-scraper, follower-export, automation, mcp, sdk, webhooks, openclaw, tweetclaw]"
+tags: "[twitter, x-api, tweet-search, twitter-api, twitter-scraper, follower-export, automation, mcp, sdk, webhooks, hermes-agent, hermes-tweet, openclaw, tweetclaw]"
 date_added: "2026-02-28"
 ---
 
@@ -12,7 +12,7 @@ date_added: "2026-02-28"
 
 ## Overview
 
-Gives AI agents X (Twitter) data and automation workflows through the Xquik platform. Covers tweet search, advanced Twitter search, profile tweets, user lookup, follower export, media download, posting, replies, DMs, giveaway draws, account monitoring, webhooks, 23 bulk extraction tools, MCP, official SDKs, and the TweetClaw OpenClaw plugin.
+Gives AI agents X (Twitter) data and automation workflows through the Xquik platform. Covers tweet search, advanced Twitter search, profile tweets, user lookup, follower export, media download, posting, replies, DMs, giveaway draws, account monitoring, webhooks, 23 bulk extraction tools, MCP, official SDKs, the Hermes Tweet Hermes Agent plugin, and the TweetClaw OpenClaw plugin.
 
 ## When to Use This Skill
 
@@ -27,6 +27,7 @@ Gives AI agents X (Twitter) data and automation workflows through the Xquik plat
 - User wants to run a giveaway draw from tweet replies
 - User needs real-time monitoring of an X account (new tweets, follower changes)
 - User wants webhook delivery of monitored events
+- User wants the Hermes Tweet Hermes Agent plugin with `tweet_explore`, `tweet_read`, and approval-gated `tweet_action`
 - User wants the TweetClaw OpenClaw plugin instead of direct REST or MCP setup
 - User asks about trending topics on X
 
@@ -47,6 +48,16 @@ git clone https://github.com/Xquik-dev/x-twitter-scraper.git .claude/skills/x-tw
 # Cursor / Codex / Gemini CLI / Copilot
 git clone https://github.com/Xquik-dev/x-twitter-scraper.git .agents/skills/x-twitter-scraper
 ```
+
+### Use the Hermes Agent Plugin
+
+For Hermes Agent runtime tools, install Hermes Tweet. It wraps the same Xquik API with `tweet_explore` for endpoint discovery, `tweet_read` for read-only calls, and approval-gated `tweet_action` for writes and private actions.
+
+```bash
+hermes plugins install Xquik-dev/hermes-tweet --enable
+```
+
+Use Hermes Tweet when a Hermes Agent should search Twitter/X, read tweet replies, look up users, export followers, monitor tweets, post tweets, post replies, send DMs, or automate X actions with explicit approval gates.
 
 ### Use the OpenClaw Plugin
 
@@ -84,6 +95,7 @@ export XQUIK_API_KEY="xq_YOUR_KEY_HERE"
 | Write Actions | Send tweets, post replies, like, repost, follow, unfollow, and send DMs after explicit approval |
 | SDKs | Official TypeScript, Python, Ruby, Go, Kotlin, Java, PHP, C#, CLI, and Terraform clients |
 | MCP Server | StreamableHTTP endpoint for AI-native integrations |
+| Hermes Tweet Hermes Agent Plugin | Installable `hermes-tweet` runtime with `tweet_explore`, `tweet_read`, and approval-gated `tweet_action` tools |
 | TweetClaw OpenClaw Plugin | Installable `@xquik/tweetclaw` runtime with `explore` and `tweetclaw` tools |
 
 ## Examples
@@ -111,6 +123,11 @@ export XQUIK_API_KEY="xq_YOUR_KEY_HERE"
 **Monitor an account:**
 ```
 "Monitor @openai for new tweets and notify me via webhook"
+```
+
+**Use Hermes Agent:**
+```
+"Use Hermes Tweet to search Twitter/X for this launch, read the tweet replies, and prepare a draft reply for approval"
 ```
 
 **Bulk extraction:**
@@ -149,6 +166,8 @@ export XQUIK_API_KEY="xq_YOUR_KEY_HERE"
 ## Repository
 
 https://github.com/Xquik-dev/x-twitter-scraper
+
+Hermes Tweet Hermes Agent plugin: https://github.com/Xquik-dev/hermes-tweet
 
 TweetClaw OpenClaw plugin: https://github.com/Xquik-dev/tweetclaw
 


### PR DESCRIPTION
## Change Classification

- [x] Skill PR
- [ ] Docs PR
- [ ] Infra PR

## Issue Link (Optional)

No issue link. This updates an existing accepted skill path.

## Summary

- Adds Hermes Tweet as the Hermes Agent runtime path inside the existing Xquik x-twitter-scraper skill.
- Documents tweet_explore, tweet_read, and approval-gated tweet_action for search Twitter/X, read tweet replies, look up users, export followers, monitor tweets, post tweets and replies, send DMs, and automate X actions.
- Keeps this source-only by changing only skills/x-twitter-scraper/SKILL.md.

## Validation

- git diff --check
- npm run validate
- npm run security:docs
- ANTIGRAVITY_PYTHON=/tmp/sickn33-antigravity-test-venv/bin/python npm test

Note: npm test skipped network integration tests by default, per the repo test runner.

## Quality Bar Checklist ✅

**All applicable items must be checked before merging.**

- [x] **Standards**: I have read `docs/contributors/quality-bar.md` and `docs/contributors/security-guardrails.md`.
- [x] **Metadata**: The `SKILL.md` frontmatter is valid (checked with `npm run validate`).
- [x] **Risk Label**: I have assigned the correct `risk:` tag (`none`, `safe`, `critical`, `offensive`, or `unknown` for legacy/unclassified content).
- [x] **Triggers**: The "When to use" section is clear and specific.
- [x] **Limitations**: The skill includes a `## Limitations` (or equivalent accepted constraints) section.
- [x] **Security**: This is not an offensive skill.
- [x] **Safety scan**: This PR modifies `SKILL.md` command guidance, remote/network examples, or token-like strings, so I ran `npm run security:docs` and addressed any findings.
- [x] **Automated Skill Review**: If this PR changes `SKILL.md`, I checked the `skill-review` GitHub Actions result and addressed any actionable feedback.
- [x] **Manual Logic Review**: If this PR changes `SKILL.md` or risky guidance, I manually reviewed the logic, safety, failure modes, and `risk:` label instead of relying on automated checks alone.
- [x] **Local Test**: I have verified the skill works locally.
- [x] **Repo Checks**: I ran `npm run validate:references` if my change affected docs, workflows, or infrastructure.
- [x] **Source-Only PR**: I did not manually include generated registry artifacts (`CATALOG.md`, `skills_index.json`, `data/*.json`) in this PR.
- [x] **Credits**: No new source credit is needed because this updates an existing Xquik skill.
- [x] **License provenance**: This update does not import from a new external `source_repo`.
- [x] **Maintainer Edits**: I enabled **Allow edits from maintainers** on the PR.

## Screenshots (if applicable)

Not applicable.
