### PR TITLE
Finish Antigravity skills path docs update

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -214,7 +214,7 @@ More examples...
 
 1. **Copy it to your AI tool's skills directory:**
    ```bash
-   cp -r skills/my-awesome-skill ~/.gemini/antigravity/skills/
+   cp -r skills/my-awesome-skill ~/.agents/skills/
    ```
 
    Or copy it into the specific tool path you are testing against, such as `~/.claude/skills/`, `~/.cursor/skills/`, or a custom workspace path like `.agent/skills/`.

--- a/skills/subagent-orchestrator/README.md
+++ b/skills/subagent-orchestrator/README.md
@@ -26,8 +26,8 @@ node scripts/install.js
 
 **Manual install — copy this folder to:**
 ```
-Windows: %APPDATA%\.gemini\antigravity\skills\subagent-orchestrator\
-Mac/Linux: ~/.gemini/antigravity/skills/subagent-orchestrator/
+Windows: %USERPROFILE%\.agents\skills\subagent-orchestrator\
+Mac/Linux: ~/.agents/skills/subagent-orchestrator/
 ```
 
 Then restart your Antigravity session.

--- a/skills/subagent-orchestrator/scripts/install.js
+++ b/skills/subagent-orchestrator/scripts/install.js
@@ -16,14 +16,14 @@ const SKILL_NAME = 'subagent-orchestrator';
 
 // Antigravity global skills path per OS
 const INSTALL_PATHS = {
-  win32:  path.join(os.homedir(), 'AppData', 'Roaming', '.gemini', 'antigravity', 'skills'),
-  darwin: path.join(os.homedir(), '.gemini', 'antigravity', 'skills'),
-  linux:  path.join(os.homedir(), '.gemini', 'antigravity', 'skills'),
+  win32:  path.join(os.homedir(), '.agents', 'skills'),
+  darwin: path.join(os.homedir(), '.agents', 'skills'),
+  linux:  path.join(os.homedir(), '.agents', 'skills'),
 };
 
 const targetBase = INSTALL_PATHS[process.platform] || INSTALL_PATHS.linux;
 const targetDir  = path.join(targetBase, SKILL_NAME);
-const sourceDir  = path.join(__dirname);
+const sourceDir  = path.join(__dirname, '..');
 
 function copyDir(src, dest) {
   fs.mkdirSync(dest, { recursive: true });


### PR DESCRIPTION
## Summary

- Finishes the Antigravity 2.0 skills-path documentation update by replacing remaining live source references to `~/.gemini/antigravity/skills` with `~/.agents/skills`.
- Updates contributor testing guidance and `subagent-orchestrator` source README/manual-install guidance.
- Aligns the `subagent-orchestrator` helper installer with the new global path and fixes it to copy the skill root instead of only the `scripts/` folder.

## Change Classification

- [x] Skill PR
- [x] Docs PR
- [x] Infra PR

## Issue Link (Optional)

Follow-up to #609. No auto-closing issue link.

## Quality Bar Checklist ✅

**All applicable items must be checked before merging.**

- [x] **Standards**: I have read `docs/contributors/quality-bar.md` and `docs/contributors/security-guardrails.md`.
- [x] **Metadata**: No `SKILL.md` frontmatter changes; `npm run validate` passed.
- [x] **Risk Label**: No skill risk label changes.
- [x] **Triggers**: No skill trigger changes.
- [x] **Limitations**: No skill limitations changes.
- [x] **Security**: N/A; this does not add an offensive skill.
- [x] **Safety scan**: Ran `npm run security:docs`.
- [x] **Automated Skill Review**: No `SKILL.md` content changed.
- [x] **Manual Logic Review**: Reviewed source path guidance and the helper installer behavior.
- [x] **Local Test**: Ran local checks listed below, including installing `subagent-orchestrator` into a temporary HOME.
- [x] **Repo Checks**: Ran `npm run validate:references` and `npm run pr:preflight`.
- [x] **Source-Only PR**: This PR does not manually include generated registry or plugin mirror artifacts.
- [x] **Credits**: N/A; no external skill/source import.
- [x] **License provenance**: N/A; no external skill/source import.
- [x] **Maintainer Edits**: Branch is in the base repository.

## Local Verification

- `node --check skills/subagent-orchestrator/scripts/install.js`
- `HOME=$(mktemp -d) node skills/subagent-orchestrator/scripts/install.js` plus checks for installed `SKILL.md` and `README.md`
- `npm run validate`
- `npm run validate:references`
- `npm run security:docs`
- `npm run pr:preflight`
- `git diff --check origin/main..HEAD`
- `rg -n "gemini\\\\antigravity\\\\skills|gemini/antigravity/skills|\\.gemini/antigravity/skills|%APPDATA%\\\\.gemini\\\\antigravity\\\\skills" --glob '!CHANGELOG.md' --glob '!tools/scripts/sync_recommended_skills.sh' --glob '!apps/web-app/dist/**' --glob '!.release-clone-20260314/**' --glob '!.worktrees/**' || true`

## Screenshots (if applicable)

N/A
