### PR TITLE
feat: add lemmaly suite (lemmaly, mathguard, invariant-guard, complexity-cuts) + credit

### DIFF
--- a/README.md
+++ b/README.md
@@ -328,6 +328,7 @@ This collection would not be possible without the incredible work of the Claude 
 - **[travisvn/awesome-claude-skills](https://github.com/travisvn/awesome-claude-skills)**: Loki Mode and Playwright integration.
 - **[Dimillian/Skills](https://github.com/Dimillian/Skills)**: Curated Codex skills focused on Apple platforms, GitHub workflows, refactoring, and performance (MIT).
 - **[zebbern/claude-code-guide](https://github.com/zebbern/claude-code-guide)**: Comprehensive Security suite & Guide (Source for ~60 new skills).
+- **[morsechimwai/lemmaly](https://github.com/morsechimwai/lemmaly)**: Source for the `lemmaly`, `mathguard`, `invariant-guard`, and `complexity-cuts` skills — algorithm-first discipline layer that forces AI coding agents to state Big-O, name the data structure, prove termination, and pick the right algorithm before writing the loop. Ships a deterministic CI scanner with 59 rules across 11 languages (Apache-2.0).
 - **[alirezarezvani/claude-skills](https://github.com/alirezarezvani/claude-skills)**: Senior Engineering and PM toolkit.
 - **[karanb192/awesome-claude-skills](https://github.com/karanb192/awesome-claude-skills)**: A massive list of verified skills for Claude Code.
 - **[VoltAgent/awesome-agent-skills](https://github.com/VoltAgent/awesome-agent-skills)**: Curated collection of 1000+ official and community agent skills from leading development teams (MIT).

--- a/skills/complexity-cuts/SKILL.md
+++ b/skills/complexity-cuts/SKILL.md
@@ -1,0 +1,254 @@
+---
+name: complexity-cuts
+description: "Lower Big-O on existing code via a one-transformation-at-a-time playbook with verify-revert-stop. For new code use lemmaly; for math-level wins escalate to mathguard."
+risk: safe
+source: community
+source_repo: morsechimwai/lemmaly
+source_type: community
+date_added: "2026-05-26"
+author: morsechimwai
+tags: [algorithms, big-o, refactoring, optimization, performance, n-plus-one]
+tools: [claude-code, antigravity, cursor, gemini-cli, codex-cli]
+license: "Apache-2.0"
+license_source: "https://github.com/morsechimwai/lemmaly/blob/main/LICENSE"
+---
+
+# complexity-cuts — Lower Big-O on Existing Code
+
+`lemmaly` prevents bad complexity before code is written. **complexity-cuts** fixes it after the fact: code already exists, it works, but its time or space complexity is worse than necessary.
+
+**Violating the letter of these rules is violating the spirit of the skill.** Adapting "just a little" is how a faster-but-wrong rewrite ships.
+
+## When to Use This Skill
+
+Use **complexity-cuts** when refactoring existing code that has poor Big-O:
+
+- Nested loops, `O(n²)` or worse scans, repeated work, redundant allocations, blown memory.
+- Stated symptoms: "this is slow on large inputs", "times out", "OOM", "too much memory", "reduce complexity", "optimize this algorithm".
+- N+1 query patterns in ORMs (Prisma, Drizzle, SQLAlchemy, Django, ActiveRecord).
+- `await` inside `for` over independent items causing serial latency.
+
+For *preventing* bad complexity before code is written, use **`lemmaly`**. For math-level optimizations (Bloom, HLL, FFT, JL projection), escalate to **`mathguard`**.
+
+## The Iron Law
+
+```text
+NO TRANSFORMATION WITHOUT EXISTING TESTS GREEN BEFORE AND AFTER
+```
+
+If the code has no tests, you write a characterization test first (golden input → current output). Then transform. Then verify the test still passes. If you skip this, the optimization can silently break callers — and faster-but-wrong is worse than slow-and-right.
+
+## Non-negotiable rules
+
+1. **State current and target Big-O before touching code.** In one line:
+   - Current: `time = O(?)`, `space = O(?)`
+   - Target: `time = O(?)`, `space = O(?)`
+   - Dominant input dimension (n = what, how large in practice)
+
+   If you cannot state current Big-O, you do not yet understand the code. Read more.
+
+2. **Identify the bottleneck, do not guess.** Point to the exact line(s) responsible for the dominant term. Nested loop? Repeated linear scan? Recomputation? Allocation inside a hot loop? The fix lives there, not elsewhere.
+
+3. **One transformation at a time, with a verify-revert-stop loop.** The loop is:
+
+   1. Apply exactly one transformation from the playbook.
+   2. Run the existing test suite (or the characterization test you wrote per the Iron Law).
+   3. If any test breaks: **revert immediately.** Do not patch the test. Do not patch around the failure. Revert.
+   4. Count reverts on this piece of code. If **3 reverts in a row**, STOP optimizing. The bottleneck is wrong, the transformation is wrong, or the code has invariants you have not modeled. Escalate to `invariant-guard` and write the missing contract — do not try a fourth transformation.
+   5. Only after a transformation lands green: pick the next one.
+
+   Stacked changes hide regressions. Patched tests hide regressions louder.
+
+4. **Preserve semantics exactly.** Lower complexity must not change outputs, ordering guarantees, stability, or error behavior. If the optimization requires a semantic change (e.g. unordered output), call it out explicitly and confirm it is acceptable.
+
+5. **No invented numbers.** Never write "10x faster" or "saves 200MB" without measuring. Write `<measured: TBD>` and move on, or actually measure with a representative input.
+
+6. **Always report the measured speedup ratio after a transformation lands.** Once the new code is green, run a representative benchmark (same input, same machine, warm cache) and report `before → after` plus the ratio as `N× faster` (or `N× less memory`). One line, attached to the diff:
+
+   ```text
+   p50:  186 ms → 1.1 ms   (169× faster, n=20,000, 200 samples)
+   ```
+
+   If you cannot measure (e.g. the win is purely asymptotic on inputs you don't have), say so explicitly: `asymptotic only, no measurement — O(n²) → O(n)`. Never silently skip this step.
+
+## The transformation playbook
+
+The vast majority of real-world Big-O wins come from a small set of moves. Try them in this order:
+
+### Time-complexity reductions
+
+| Smell | Fix | Typical win |
+|---|---|---|
+| `for x in A: if x in B` where B is list/array | Convert B to `Set`/`Map` once | O(n·m) → O(n+m) |
+| Nested loop computing pairs/joins | Hash-join on the key; index by lookup field | O(n·m) → O(n+m) |
+| Repeated `.find` / `.indexOf` / `.includes` inside a loop | Precompute index `Map<key, item>` outside loop | O(n^2) → O(n) |
+| Repeated recomputation of same value | Memoize / cache by input key | O(n·f(n)) → O(n + f(n)) |
+| Sort inside a loop | Sort once outside | O(n^2 log n) → O(n log n) |
+| Linear scan for min/max/median repeatedly | Heap / sorted structure | O(n·k) → O(n log k) |
+| Recursive recomputation (naive Fibonacci shape) | Memoize, or convert to iterative DP | exponential → O(n) |
+| String concatenation in a loop (some langs) | Use builder / `join` / `array.push` then join | O(n^2) → O(n) |
+| Repeated regex compile in loop | Compile once outside | constant-factor, large |
+| Counting / grouping via nested loop | Single pass with `Counter` / `Map<k, count>` | O(n^2) → O(n) |
+| Sliding-window written as nested loop | Two-pointer / windowed sum | O(n^2) → O(n) |
+| Repeated prefix sums | Precompute prefix array, O(1) range queries | O(n·q) → O(n+q) |
+| Pairwise distance / containment checks on intervals | Sort + sweep line | O(n^2) → O(n log n) |
+| Top-K via full sort | Heap of size K | O(n log n) → O(n log k) |
+| Repeated set membership in loop body | `Set` once, reuse | O(n·m) → O(n) |
+| `await` inside a `for` over independent items | `Promise.all` / batched concurrency | wall-clock O(n·latency) → O(latency) |
+| ORM query inside a loop (N+1) | `IN (...)` / `select_related` / bulk fetch | O(n) round-trips → O(1) |
+
+### Space-complexity reductions
+
+| Smell | Fix | Typical win |
+|---|---|---|
+| Materializing whole list/array just to iterate | Generator / iterator / stream | O(n) → O(1) |
+| Building intermediate arrays via chained `.map().filter().map()` on huge data | Single-pass loop or lazy pipeline | k·O(n) → O(n) (often O(1) extra) |
+| Caching every intermediate result of a recursion | Rolling window (keep last k states) | O(n) → O(k) |
+| Storing parents/visited for graph traversal when only count needed | Bitset / counter only | O(n) → O(1) |
+| Copying input to mutate | In-place mutation when caller allows | O(n) → O(1) |
+| Reading entire file before processing | Stream line-by-line / chunked | O(file) → O(chunk) |
+| Deep-clone for safety in a loop | Clone once, or use structural sharing / immutables | O(n·m) → O(n+m) |
+| Holding references that prevent GC (closures, listeners, caches) | Bound the cache (LRU), remove listeners, scope closures tightly | unbounded → bounded |
+| Loading full result set from DB | Cursor / pagination / streaming query | O(rows) → O(page) |
+| `JSON.parse(JSON.stringify(x))` for cloning | `structuredClone` or targeted copy | O(n) work and allocation removed |
+
+### When you cannot lower asymptotic Big-O
+
+Sometimes O(n log n) really is the floor. Then move to constant-factor wins:
+
+- Replace pointer-chasing structures with contiguous arrays (cache locality).
+- Hoist invariants out of loops.
+- Avoid allocation in the hot loop (reuse buffers).
+- Prefer typed arrays / native containers over boxed objects for numeric work.
+- Batch syscalls / I/O.
+
+State explicitly: "Asymptotic floor is O(n log n); applying constant-factor optimizations only."
+
+## Required workflow
+
+For each piece of code you optimize:
+
+1. **Measure or estimate current Big-O.** Write it down.
+2. **Identify the bottleneck line(s).** Point at them.
+3. **Pick one transformation from the playbook.** Name it.
+4. **Apply it.** One change.
+5. **Verify behavior.** Tests pass, or outputs match on a representative input.
+6. **State new Big-O.** Time and space.
+7. **Repeat if more wins exist and are worth the complexity cost.**
+
+## Canonical example — workflow vs no-workflow
+
+The same optimization with and without the verify-revert-stop loop.
+
+**Bottleneck.** `getOrdersWithUsers()` runs 10s on 10k orders. Cause: `users.find(u => u.id === o.userId)` inside the map → O(n·m).
+
+### Without the workflow — changes semantics AND patches the test
+
+```ts
+// No workflow: change semantics + the optimization in one go
+export function getOrdersWithUsers(orders, users) {
+  const userById = Object.fromEntries(users.map(u => [u.id, u]));
+  return orders
+    .map(o => ({ ...o, user: userById[o.userId] }))
+    .filter(o => o.user); // silently drops orders whose user was deleted
+}
+```
+
+Faster, *and* changes the result set. Existing tests catch it — but the diff also "fixes" a flaky test by removing the assertion that checked the old behavior. Ships green. Breaks the billing report two weeks later.
+
+### With the workflow — one transformation, semantics preserved
+
+```ts
+// Workflow applied:
+//   Bottleneck: orders.map → users.find  (line 14)
+//   Current: time = O(n·m), space = O(1)
+//   Target:  time = O(n+m), space = O(m)
+//   Transformation: precompute index Map<userId, User> outside the loop
+//   Semantic risk: None — orders with missing users still emit `user: undefined` exactly as before
+//   Reverts so far: 0
+
+export function getOrdersWithUsers(orders, users) {
+  const userById = new Map(users.map(u => [u.id, u]));
+  return orders.map(o => ({ ...o, user: userById.get(o.userId) }));
+}
+```
+
+One transformation. Existing tests stay untouched. Run them. If green, ship. If red, revert (don't patch). After 3 reverts, stop and load `invariant-guard` — the bottleneck is wrong, or the function has a contract no one wrote down.
+
+## Output discipline
+
+When proposing or applying an optimization, your message must contain — in this order:
+
+1. **Bottleneck** — file:line and one-sentence reason.
+2. **Current complexity** — `time = O(?)`, `space = O(?)`.
+3. **Transformation** — name from the playbook (or describe it if novel).
+4. **New complexity** — `time = O(?)`, `space = O(?)`.
+5. **Semantic risk** — anything callers might notice (ordering, stability, error timing). "None" is a valid answer if true.
+6. **Measured speedup** — `before → after` with the ratio as `N× faster` (or `asymptotic only` if not measured). One line, honest numbers.
+7. **The diff.**
+
+If any of 1–6 is missing, the optimization is not ready to apply.
+
+## Stop conditions — do not optimize further when
+
+- Asymptotic Big-O already matches a known lower bound for the problem.
+- The input is provably small and bounded (n < ~100 and not on a hot path).
+- The optimization would obscure correctness or harm readability without a measured win.
+- The bottleneck is I/O or external service latency, not CPU/memory — go fix that instead.
+
+Premature optimization past these points adds risk without payoff.
+
+## Rationalizations to watch for
+
+| Excuse | Reality |
+| --- | --- |
+| "I already solved this in my head — just paste the diff and add labels after." | Retrofitted labels lie about the reasoning order. Write bottleneck → complexity → transformation → diff in that order, or you are writing fiction. |
+| "Stating the current Big-O is busywork — everyone can see the nested loop." | If everyone can see it, writing one line costs nothing. If only you can see it, you just saved the reviewer's time. |
+| "Semantic risk is None, skip that step." | "None" is a valid answer — but write it. The next reader does not know which guarantees you considered. |
+| "I'll do all three transformations in one diff." | Stacked transformations hide regressions. One transformation, verify, repeat. |
+| "It's just a small refactor, the workflow is overkill." | Then it takes 30 seconds. The cases where you skip the workflow are the ones where you miss the optimization next to the obvious one. |
+| "I'll measure later." | Later is `<measured: TBD>` forever. Either measure now or accept the asymptotic argument as the only claim. |
+
+## Red flags — STOP
+
+- Optimizing without stating current Big-O.
+- "This should be faster" without identifying a specific bottleneck line.
+- Stacking multiple transformations before verifying any one of them.
+- Claiming a speedup without measuring or without an asymptotic argument.
+- Lowering complexity by silently changing output semantics.
+- Rewriting code that runs once at startup with n = 12.
+
+## Verification checklist
+
+Before claiming an optimization is complete:
+
+- [ ] Existing tests (or a written characterization test) were green BEFORE the transformation.
+- [ ] Exactly one transformation was applied.
+- [ ] Tests are green AFTER the transformation.
+- [ ] No test was modified, weakened, or skipped to make it pass.
+- [ ] Current Big-O and target Big-O are stated in the diff or PR description.
+- [ ] Semantic risk is written down ("None" is valid if true).
+- [ ] Measured speedup ratio is reported as `before → after · N× faster` (or explicitly marked `asymptotic only` if no measurement was possible).
+- [ ] If a measured claim was made (e.g. "3x faster"), the measurement command is included.
+- [ ] Revert count on this code is < 3.
+
+Cannot check every box? The optimization is not done. Either revert or finish the gap — do not ship a half-verified speedup.
+
+## Limitations
+
+- **Requires existing tests or a written characterization test.** Without one, you cannot detect silent semantic regressions; the Iron Law refuses to skip this.
+- **Asymptotic wins only; constant-factor work is a separate mode** (clearly labeled). The playbook will not improve cache locality or SIMD utilization on its own.
+- **Single-process scope.** Distributed-system bottlenecks (consensus latency, replication lag, queue backpressure) are out of scope.
+- **3-revert rule is firm.** If three transformations failed, the skill explicitly forces escalation to `invariant-guard`; it does not let you try a fourth.
+- **Measurement is on the author.** complexity-cuts requires the ratio to be reported but does not run the benchmark for you — you must produce a representative input.
+- **Won't help I/O-bound code.** If the dominant term is network latency or disk, the playbook will not move the needle — fix the I/O pattern instead.
+
+## The thesis, in one line
+
+> **Existing code earned its slowness one shortcut at a time. complexity-cuts removes them one transformation at a time — and refuses to ship the optimization without a green test.**
+
+## Related Skills
+
+- `lemmaly` — prevention gateway; use when writing new code instead of refactoring existing.
+- `invariant-guard` — escalation target when 3+ transformations have failed tests — the missing piece is a contract, not an optimization.
+- `mathguard` — escalation when the classical floor is reached and an approximate or math-heavy structure could win.

--- a/skills/invariant-guard/SKILL.md
+++ b/skills/invariant-guard/SKILL.md
@@ -1,0 +1,307 @@
+---
+name: invariant-guard
+description: "Correctness-first: forces writing the function contract, loop invariant, termination argument, and edge cases BEFORE code. Catches Boyer-Moore, leftmost binary search, QuickSelect traps."
+risk: safe
+source: community
+source_repo: morsechimwai/lemmaly
+source_type: community
+date_added: "2026-05-26"
+author: morsechimwai
+tags: [algorithms, correctness, loop-invariants, contracts, edge-cases, verification]
+tools: [claude-code, antigravity, cursor, gemini-cli, codex-cli]
+license: "Apache-2.0"
+license_source: "https://github.com/morsechimwai/lemmaly/blob/main/LICENSE"
+---
+
+# invariant-guard — Correctness-First Coding
+
+The model knows what a loop invariant is. It knows recursion needs a base case. It knows about empty lists, integer overflow, and the difference between `<` and `≤`. It just does not write these down before producing code, so it ships subtle correctness bugs that tests do not catch.
+
+invariant-guard fixes the behavior. State the invariants. State the base case. State the termination argument. State the edge cases. Then write the code — and verify that the code maintains what you stated.
+
+**Violating the letter of these rules is violating the spirit of the skill.** "I know this algorithm" is the exact rationalization that ships off-by-one and missing-postcondition bugs.
+
+## When to Use This Skill
+
+Use **invariant-guard** when writing or reviewing algorithms where the obvious implementation is subtly wrong:
+
+- Postcondition stronger than the loop's natural invariant: Boyer–Moore majority, Floyd's cycle detection, leftmost vs any binary search, QuickSelect partition.
+- In-place mutation with read+write pointers: dedup-in-place, partition, rotate.
+- Recursion with multiple parameters or accumulator state.
+- Off-by-one suspects with duplicates, empty inputs, boundary values.
+- Iterative refinements that must terminate: fixed-point, Newton, EM.
+- Any function where you catch yourself thinking "I know this algorithm" — the trap is usually in the contract, not the loop body.
+
+Pairs with `lemmaly` (picks the algorithm) and `mathguard` (picks the math). Load `invariant-guard` *after* the algorithm has been chosen and *before* the loop body is written.
+
+## The Iron Law
+
+```text
+NO LOOP OR RECURSION WITHOUT A WRITTEN INVARIANT AND TERMINATION ARGUMENT
+```
+
+If you cannot write the invariant in one sentence, you have not designed the loop. Write code anyway and you are coding by guess — and the bug will be in the case you did not enumerate.
+
+## Non-negotiable rules
+
+1. **Every loop gets a one-line invariant.** Before writing any loop, state in one sentence what is true at the top of every iteration. Examples:
+   - "At loop top: `result` contains the sum of `a[0..i)`."
+   - "At loop top: `lo ≤ target_position ≤ hi`."
+   - "At loop top: `seen` contains every element processed so far; `dups` contains every element that appeared at least twice."
+
+   If you cannot write the invariant in one sentence, you have not designed the loop yet.
+
+2. **Every loop gets a one-line termination argument.** Name the quantity that strictly decreases (or strictly increases toward a bound) on every iteration. Examples:
+   - "`hi − lo` strictly decreases each iteration."
+   - "`i` increases by 1 and is bounded above by `n`."
+   - "`stack.length` strictly decreases each pop; nothing pushes inside this branch."
+
+   No termination argument, no loop.
+
+3. **Every recursion gets an explicit base case and a measure.** Before writing a recursive function, state:
+   - The base case(s) — the smallest inputs that return without recursing.
+   - The measure — a non-negative integer that strictly decreases on every recursive call (e.g. `len(xs)`, `hi − lo`, `depth`, `n`).
+   - The combination — how the recursive results combine into the answer.
+
+   No base case + measure, no recursion. (Mutual recursion: state the measure across the cycle.)
+
+4. **List edge cases before writing, not after.** For every function operating on a collection or number, list which of these apply and how they behave:
+   - Empty input (`[]`, `""`, `null`, `undefined`, `None`).
+   - Singleton (`[x]`).
+   - All-equal elements.
+   - Already-sorted / reverse-sorted input.
+   - Duplicates (when uniqueness is assumed).
+   - Negative numbers, zero, exactly the boundary value.
+   - Integer overflow / underflow at the type max/min.
+   - NaN, ±Infinity, `-0`, denormals (for floats).
+   - Off-by-one boundaries: index 0, index n−1, index n, length 0, length 1.
+   - Concurrent modification while iterating.
+
+   The cases that apply must each have a one-phrase expected behavior written down.
+
+5. **Make illegal states unreachable, not just unhandled.** Prefer encoding constraints in types and structure so the wrong state cannot be constructed:
+   - Sum type over boolean flag soup (`Loading | Loaded(data) | Error(msg)` not `{loading, data, error}`).
+   - Newtype for IDs that must not be swapped (`UserId` vs `OrderId`).
+   - Non-empty list type when the function requires at least one element.
+   - Parsed value at the boundary, not validated repeatedly downstream (parse-don't-validate).
+
+   If the language cannot encode it, write the invariant as a comment and assert it at the boundary.
+
+## The pre-write protocol
+
+Before producing non-trivial code that has loops, recursion, or non-trivial state, your message must contain — in this order:
+
+1. **Function contract** — preconditions, postconditions, and what the function returns. One line each.
+2. **Loop invariants** — one per loop. (Rule 1.)
+3. **Termination arguments** — one per loop or recursion. (Rules 2, 3.)
+4. **Base cases and measure** — for recursion. (Rule 3.)
+5. **Edge case table** — bullets, one per applicable case, with expected behavior. (Rule 4.)
+6. **Illegal states made unrepresentable** — name the types or asserts that enforce invariants. (Rule 5.)
+7. **The code.**
+8. **Self-check** — one line per loop confirming the invariant holds at top, body preserves it, and exit implies postcondition.
+
+If any of 1–6 is missing, do not emit code.
+
+## Worked trap — Boyer–Moore majority vote
+
+This is the canonical "the trap is in the contract, not the loop body" case.
+
+**Naive baseline (what gets shipped without the skill):**
+
+```typescript
+function findMajority(arr: number[]): number | null {
+  if (arr.length === 0) return null;
+  let candidate = arr[0], count = 0;
+  for (const x of arr) {
+    if (count === 0) candidate = x;
+    if (x === candidate) count++; else count--;
+  }
+  return candidate;   // BUG: returns the candidate even when no majority exists
+}
+```
+
+This implementation fails on `[1,2,3]` (returns `3`, expected `null`) and `[2,2,1,1]` (returns `1`, expected `null`). The voting loop is correct; the postcondition is wrong.
+
+**Why the protocol catches it.** Writing **step 1 (function contract)** forces the postcondition in plain language:
+
+> Returns `x` iff `count(x, arr) > arr.length / 2`; else `null`.
+
+Then writing **step 2 (loop invariant)** forces the invariant of the voting pass:
+
+> If a strict majority element exists in `arr`, it equals `candidate` when the loop exits.
+
+These two statements are not equivalent. The loop invariant guarantees "if a majority exists, it is the candidate" — not "the candidate is a majority." Once you write both down, the gap is visible: you need a second pass to verify, or the postcondition is unmet.
+
+**Correct implementation that survives the protocol:**
+
+```typescript
+function findMajority(arr: number[]): number | null {
+  if (arr.length === 0) return null;
+  // Pass 1: vote.
+  let candidate = arr[0], count = 0;
+  // inv: if a strict majority exists in arr, it equals candidate at every count===0 reset.
+  for (const x of arr) {
+    if (count === 0) candidate = x;
+    if (x === candidate) count++; else count--;
+  }
+  // Pass 2: verify — the voting invariant is strictly weaker than the postcondition.
+  let tally = 0;
+  // inv: tally = count of candidate in arr[0..i).
+  for (const x of arr) if (x === candidate) tally++;
+  return tally * 2 > arr.length ? candidate : null;
+}
+```
+
+**Pattern to generalize.** The same trap appears in:
+
+- **Floyd's cycle detection** — finding the meeting point tells you a cycle exists, *not* where it starts. You need a second walk.
+- **Two-pointer "find any"** vs **"find leftmost"** — the loop invariant for one does not satisfy the postcondition of the other.
+- **QuickSelect partition** — the loop returns a position; the postcondition is that the element at that position is the k-th smallest. Off by one in the partition invariant silently breaks it.
+- **DP with reconstruction** — the table tells you the optimum value; reconstructing the optimum path needs separate invariants on the choice array.
+
+In every case: **write the postcondition first; write the loop invariant second; check that the second implies the first. If not, you are missing a pass, a check, or an auxiliary state.**
+
+## Canonical example — binary search for the leftmost match
+
+Most "I know binary search" implementations are written for "find any match." The trap is the postcondition.
+
+**Problem.** Given a sorted array with duplicates, return the index of the **leftmost** occurrence of `target`, or `-1`.
+
+### Without the protocol — returns any match
+
+```ts
+function leftmost(a: number[], target: number): number {
+  let lo = 0, hi = a.length - 1;
+  while (lo <= hi) {
+    const mid = (lo + hi) >> 1;
+    if (a[mid] === target) return mid;       // returns ANY occurrence
+    if (a[mid] < target) lo = mid + 1; else hi = mid - 1;
+  }
+  return -1;
+}
+// leftmost([1,2,2,2,3], 2) → may return 2, not 1
+```
+
+The loop invariant ("target lies in `a[lo..hi]` if anywhere") is satisfied. But the postcondition ("returned index is the *smallest* `i` with `a[i] === target`") is strictly stronger. The loop body's early return abandons the search before reaching the leftmost.
+
+### With the protocol — contract-driven leftmost
+
+```ts
+function leftmost(a: number[], target: number): number {
+  // contract:
+  //   pre:  a is sorted ascending
+  //   post: returns smallest i with a[i] === target, or -1 if absent
+  let lo = 0, hi = a.length;                 // half-open [lo, hi)
+  // inv: every index < lo has a[i] < target; every index ≥ hi has a[i] > target OR is past leftmost match
+  // term: hi - lo strictly halves each iteration
+  while (lo < hi) {
+    const mid = (lo + hi) >> 1;
+    if (a[mid] < target) lo = mid + 1; else hi = mid;
+  }
+  // exit: lo === hi, and by invariant lo is the leftmost index where a[lo] >= target
+  return lo < a.length && a[lo] === target ? lo : -1;
+}
+```
+
+Same loop shape. The difference is the contract was written first — and the loop body was chosen to maintain an invariant that *implies* the postcondition.
+
+## Common invariant patterns to reach for
+
+| Loop / algorithm shape | Canonical invariant | Termination |
+|---|---|---|
+| Linear scan accumulating | `acc = f(a[0..i))` at top | `i` increases by 1, bounded by `n` |
+| Two-pointer (sorted) | `target (if any) lies in a[lo..hi]` | `hi − lo` strictly decreases |
+| Binary search | `target (if present) ∈ a[lo..hi]` and `a[lo..hi]` non-empty | `hi − lo` strictly halves |
+| Sliding window | window `[l..r)` satisfies the constraint; answer ≥ best so far | `r` advances at least once per outer iter |
+| BFS | every node at distance < d has been popped; queue contains some at distance d | strict node count decrease per pop |
+| DFS / recursion on tree | result for subtree rooted at v = combine(children results) | depth (or remaining nodes) strictly decreases |
+| Divide and conquer | result on `a[lo..hi]` = combine(results on the two halves) | `hi − lo` strictly halves |
+| Greedy with priority queue | extracted item is globally optimal for the remaining problem | heap size strictly decreases per extract |
+| Union-Find op | `find(x)` always returns the canonical root of x's component | tree height bounded by O(log n) (with rank) |
+| In-place partition | `a[0..i)` < pivot; `a[i..j)` ≥ pivot; `a[j..n)` unseen | `n − j` strictly decreases |
+
+## Edge case table — defaults to consider
+
+| Input shape | Cases to check |
+|---|---|
+| Array / list | empty, singleton, all-equal, sorted, reversed, with duplicates |
+| String | empty, single char, all whitespace, unicode (surrogates, combining), bytes vs code points |
+| Integer | 0, 1, −1, MIN, MAX, MAX − 1, near overflow in arithmetic, division by 0 |
+| Float | 0.0, −0.0, NaN, ±Inf, denormal, exact comparison should be ε-based |
+| Map / dict | empty, missing key (default vs error), key collision semantics |
+| Tree / graph | empty, single node, cycle (if undirected), self-loop, multigraph, disconnected |
+| Stream / iterator | empty, infinite, single yield, exception mid-iteration |
+| Time / date | DST transition, leap second/day, timezone offset, epoch boundary |
+| Concurrent | empty contention, single thread, max contention, cancellation mid-op |
+
+## Output discipline
+
+Code you emit must:
+
+- Have one comment per loop stating the invariant (use `// inv:` or `# inv:`).
+- Have one comment per recursion stating the base case and measure.
+- Handle every edge case you listed in step 5, or explicitly delegate ("throws on empty — caller responsibility").
+- Assert preconditions at function entry when the language supports it cheaply.
+- Use types (sum types, newtypes, non-empty, non-null) over runtime checks where the language allows.
+
+## When to escalate or redirect
+
+- The function is performance-critical and you have not picked the algorithm — go back to **`lemmaly`** first; pick the algorithm, then state its invariants here.
+- The technique is mathematical (probabilistic, FFT, geometry) — load **`mathguard`**; invariants for approximate algorithms include ε-bounds, not equality.
+- The code is concurrent — invariants must account for interleaving; explicitly state "single-threaded only" if that is the assumption.
+
+## Rationalizations to watch for
+
+| Excuse | Reality |
+| --- | --- |
+| "I know this algorithm — single pass, done." | Knowing the loop ≠ knowing the contract. The trap usually lives in the postcondition the loop does not enforce. |
+| "I traced it in my head, it works." | Mental tracing skips edge cases. Write the invariant; check it implies the postcondition. |
+| "Edge cases are obvious." | Then write them down in 30 seconds. If they are obvious, the table is cheap. If they are not, the table just saved you. |
+| "Tests will catch it." | Tests catch the examples you thought of. The trap is the example you did not. Postconditions catch all examples. |
+| "The postcondition is implied." | If it were, the natural loop invariant would equal it. When they differ (Boyer–Moore, leftmost search, QuickSelect), you need a second pass, an extra check, or auxiliary state. |
+| "Adding a verification pass feels redundant." | Boyer–Moore voting + verification is still O(n). "Feels redundant" is the rationalization that ships the bug. |
+
+## Red flags — STOP and write the invariant first
+
+- About to write `while (...)` without having stated what is true on entry.
+- About to write `if (i === n − 1)` or `if (i === n)` — boundary suspicious, restate the invariant.
+- About to recurse without naming the base case in this message.
+- About to write `// TODO: handle empty` — handle it now or change the type so empty is impossible.
+- About to use `==` on floats.
+- About to compare across signed/unsigned or across types where overflow rolls.
+- About to silently swallow an error in the middle of a loop ("just continue").
+- Tests pass but you did not actually state what the function guarantees.
+- "It works on the examples I tried."
+
+## Verification checklist
+
+Before claiming the function is correct:
+
+- [ ] Every loop has a one-line `// inv:` comment in code.
+- [ ] Every loop has a termination argument written down (in comment or PR description).
+- [ ] Every recursion names its base case and measure in code.
+- [ ] The function's postcondition is written and is implied by the exit state of the last loop.
+- [ ] Every applicable edge case from the table has a test or an explicit "delegated to caller" note.
+- [ ] At least one test exercises each non-trivial boundary (empty, singleton, max, off-by-one).
+- [ ] Illegal states the function rejects are either unrepresentable in the type, or asserted at entry.
+- [ ] For approximate/randomized algorithms (escalated to mathguard): ε-bounds are part of the postcondition, not equality.
+
+Cannot check every box? The code is example-correct, not behavior-correct. Either fill the gap or downgrade the function's claimed contract.
+
+## Limitations
+
+- **Not an automated prover.** invariant-guard requires the author to *write* invariants; it does not mechanically check them. Pair with property-based tests for stronger evidence.
+- **Concurrency is out of scope by default.** Stated invariants assume single-threaded execution unless explicitly extended; multi-threaded reasoning needs additional happens-before / linearizability arguments.
+- **Float and overflow edge cases are language-specific.** The edge-case table is a checklist, not a substitute for understanding your language's numeric semantics.
+- **Will slow down trivial code.** For one-liners that obviously cannot fail, the protocol is overhead; reserve it for non-trivial loops, recursion, and in-place mutation.
+- **Documentation is the only enforcement.** If the author skips writing the invariants, this skill cannot detect that — pair with code review or a PR template that asks for the contract.
+
+## The thesis, in one line
+
+> **Tests verify examples. Invariants verify behavior. AI assistants ship example-correct, behavior-wrong code by default. invariant-guard makes them reason about behavior first.**
+
+## Related Skills
+
+- `lemmaly` — algorithm choice must be settled before invariants; load lemmaly first if the algorithm family is unclear.
+- `mathguard` — ε-bounded postconditions for approximate / randomized algorithms.
+- `complexity-cuts` — if 3+ optimization transformations have failed tests, the bug is a missing contract, not a missing optimization — escalate here.

--- a/skills/lemmaly/SKILL.md
+++ b/skills/lemmaly/SKILL.md
@@ -1,0 +1,236 @@
+---
+name: lemmaly
+description: "Algorithm-first discipline: state Big-O, data structure, and algorithm family BEFORE writing loops, queries, or recursion. Catches O(n^2), N+1, and brute-force defaults."
+risk: safe
+source: community
+source_repo: morsechimwai/lemmaly
+source_type: community
+date_added: "2026-05-26"
+author: morsechimwai
+tags: [algorithms, big-o, performance, code-review, complexity, gateway]
+tools: [claude-code, antigravity, cursor, gemini-cli, codex-cli]
+license: "Apache-2.0"
+license_source: "https://github.com/morsechimwai/lemmaly/blob/main/LICENSE"
+---
+
+# lemmaly — Algorithm-First Proof
+
+The model already knows Big-O, hash tables, divide-and-conquer, dynamic programming, sorting, graph algorithms, and amortized analysis. It just does not apply them spontaneously. lemmaly fixes the behavior, not the knowledge.
+
+This skill is the gateway for an algorithm-discipline suite of four skills (`lemmaly`, `mathguard`, `invariant-guard`, `complexity-cuts`). It enforces the hard rules that every other guard in the suite assumes.
+
+**Violating the letter of these rules is violating the spirit of the skill.** "Just this once" is how O(n²) ships to production.
+
+## When to Use This Skill
+
+Use **lemmaly** when:
+
+- Writing, editing, or reviewing code that involves loops, collections, lookups, searches, joins, recursion, graphs, queries, or any computation over more than a handful of items.
+- About to write a `for` inside a `for`, `.find` / `.includes` / `.indexOf` inside a loop, `await` inside `for` / `map` / `forEach` over independent items, or one query per item in a collection.
+- Auditing a codebase / PR for known anti-patterns (await-in-loop, `.includes` inside `.filter`, string-concat in loop, `SELECT *`, N+1, etc.).
+- Reviewing AI-generated code that "looks idiomatic" but might hide O(n²) or N+1.
+
+When in doubt, **start at lemmaly** — it is the gateway and will tell you when to escalate to its three sibling skills.
+
+| If you are about to… | Use | Why |
+| --- | --- | --- |
+| Write *new* code that loops, queries, joins, recurses, or processes a collection | **lemmaly** | Forces complexity + data structure + algorithm family **before** code is written. |
+| Refactor *existing* code that is already slow, OOMs, times out, or has nested loops / N+1 / repeated work | **complexity-cuts** | Corrective playbook for code that already shipped with bad Big-O. |
+| Implement an algorithm where the obvious version is subtly wrong (binary search variants, in-place dedup, Boyer–Moore, QuickSelect partition, recursion with accumulators, fixed-point / termination concerns) | **invariant-guard** | Forces writing the function contract + loop invariant before code. The trap is in the contract, not the loop body. |
+| Work with n ≥ 10⁶, similarity search, dedup at scale, top-K, streaming analytics, cardinality estimation, embeddings, FFT/NTT, dimensionality reduction, computational geometry, randomized algorithms | **mathguard** | Classical algorithms have hit their lower bound; an approximate or math-heavy technique (Bloom, HLL, Count-Min, MinHash/LSH, FFT, JL projection, sweep line, kd-tree) gives the asymptotic win. |
+
+### Routing flow
+
+```text
+Are you writing new code?
+├── yes → lemmaly (state complexity, structure, family BEFORE coding)
+│         ├── classical algorithm at its lower bound AND n is large? → mathguard
+│         └── subtle correctness trap (invariant, base case, off-by-one)? → invariant-guard
+└── no, refactoring existing slow / OOM / timed-out code → complexity-cuts
+          └── still slow after classical fixes? → mathguard
+```
+
+### One-line mental model
+
+- **lemmaly** = think first (prevention).
+- **complexity-cuts** = clean up bad Big-O (correction).
+- **invariant-guard** = prove it's correct (verification).
+- **mathguard** = beat the classical floor (acceleration).
+
+## The Iron Law
+
+```text
+NO NON-TRIVIAL CODE WITHOUT STATED COMPLEXITY, DATA STRUCTURE, AND ALGORITHM FAMILY
+```
+
+Before you write a loop, a recursion, a query, or any computation over more than a handful of items, three things must appear in your message — in this order:
+
+1. `time = O(?)`, `space = O(?)`, with the dominant input dimension named.
+2. The data structure you will use, with a one-phrase reason.
+3. The algorithm family (one of: linear scan, two-pointer, sliding window, binary search, sort+sweep, hash join, BFS/DFS, topo sort, Dijkstra/A*, union-find, DP, greedy, recursion+memo, prefix sum, segment tree, monoid reduction).
+
+If you cannot state all three, you do not understand the problem yet. Ask, or read more code. Do not write code.
+
+## Non-negotiable rules
+
+1. **State complexity before writing any non-trivial code.** In one line:
+   - `time = O(?)`, `space = O(?)`
+   - Dominant input dimension: `n = what`, with realistic magnitude (e.g. `n ~ 10^6 rows`)
+   - If you cannot state these, you do not yet understand the problem. Ask, or read more code.
+
+2. **Name the data structure with a one-phrase reason.** Every collection-shaped value gets a deliberate choice from `Array / List / Set / HashMap / TreeMap / Heap / Deque / Trie / Graph / BitSet / Counter / LinkedList` — with the reason: "Set for O(1) membership inside the loop", "Heap for top-K in O(n log k)", "Counter to fold the nested loop into a single pass". Default to hashed structures (`Set`, `Map`) for lookup inside loops. Default to streaming/iterator over materialized list when n is large.
+
+3. **Identify the algorithm family before writing.** Name one of: `linear scan`, `divide and conquer`, `two-pointer`, `sliding window`, `binary search`, `sort + sweep`, `hash join`, `BFS/DFS`, `topological sort`, `Dijkstra/A*`, `union-find`, `dynamic programming`, `greedy`, `recursion + memoization`, `prefix sum`, `segment tree`, `monoid reduction`. If you cannot name a family, you are about to write brute force. Stop and reconsider.
+
+4. **Repeated work in loops is algorithmic waste.** All of these are presumed wrong until justified:
+   - I/O inside a loop (database queries, HTTP calls, file reads) — batch with `IN (...)`, `Promise.all`, bulk endpoints, streaming
+   - Recomputing the same value in a loop — hoist or memoize
+   - Re-sorting / re-grouping inside a loop — sort once outside
+   - Linear scan (`.find`, `.indexOf`, `.includes`, `in list`) inside a loop — precompute an index `Map`
+   - Allocating fresh structures per iteration when one can be reused — hoist allocation
+   - Materializing intermediate collections only to iterate again — fuse into one pass
+
+   If you must do any of these inside a loop, write one comment line explaining why.
+
+5. **No invented complexity or numbers.** Never write "O(log n) on average" without an argument. Never write "10x faster" or "~3ms" without measuring. If you cannot derive the complexity, write `<complexity: TBD>`. If you have not measured, write `<measured: TBD>`. Move on.
+
+## The pre-write protocol
+
+Before producing non-trivial code, your message must contain — in this order:
+
+1. **Problem shape** — one sentence. ("Given n events with a timestamp, find the longest contiguous window where total weight ≤ K.")
+2. **Input dimensions** — `n = ?`, realistic magnitude, whether hot path.
+3. **Target complexity** — `time = O(?)`, `space = O(?)`.
+4. **Data structures** — name them with a phrase each.
+5. **Algorithm family** — one phrase.
+6. **Edge cases you will handle** — empty, singleton, all-equal, n=1, n=max, overflow, duplicates. List the ones that apply.
+7. **The code.**
+
+If any of 1–6 is missing, do not emit code yet.
+
+## Canonical example — protocol vs no-protocol
+
+The same problem with and without the seven-step protocol.
+
+**Problem.** Given `users: User[]` and `bannedIds: string[]`, return users whose `id` is not banned. Realistic n: 50k users, 5k banned.
+
+### Without the protocol — ships O(n·m)
+
+```ts
+// Looks idiomatic, ships O(n·m)
+const active = users.filter((u) => !bannedIds.includes(u.id));
+```
+
+`bannedIds.includes` is O(m) per call. The filter runs it n times → 50k × 5k = 250M comparisons.
+
+### With the protocol — O(n + m)
+
+```ts
+// Protocol applied:
+//   time = O(n + m), space = O(m), n = 50k users, m = 5k banned
+//   structure: Set<string> for O(1) membership inside the loop
+//   family: linear scan with hashed lookup
+//   edge cases: empty users → [], empty bannedIds → users, duplicates in bannedIds → fine (Set dedupes)
+const banned = new Set(bannedIds);
+const active = users.filter((u) => !banned.has(u.id));
+```
+
+The first version is the default an AI ships when asked "filter the active users." The second is what the protocol forces — without changing how the code reads.
+
+## Rule catalog (the lemmaly scanner)
+
+The upstream repo ships a deterministic CLI scanner with the same anti-patterns this skill enforces (**59 rules across 11 languages**: JavaScript/TypeScript, Python, SQL, Java, C#, C++, Go, Rust, PHP, Ruby, Shell/Bash). Each rule has a documented why, an incorrect example, a correct example, and the sibling skill to escalate to.
+
+To run the scanner locally:
+
+```bash
+# Clone the upstream repo for the CLI tool
+git clone https://github.com/morsechimwai/lemmaly.git
+cd lemmaly
+node cli/lemmaly.js scan <path>          # flag instances of anti-patterns
+node cli/lemmaly.js rules                # list all 59 rules
+```
+
+**CRITICAL severity (error in CI):**
+
+- `js-await-in-for-loop` — N+1 over network
+- `js-async-in-foreach` — dropped promises
+- `py-mutable-default-arg` — shared default state
+- `sql-update-no-where` — touches every row
+- `java-arraylist-remove-in-for-i` — index shifts; ConcurrentModification
+- `cs-async-void` — exceptions unobserved; crashes the process
+- `go-loop-var-capture` — pre-1.22 race on the last value
+- `php-query-in-loop` — N+1 against the database
+
+**HIGH severity (warning in CI):** `js-deep-clone-via-json`, `js-useeffect-missing-deps`, `js-inline-object-jsx-prop`, `js-anonymous-handler-jsx`, `js-spread-in-reduce`, `js-unique-via-indexof`, `js-helper-call-in-iterator`, `py-string-concat-in-loop`, `py-django-loop-without-eager`, `py-bare-except`, `sql-select-star`, `sql-leading-wildcard-like`, `sql-not-in-subquery`, `java-string-concat-in-loop`, `java-list-contains-in-loop`, `java-bare-catch-exception`, `cs-string-concat-in-loop`, `cs-list-contains-in-loop`, `cs-disposable-no-using`, `go-string-concat-in-loop`, `go-defer-in-loop`, `go-err-not-checked`, `rs-unwrap-in-prod`, `cpp-string-concat-in-loop`, `cpp-raw-new`, `php-count-in-for-condition`, `php-in-array-in-loop`, `rb-include-in-iterator`, `rb-n-plus-one-activerecord`, `rb-bare-rescue`, `sh-set-e-no-pipefail`, `sh-unquoted-var`, `sh-for-ls`.
+
+**MEDIUM severity (info in CI):** `js-nested-for-loops`, `js-includes-in-iterator`, `js-array-key-index`, `py-range-len`, `py-in-list-literal`, `py-open-without-with`, `sql-select-no-limit`, `sql-or-in-where`, `go-slice-append-no-cap`, `rs-clone-in-loop`, `rs-vec-push-no-capacity`, `rs-string-push-no-capacity`, `cpp-vector-push-no-reserve`, `cpp-range-loop-copy`, `cpp-map-double-lookup`, `php-loose-equality`, `rb-string-concat-in-loop`, `sh-useless-cat-pipe`.
+
+## When to escalate to sibling skills
+
+lemmaly handles classical, day-to-day algorithmic discipline. Escalate when:
+
+- **Math-level optimization** (probabilistic data structures, FFT, dimensionality reduction, approximation algorithms, computational geometry) — load **mathguard**.
+- **Algorithm correctness** (loop invariants, termination, recursion base cases, edge cases that tests miss) — load **invariant-guard**.
+- **Existing code with bad complexity that already shipped** — load **complexity-cuts** for the corrective transformation playbook.
+
+## Rationalizations to watch for
+
+These are real verbatim thoughts captured from controlled tests where the model shipped O(n·m) code that the seven-step protocol would have prevented:
+
+| Excuse | Reality |
+| --- | --- |
+| "`.filter` then `.reduce` is the idiomatic way, ship it." | Idiomatic ≠ correct asymptotic. Idiom-driven coding is how O(n²) ships. |
+| "It's fine for now, we can optimize later." | Later is a different engineer with no context. State the complexity now. |
+| "I'll just use `Array.find` here, it's just one lookup." | One lookup inside a loop over `n` items is `O(n)` lookups. Make the `Map` outside. |
+| "The data is small in dev — I'll worry about scale when we ship." | Production data is never the size of dev data. The seven-step protocol takes 30 seconds. |
+| "I already understand the problem, the protocol is overhead." | The cases the protocol "wastes time on" are the cases that break in prod. |
+
+If any of these sound familiar mid-thought: stop, write the seven steps.
+
+## Red flags — STOP and restart the protocol
+
+- About to write a `for` inside a `for` without first stating it is the intended O(n·m).
+- About to call `.find` / `.includes` / `.indexOf` inside a loop body.
+- About to `await` inside `for` / `map` / `forEach` over independent items.
+- About to issue one query per item in a collection.
+- About to recurse without stating the base case or memoization plan.
+- About to write code without having stated complexity.
+- About to claim "this is fast" / "this is efficient" / "this scales" without a derivation.
+- About to copy a brute-force solution from memory because it "should work for now".
+
+All of these mean: stop, restart the seven-step protocol, choose a better algorithm or explicitly accept the brute force with a written justification.
+
+## Verification checklist
+
+Before claiming the implementation is done:
+
+- [ ] Stated `time = O(?)` and `space = O(?)` appear in the message or PR description.
+- [ ] Dominant input dimension is named with a realistic magnitude.
+- [ ] Every collection-shaped value has a deliberate data-structure choice with a one-phrase reason.
+- [ ] The algorithm family is named (not "a loop").
+- [ ] No I/O, `.find` / `.includes` / `.indexOf`, regex compile, sort, or independent `await` sits inside a loop without a one-line justification.
+- [ ] The shipped code matches the complexity that was claimed (re-derive if uncertain).
+- [ ] Edge cases listed in the pre-write protocol each have a corresponding code path or test.
+- [ ] Any "fast" / "efficient" / "scales" claims have either a derivation or a measurement — `<measured: TBD>` is acceptable; an unsupported claim is not.
+
+Cannot check every box? You did not run the protocol. Restart from step 1.
+
+## Limitations
+
+- **Not a substitute for profiling.** lemmaly forces asymptotic reasoning, not measurement. For constant-factor wins, latency tails, or I/O bottlenecks you still need a profiler.
+- **Reasoning gate, not a code generator.** This skill changes how the model thinks before writing; it does not auto-rewrite existing code (use `complexity-cuts` for that).
+- **English-language enforcement.** The rule catalog and prompts are English-only.
+- **n < ~10 is exempt.** The protocol explicitly accepts trivial collections and one-shot setup code; do not waste time stating complexity for `for i in range(3)`.
+- **Cannot prevent intentional brute force.** If the author writes a one-line justification ("n ≤ 100 in practice; readability matters more"), brute force ships. The skill only requires the justification, not its absence.
+- **CLI scanner is separate.** The 59 rules are enforced by `lemmaly scan` in the upstream repo, not by this SKILL.md alone.
+
+## The thesis, in one line
+
+> **AI ships algorithmically lazy code by default. lemmaly makes it think first.**
+
+## Related Skills
+
+- `mathguard` — escalation for n ≥ 10⁶ where classical O(n log n) is the floor and probabilistic / math-heavy techniques win.
+- `invariant-guard` — correctness layer for algorithms whose obvious version is subtly wrong.
+- `complexity-cuts` — corrective playbook for code that already shipped with bad Big-O.

--- a/skills/mathguard/SKILL.md
+++ b/skills/mathguard/SKILL.md
@@ -1,0 +1,269 @@
+---
+name: mathguard
+description: "Math-heavy escalation for n >= 10^6 — Bloom, HyperLogLog, Count-Min, MinHash/LSH, FFT, JL projection, sweep line. Use when classical O(n log n) is the floor and approximate or math wins."
+risk: safe
+source: community
+source_repo: morsechimwai/lemmaly
+source_type: community
+date_added: "2026-05-26"
+author: morsechimwai
+tags: [algorithms, probabilistic-data-structures, approximate-algorithms, bloom-filter, hyperloglog, fft, performance]
+tools: [claude-code, antigravity, cursor, gemini-cli, codex-cli]
+license: "Apache-2.0"
+license_source: "https://github.com/morsechimwai/lemmaly/blob/main/LICENSE"
+---
+
+# mathguard — Math-Heavy Optimization for AI Code
+
+`lemmaly` makes you pick the right classical algorithm. `mathguard` kicks in when the classical algorithm is already optimal but **mathematics gives a better bound** — usually by accepting bounded approximation, exploiting structure, or moving to a smarter algebraic space.
+
+The model knows these techniques. It almost never proposes them spontaneously. mathguard fixes that.
+
+**Violating the letter of these rules is violating the spirit of the skill.** A Bloom filter where the caller assumed exact answers is a production incident, not an optimization.
+
+## When to Use This Skill
+
+Use **mathguard** when:
+
+- Working with large-scale data (`n ≥ 10⁶`): similarity search, deduplication, top-K / heavy-hitters, streaming analytics, cardinality estimation, embeddings, recommender systems.
+- Doing signal/image processing, polynomial or big-integer arithmetic, convolution, graph distance, computational geometry, randomized algorithms.
+- The classical O(n log n) is already the floor and you need an asymptotic win (Bloom filter, HyperLogLog, Count-Min Sketch, MinHash/LSH, FFT/NTT, Johnson-Lindenstrauss projection, sweep line, kd-tree/BVH, fast exponentiation, monoid parallel reduction, amortized potential method).
+- Loaded *after* `lemmaly` has confirmed the classical answer is not enough.
+
+Do **not** use mathguard when:
+- The caller needs exact answers (auth, billing, dedup-for-correctness, primary keys).
+- `n` is small (n < 10⁴) and the path is not hot.
+- The bottleneck is I/O, not CPU/memory.
+
+## The Iron Law
+
+```text
+NO APPROXIMATE STRUCTURE WITHOUT WRITTEN ε/δ AND EXPLICIT CALLER ACCEPTANCE
+```
+
+Probabilistic data structures (Bloom, HyperLogLog, Count-Min, MinHash/LSH, t-digest), randomized projections (JL), and lossy transforms (floating FFT) all change the answer's meaning. Before proposing one:
+
+1. Write the error parameter the caller will see (false-positive rate, relative error, distortion bound).
+2. Identify the caller and state, in one sentence, that they tolerate this kind of wrong answer.
+3. If you cannot identify the caller, or they need exact (auth checks, billing, dedup keys, deduplication for correctness, anything that flows into a primary key), DO NOT propose the approximate structure. Keep classical, or escalate to a sharded/streaming exact design.
+
+This rule has saved more incidents than any other in this skill. Do not soften it.
+
+## Non-negotiable rules
+
+1. **Declare exact vs approximate up front.** Before suggesting a math-level technique, state:
+   - `mode: exact` or `mode: approximate`
+   - If approximate: the error parameter (ε, δ, false-positive rate) and a sentence on whether the caller can tolerate it.
+   - If the caller needs exact and there is no exact win, say so and stop — do not silently degrade to approximate.
+
+2. **Cite the technique by name.** Never describe a probabilistic or numerical trick in vague terms. Name it: `Bloom filter`, `HyperLogLog`, `Count-Min Sketch`, `MinHash + LSH`, `Johnson–Lindenstrauss projection`, `FFT`, `NTT`, `fast exponentiation`, `Karatsuba`, `Strassen`, `sweep line`, `kd-tree`, `BVH`, `union-find with path compression`, `Floyd's cycle detection`, `Boyer-Moore majority`, `reservoir sampling`, `Knuth shuffle`, `Aho-Corasick`, `suffix automaton`, `segment tree with lazy propagation`, `Fenwick tree`, `monoid scan / parallel prefix`. A named technique is auditable; "a smart approximation" is not.
+
+3. **State the trade you are making.** Every math-level optimization buys something at a cost. In one line:
+   - Buys: `space`, `time`, `wall-clock`, `parallelism`.
+   - Costs: `accuracy ε=?`, `code complexity`, `dependency`, `non-determinism`, `numerical stability`.
+   - If the cost is invisible to the caller, write "callers see no change".
+
+4. **Justify the asymptotic win.** Do not propose a math technique without a one-line bound argument:
+   - "HyperLogLog: count uniques in O(log log n) bits at standard error 1.04/√m."
+   - "FFT: polynomial multiplication O(n log n) vs schoolbook O(n²)."
+   - "JL projection: preserves pairwise distances within (1±ε) using O(log n / ε²) dimensions."
+   - "Sweep line: rectangle overlap from O(n²) pair checks to O(n log n) events."
+   No bound, no proposal.
+
+5. **Forbid math cargo-culting.** Do not introduce these techniques when:
+   - n is small enough that a linear scan finishes in microseconds (n < ~10⁴ unless it is a hot path).
+   - The problem is I/O-bound — the math win disappears behind network/disk.
+   - Exact answers are required and no exact technique exists.
+   - The team will not maintain it (write that down: "team familiarity: ?").
+
+## The pre-proposal protocol
+
+Before suggesting a math-level technique, your message must contain — in this order:
+
+1. **The classical floor** — what is the best non-mathy algorithm and its Big-O? ("Hash join is O(n+m); we're already there.")
+2. **Why classical is not enough** — n too large, space blows up, real-time deadline, etc.
+3. **The math technique** — named (rule 2).
+4. **Exact or approximate** — with ε if approximate (rule 1).
+5. **The new bound** — with one-line derivation (rule 4).
+6. **The trade** — buys/costs (rule 3).
+7. **When NOT to use this** — at least one disqualifier.
+8. **The code or pseudocode.**
+
+If any of 1–7 is missing, do not propose the technique.
+
+## Playbook — math technique → problem → win → caveat
+
+### Sketches and probabilistic structures (massive data, approximate)
+
+| Problem | Classical | Math technique | Win | Caveat |
+|---|---|---|---|---|
+| Membership: "have I seen this key?" at scale | `Set<id>`, O(n) space | **Bloom filter** | O(n) bits at chosen ε false-positive | False positives only; cannot remove (use Cuckoo if needed) |
+| Count distinct values in a stream | `Set` to count, O(unique) space | **HyperLogLog** | O(log log n) bits, ~1% relative error | Approximate; cannot list elements |
+| Top-K / heavy hitters in a stream | full counter, O(unique) space | **Count-Min Sketch** + heap | O(log(1/δ)·1/ε) space | Overestimates; choose ε,δ deliberately |
+| Document / set similarity at scale | full Jaccard, O(n·m) | **MinHash + LSH** | Sub-linear ANN query | Tunes recall vs precision; param search |
+| k-NN in high-dim vectors | brute O(n·d) | **JL projection → HNSW / IVF** | O(log n) per query, (1±ε) distortion | Index build cost; recall < 1 |
+| Reservoir of size k from a stream of unknown length | buffer all, O(n) space | **Reservoir sampling** | O(k) space, uniform sample | Single-pass only |
+| Find majority element | counter map | **Boyer-Moore majority vote** | O(1) space, O(n) time | Requires majority exists; verify pass |
+| Quantiles in a stream | sort, O(n log n) | **t-digest / GK** | O(1/ε) space, ε-accurate quantiles | Approximate |
+
+### Fast arithmetic / transforms (numeric and combinatorial)
+
+| Problem | Classical | Math technique | Win | Caveat |
+|---|---|---|---|---|
+| Multiply two polynomials / big integers | O(n²) | **FFT / NTT / Karatsuba** | O(n log n) | Floating FFT loses precision — use NTT for integers |
+| Convolution of two signals | O(n·m) | **FFT-based convolution** | O((n+m) log(n+m)) | Numerical noise at very small magnitudes |
+| `pow(a, b) mod p`, b large | O(b) multiplications | **Fast exponentiation (square-and-multiply)** | O(log b) | Watch for overflow inside; use modular arithmetic |
+| GCD of large integers | repeated subtraction | **Euclidean algorithm** | O(log min) | Standard; AI sometimes still writes the subtraction loop |
+| Matrix multiplication, n large | O(n³) | **Strassen** (then Coppersmith-Winograd family) | O(n^2.81) | High constant; only wins for very large dense |
+| Solving Ax=b for sparse A | O(n³) dense | **Conjugate gradient / sparse LU** | O(nnz · iterations) | Numerical conditioning matters |
+| Modular inverse | brute force | **Extended Euclidean** or **Fermat** when p prime | O(log p) | p must be prime for Fermat |
+
+### Dimensionality reduction and linear algebra
+
+| Problem | Classical | Math technique | Win | Caveat |
+|---|---|---|---|---|
+| Similarity in d-dim, d large | O(n·d) brute | **JL projection** to k = O(log n / ε²) | O(n·k) at (1±ε) distortion | Random; verify on validation set |
+| Recommender from rating matrix | iterate full matrix | **Truncated SVD / matrix factorization** | O(k·(n+m)) for rank-k | Choose k; refresh strategy |
+| Document-term similarity | TF-IDF O(n·m) | **LSA via SVD** | rank-k approximation | Latent dims are not interpretable |
+| PCA on n samples in d dims | O(n·d²) | **Randomized SVD** | O(n·d·k) for rank-k | Randomized; set oversampling |
+
+### Geometry (spatial queries)
+
+| Problem | Classical | Math technique | Win | Caveat |
+|---|---|---|---|---|
+| Range / nearest-neighbor in 2D-3D | O(n) per query | **kd-tree / R-tree / BVH** | O(log n) per query | Degrades in high d; use ANN instead |
+| Rectangle / interval overlap pairs | O(n²) pair check | **Sweep line + active set (BBST)** | O((n+k) log n) | k = output size; segment tree variant exists |
+| Polygon point-in-polygon at scale | O(n·v) | **BSP / monotone decomposition / R-tree** | O(log v) per query after build | Build cost |
+| Convex hull of n points | O(n²) gift wrap | **Graham scan / Andrew's monotone chain** | O(n log n) | Numerical robustness for collinear |
+| Closest pair of points | O(n²) | **Divide and conquer** | O(n log n) | Carefully merge across the strip |
+
+### Graph and algebraic tricks
+
+| Problem | Classical | Math technique | Win | Caveat |
+|---|---|---|---|---|
+| Connected components under merges | recompute BFS each merge | **Union-Find with path compression + rank** | α(n) ≈ O(1) per op amortized | Inverse Ackermann is effectively constant |
+| Range sum / update on array | O(n) per query | **Fenwick tree** | O(log n) per op | Inclusive ranges; off-by-one risk |
+| Range query with monoid (sum/min/max/gcd) | O(n) per query | **Segment tree (with lazy if range updates)** | O(log n) | More code than Fenwick; more general |
+| LCA in a tree, many queries | O(n) per query | **Binary lifting** or **Euler tour + RMQ** | O(log n) or O(1) per query | Preprocessing cost |
+| Shortest path on DAG | Dijkstra | **Topo sort + relax** | O(V+E) | Only works on DAG |
+| Detect cycle in linked list | hash visited | **Floyd's tortoise and hare** | O(1) space | Same big-O time, dramatic space win |
+| Parallel reduction over n items | sequential fold | **Monoid + parallel scan** | O(n/p + log p) on p cores | Operation must be associative; verify it |
+
+### Amortized and online algorithms
+
+| Problem | Classical | Math technique | Win | Caveat |
+|---|---|---|---|---|
+| "Dynamic array push is expensive" | per-op O(n) on resize | **Amortized analysis (doubling)** | O(1) amortized | This is what `ArrayList` / `vec` already do; just defend it |
+| Streaming median | re-sort | **Two heaps (max-heap + min-heap)** | O(log n) per insert | Maintain size invariant |
+| Online interval scheduling | re-sort by deadline | **Greedy with priority queue** | O(log n) per arrival | Specific objective; check problem fit |
+| Sliding-window max | O(n·k) | **Monotonic deque** | O(n) total | Window invariant subtle to maintain |
+
+## Canonical example — counting distinct users
+
+**Problem.** Count unique users seen across a 24-hour event stream. ~2B events/day, ~50M unique users. Reported on a dashboard, ±2% is acceptable.
+
+### Without the protocol — silent OOM, or worse, silent billing error
+
+```ts
+// "Just use a Set" — silently OOMs the box at ~50M strings
+const seen = new Set<string>();
+for await (const event of stream) {
+  seen.add(event.userId);
+}
+return seen.size; // exact, but the process died at row 41M
+```
+
+Or worse — proposed *with* a HyperLogLog "for performance" but plugged into the billing pipeline, which keys off the result. Billing then sees 49.7M instead of 50.0M users and a fraction never get charged.
+
+### With the protocol — auditable HLL
+
+```ts
+// Classical floor: O(unique) memory for an exact Set. At 50M strings × ~50B each, ~2.5GB.
+// Why classical is not enough: dashboard box has 512MB and refreshes every minute.
+// Technique: HyperLogLog (HLL).
+// Mode: approximate. ε ≈ 1.04/√m. With m=2^14 registers → ~0.8% relative error.
+// Trade: buys O(log log n)-bit space (~12KB); costs ±0.8% on the displayed count.
+// When NOT to use: anything that flows into billing, primary keys, or per-user actions.
+// Caller acceptance: confirmed — dashboard product owner accepts ±2%, written in PR.
+
+import { createHLL } from 'hyperloglog-lite';
+const hll = createHLL({ precision: 14 });
+for await (const event of stream) {
+  hll.add(event.userId);
+}
+return hll.estimate(); // 49.6M ± 0.4M; dashboard reads ~50M
+```
+
+The first version is not "no HLL" — it is "HLL without writing down ε and who tolerates it." The second is identical in technique but auditable: ε is in the comment, the caller is named, the disqualifier (billing) is explicit.
+
+## Output discipline
+
+Code that uses a math-level technique must include:
+
+- One comment naming the technique with a doc link or one-line citation.
+- The exact error parameters chosen (ε, δ, bits, dimensions, etc.) and why those values.
+- A measured or asymptotic justification next to the chosen parameters.
+- An exact-mode fallback path, if the caller might need it.
+
+## When to escalate or redirect
+
+- The bottleneck is I/O, not CPU/memory → go back to `lemmaly` rule 4; math will not help.
+- You need bit-exact reproducibility → avoid floating FFT, randomized projections, and probabilistic structures.
+- The result is consumed by a downstream system that assumes exact → keep classical or wrap with a validation pass.
+- You need a correctness proof (not just a bound) → load **invariant-guard** after picking the technique.
+
+## Rationalizations to watch for
+
+| Excuse | Reality |
+| --- | --- |
+| "A `set` works — I'll flag the memory issue in a comment." | Noticing the problem is not solving it. If memory is the budget, ship the structure that respects it. |
+| "Probabilistic structures sound fancy / academic." | Cloudflare runs Bloom filters in the request path. Redis ships HyperLogLog. These are production-tested, not academic. |
+| "Approximate is risky — I'll do exact and let it OOM later." | Silent OOM at 3am is riskier than a stated 0.81% error. State the ε, pick parameters, ship. |
+| "I'll just shard the set across machines." | Sharding multiplies your infra cost; HLL solves it in 12KB on one box. Ask whether you actually need exact. |
+| "FFT is overkill for this." | True 99% of the time. But state the n. At n ≥ ~64 for polynomial mult, schoolbook is already losing. |
+| "JL projection feels too lossy for embeddings." | At ε = 0.1, JL preserves pairwise distances within 10%. For ANN this is almost always fine — measure recall, do not eyeball. |
+
+## Red flags — STOP
+
+- Proposing a probabilistic structure without stating ε and δ.
+- Saying "we can use FFT here" without writing the n at which FFT actually beats schoolbook.
+- Using `JSON.parse(JSON.stringify(...))` to deep-clone when `structuredClone` exists, then claiming it as an optimization.
+- Recommending Strassen on a 100×100 matrix.
+- Switching to approximate output without the caller having agreed to it.
+- Naming a technique you cannot derive the bound for.
+- Math optimization where n is small and not on a hot path.
+- "Should be O(log n) on average" with no average-case argument.
+
+## Verification checklist
+
+Before shipping code that uses a math-level technique:
+
+- [ ] The technique is named (no "a smart approximation").
+- [ ] If approximate: ε and δ (or the equivalent error parameter) are written in code or in the PR description.
+- [ ] The caller has been identified and their tolerance for that error is stated.
+- [ ] A one-line bound derivation is present (asymptotic or measured).
+- [ ] At least one disqualifier ("when NOT to use this") is documented.
+- [ ] An exact-mode fallback exists, OR a one-line note explains why exact is impossible.
+- [ ] If randomized: the seed strategy is documented (fixed for reproducibility, or stated as non-deterministic).
+- [ ] Downstream consumers that assume exactness (joins on this value, billing, auth, primary keys) have been audited.
+
+Cannot check every box? The technique is not ready to ship. Keep classical, or stop and ask.
+
+## Limitations
+
+- **Not for exact-required pipelines.** Any system where the result is a primary key, dedup key, billing input, or auth decision is out of scope — keep classical.
+- **Assumes representative inputs.** ε/δ bounds are average-case or high-probability; adversarial inputs can blow past them. State the threat model.
+- **Library quality varies.** Bloom / HLL / MinHash implementations differ in seed strategy, hash function, and memory layout — pick a maintained library and pin the version.
+- **Numerical stability.** Floating FFT, randomized SVD, and JL projection accumulate float error; for combinatorial exactness use NTT or exact integer variants.
+- **Team-familiarity risk.** A technique nobody can debug at 3 a.m. is a liability — write the maintainer note next to the trade-off.
+- **Not a profiler.** mathguard tells you which asymptotic ceiling you can break; it does not measure constant factors. Benchmark before claiming a wall-clock win.
+
+## The thesis, in one line
+
+> **When classical algorithms hit their floor, mathematics still has another floor below. mathguard makes the model reach for it instead of accepting the first answer.**
+
+## Related Skills
+
+- `lemmaly` — gateway; pick the classical algorithm first before reaching for math.
+- `invariant-guard` — for stating ε-bounds as part of the postcondition of an approximate algorithm.
+- `complexity-cuts` — when baseline code already exists and the bottleneck is CPU/memory, not approximation.


### PR DESCRIPTION
Per @sickn33's note on PR #622 — the README credit and the skill ports are now in the same PR.

## What this PR adds

**4 new skills under `skills/`** (algorithm-discipline suite from [morsechimwai/lemmaly](https://github.com/morsechimwai/lemmaly), Apache-2.0):

| Skill | Role | Risk |
|---|---|---|
| `lemmaly` | **Gateway.** Forces stating Big-O, data structure, and algorithm family BEFORE writing loops, queries, or recursion. Catches O(n²), N+1, and brute-force defaults. | `safe` |
| `mathguard` | Escalation for n ≥ 10⁶ where classical O(n log n) is the floor — Bloom, HyperLogLog, Count-Min, MinHash/LSH, FFT, JL projection, sweep line, kd-tree. | `safe` |
| `invariant-guard` | Correctness-first: forces writing the function contract, loop invariant, termination argument, and edge cases BEFORE code. Catches Boyer–Moore, leftmost binary search, QuickSelect partition traps. | `safe` |
| `complexity-cuts` | Corrective playbook for code that already shipped with bad Big-O — one-transformation-at-a-time workflow with verify-revert-stop. | `safe` |

**1 README line** under Community Contributors crediting `morsechimwai/lemmaly` as the upstream source.

## Quality bar checklist (per `docs/contributors/quality-bar.md`)

Each skill ships with:

- [x] **Metadata integrity** — valid YAML frontmatter, `name` matches folder, `description` ≤300 chars, `risk: safe`, `source: community`, `source_repo: morsechimwai/lemmaly`, `source_type: community`, `date_added: 2026-05-26`, `license: Apache-2.0`, `license_source` set.
- [x] **Clear triggers** — every skill has `## When to Use This Skill` (matches the accepted heading patterns).
- [x] **Safety classification** — all four are `risk: safe` (no shell mutation, no network call, no offensive use).
- [x] **Copy-pasteable examples** — each skill contains before/after code blocks demonstrating the discipline.
- [x] **Explicit `## Limitations`** — each skill lists known edge cases and what it cannot do.
- [x] **Instruction safety review** — no `curl … | bash`, `wget … | sh`, `irm … | iex`, or embedded credentials. The only shell example is `git clone` + `node cli/lemmaly.js scan <path>` against the upstream repo.

Source-only PR: no `CATALOG.md`, `skills_index.json`, or `data/*.json` regenerated.

## Why these four together

They're designed as one composable suite — `lemmaly` is the gateway and explicitly routes to its three siblings:

- **New code?** → `lemmaly` (prevention)
- **Existing slow code?** → `complexity-cuts` (correction)
- **Subtle correctness trap?** → `invariant-guard` (verification)
- **Classical floor reached, n ≥ 10⁶?** → `mathguard` (acceleration)

Each skill's `## Related Skills` section cross-links the other three so the routing flow is discoverable from any entry point.

## Test plan

- [ ] CI: `skill-review` GitHub Action passes on the four new `SKILL.md` files.
- [ ] CI: `npm run validate` passes (frontmatter schema, name/folder match, dates, source format).
- [ ] CI: `npm run security:docs` passes (no risky command patterns).
- [ ] Manual: maintainer sanity-check that the `## When to Use` triggers are non-overlapping with similar existing skills.

Happy to adjust frontmatter, descriptions, or tags to match conventions if anything diverges from current expectations.