### PR TITLE
feat: add bumblebee skill

### DIFF
--- a/skills/bumblebee/SKILL.md
+++ b/skills/bumblebee/SKILL.md
@@ -1,0 +1,171 @@
+---
+name: bumblebee
+description: "Run Bumblebee supply-chain inventory and exposure scans on macOS/Linux to detect compromised packages, extensions, and MCP host configs."
+category: security
+risk: safe
+source: community
+source_repo: mycelos-ai/bumblebee-skill
+source_type: community
+date_added: "2026-05-27"
+author: stefan-kp
+tags: [security, supply-chain, incident-response, npm, pypi, tooling]
+tools: [claude]
+license: "MIT"
+license_source: "https://github.com/mycelos-ai/bumblebee-skill/blob/main/LICENSE"
+---
+
+# Bumblebee Security Scan
+
+Bumblebee (https://github.com/perplexityai/bumblebee) is a read-only inventory collector that surfaces package, extension, and developer-tool metadata on developer endpoints. It answers a focused supply-chain question: when an advisory names a package or version, do any matches exist on this machine right now?
+
+This skill drives a single Bumblebee scan from start to finish:
+
+1. Verify Go is on the PATH (provide install guidance if not).
+2. Verify or install the `bumblebee` binary.
+3. Run the requested scan profile (`baseline`, `project`, or `deep`).
+4. Save raw NDJSON output plus a Markdown report into the user's workspace.
+5. Summarize findings — especially exposure-catalog matches — in the chat reply.
+
+Communicate with the user in the language they used (German for Stefan). Code, commit messages, and on-disk file contents stay in English to match existing project conventions.
+
+## Step 1 — Clarify the scan request
+
+Before running anything, confirm two things with the user via `AskUserQuestion`, unless the message already pins them down:
+
+- **Profile**: `baseline` (global package roots), `project` (specific dev folders like `~/code`), or `deep` (explicit `--root` paths, including `$HOME` for incident response).
+- **Roots**: For `project` and `deep` profiles, ask which directories to scan. `deep` is the only profile that accepts a bare-home root.
+
+If the user has an advisory or exposure-catalog file ready, also ask whether they want to pass it via `--exposure-catalog`. The skill does not ship its own catalogs — point them at `threat_intel/` in the Bumblebee repo if they ask where to find ready-made ones.
+
+Skip the questions for one-liner asks like "lauf mal ne Baseline-Scan" — just run a baseline.
+
+## Step 2 — Check Go
+
+Run `command -v go && go version` in bash. Three outcomes:
+
+- **Go ≥ 1.25 present** → continue.
+- **Go present but < 1.25** → tell the user the version, explain Bumblebee needs Go 1.25+, and stop until they upgrade.
+- **Go missing** → do not install Go automatically. Show platform-appropriate instructions and stop:
+  - macOS: `brew install go` (or download from https://go.dev/dl/).
+  - Debian/Ubuntu: prefer the official tarball from https://go.dev/dl/ because distro repos lag; `sudo apt install golang-go` only as fallback.
+  - Fedora/RHEL: `sudo dnf install golang` or the official tarball.
+
+After installation, the user must ensure `$GOBIN` (or `$HOME/go/bin`) is on `$PATH` so `bumblebee` is found later.
+
+## Step 3 — Check or install Bumblebee
+
+Run `command -v bumblebee && bumblebee version`. If missing:
+
+```bash
+go install github.com/perplexityai/bumblebee/cmd/bumblebee@latest
+```
+
+Then re-check `bumblebee version`. If the binary still cannot be located, the user's `GOBIN`/`PATH` is likely misconfigured — surface the resolved `go env GOPATH` and `go env GOBIN` so they can fix it. Do not fall back to running the binary by absolute path silently; explain what is happening.
+
+Once installed, also run `bumblebee selftest` as a sanity check. A non-zero exit means the local install is broken and the scan should not proceed.
+
+## Step 4 — Run the scan
+
+All scans write NDJSON to a file. Use the workspace folder for output so the user can open the results afterwards.
+
+Output filenames (use the user's workspace path; the example below assumes `$OUT` is set):
+
+- `bumblebee-<profile>-<UTC-timestamp>.ndjson` — raw records.
+- `bumblebee-<profile>-<UTC-timestamp>.report.md` — Markdown report (generated in Step 5).
+
+Pick a sensible `--max-duration` so a runaway scan does not hang the session. Reasonable defaults:
+
+- `baseline`: 5m
+- `project`: 10m
+- `deep`: 15m (warn the user that scanning `$HOME` can still take longer; offer to raise the limit)
+
+Always stream stderr to a sibling `.log` file — Bumblebee emits diagnostic NDJSON there that helps explain partial scans.
+
+### Baseline
+
+```bash
+bumblebee scan --profile baseline \
+  --max-duration 5m \
+  > "$OUT/bumblebee-baseline-$TS.ndjson" \
+  2> "$OUT/bumblebee-baseline-$TS.log"
+```
+
+Optional: scope to specific ecosystems if the user only cares about, say, npm and PyPI:
+
+```bash
+bumblebee scan --profile baseline --ecosystem npm,pypi ...
+```
+
+### Project
+
+Each `--root` must be an existing absolute path. Reject bare `$HOME` for this profile (Bumblebee will reject it too — surface the message clearly).
+
+```bash
+bumblebee scan --profile project \
+  --root "$HOME/code" \
+  --root "$HOME/Developer" \
+  --max-duration 10m \
+  > "$OUT/bumblebee-project-$TS.ndjson" \
+  2> "$OUT/bumblebee-project-$TS.log"
+```
+
+### Deep
+
+Used for incident response — broad roots are allowed but should be paired with an exposure catalog and `--findings-only` whenever possible, so the output stays focused.
+
+```bash
+bumblebee scan --profile deep \
+  --root "$HOME" \
+  --exposure-catalog "$CATALOG" \
+  --findings-only \
+  --max-duration 15m \
+  > "$OUT/bumblebee-deep-$TS.ndjson" \
+  2> "$OUT/bumblebee-deep-$TS.log"
+```
+
+If the user has no catalog, run deep without `--findings-only` but warn them that the NDJSON file can grow large (hundreds of MB on dense developer machines).
+
+## Step 5 — Generate the Markdown report
+
+Run the bundled helper to turn the NDJSON into a human-readable report:
+
+```bash
+python3 scripts/render_report.py \
+  "$OUT/bumblebee-<profile>-$TS.ndjson" \
+  "$OUT/bumblebee-<profile>-$TS.report.md"
+```
+
+The helper groups records by type and ecosystem, lists every `finding` record with its catalog entry and severity, and embeds the `scan_summary` for traceability. It is dependency-free Python 3 — no `pip install` needed.
+
+If `render_report.py` exits non-zero (malformed NDJSON, missing summary), surface stderr to the user instead of silently producing an empty report.
+
+## Step 6 — Present results
+
+End the turn with:
+
+- A short summary in chat: profile, root(s), record counts, and — most importantly — any findings with their severity. If there are zero findings, say so explicitly; silence on findings is the kind of thing that gets misread.
+- `computer://` links to both the NDJSON and the Markdown report so the user can open them directly.
+- If diagnostics in the `.log` file indicate skipped roots or read errors, mention it and link the log too.
+
+Do not paste large chunks of NDJSON into the chat — it is noisy and not where the user will read it.
+
+## Safety and privacy notes
+
+- Bumblebee is read-only by design. Do not propose patches, deletions, or `npm uninstall` actions from inside this skill; the user runs remediation themselves once they know what is affected.
+- MCP host configs can carry secrets in their `env` blocks. Bumblebee does not emit those values, but the `.log` file may still contain paths to sensitive config files. Treat the output files as containing inventory data and do not upload them to third-party services without the user's explicit consent (DSGVO-relevant).
+- Never run `bumblebee` with elevated privileges (`sudo`). It is meant to inspect the current user's developer environment, not the whole system.
+
+## Failure modes to watch for
+
+- `bumblebee: command not found` after `go install` → almost always a `PATH`/`GOBIN` problem. Show `go env GOPATH GOBIN PATH` to debug.
+- `refusing to scan bare home with profile baseline` → use `deep` for `$HOME`, or pick a subdirectory for `project`.
+- Scan times out → either narrow the `--root` set, scope with `--ecosystem`, or raise `--max-duration`. Do not loop and retry blindly.
+- Exposure catalog rejected → check that the JSON has both `schema_version` and `entries` keys (bare top-level arrays are rejected) and that `schema_version` is one Bumblebee understands.
+
+## Reference
+
+See `scripts/render_report.py` for the report layout. Bumblebee's own documentation lives at https://github.com/perplexityai/bumblebee — consult `docs/inventory-sources.md`, `docs/transport.md`, and `docs/state-model.md` when a question goes beyond what this skill covers.
+
+## Credit
+
+Bumblebee is developed by Perplexity (https://github.com/perplexityai/bumblebee, Apache-2.0). All scan logic, output formats, and exposure-catalog semantics belong to that project. This repository is just a thin Claude-skill wrapper around the official `bumblebee` CLI; the wrapper itself is MIT-licensed (see `LICENSE`).

--- a/skills/bumblebee/scripts/render_report.py
+++ b/skills/bumblebee/scripts/render_report.py
@@ -1,0 +1,362 @@
+#!/usr/bin/env python3
+"""Render a Bumblebee NDJSON scan into a human-readable Markdown report.
+
+Bumblebee emits one JSON record per line. Record types we know about:
+
+- package           — an inventory record for a discovered package
+- finding           — an exposure-catalog match (high signal)
+- scan_summary      — emitted once at end of run, contains counts/duration
+- diagnostic        — non-fatal warnings (skipped roots, parse errors)
+
+Unknown record types are bucketed under "other" and counted but not
+rendered in detail. The script never imports anything outside the
+standard library — it has to run on whatever Python 3 ships with the
+developer's machine.
+
+Usage:
+    python3 render_report.py <input.ndjson> <output.md>
+
+Exit codes:
+    0  success
+    1  usage error
+    2  input file unreadable or empty
+    3  no records parsed (likely malformed file)
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from collections import Counter, defaultdict
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+
+SEVERITY_ORDER = ["critical", "high", "medium", "low", "info", "unknown"]
+
+
+def severity_rank(value: str | None) -> int:
+    """Return a sort key for severities; unknown values sort last."""
+    if not value:
+        return len(SEVERITY_ORDER)
+    try:
+        return SEVERITY_ORDER.index(value.lower())
+    except ValueError:
+        return len(SEVERITY_ORDER)
+
+
+def load_records(path: Path) -> list[dict[str, Any]]:
+    """Parse NDJSON, tolerating blank lines and trailing whitespace.
+
+    Malformed lines are reported on stderr but do not abort the run —
+    Bumblebee can interleave records from multiple goroutines and a single
+    truncated line should not lose the rest of the report.
+    """
+    records: list[dict[str, Any]] = []
+    with path.open("r", encoding="utf-8") as fh:
+        for lineno, raw in enumerate(fh, start=1):
+            line = raw.strip()
+            if not line:
+                continue
+            try:
+                records.append(json.loads(line))
+            except json.JSONDecodeError as exc:
+                print(
+                    f"warning: skipping malformed line {lineno}: {exc}",
+                    file=sys.stderr,
+                )
+    return records
+
+
+def group_by_kind(records: list[dict[str, Any]]) -> dict[str, list[dict[str, Any]]]:
+    groups: dict[str, list[dict[str, Any]]] = defaultdict(list)
+    for rec in records:
+        kind = rec.get("record_type") or rec.get("type") or "unknown"
+        groups[kind].append(rec)
+    return groups
+
+
+def render_findings(findings: list[dict[str, Any]]) -> str:
+    """Findings are the most important section — render them first.
+
+    Each finding carries the matched package's identity (Bumblebee uses
+    `normalized_name` / `source_file` per docs/state-model.md) plus
+    catalog metadata. We look up by the canonical Bumblebee names first
+    and keep a small set of fallbacks so the helper still works against
+    older schemas or hand-rolled fixtures.
+    """
+    if not findings:
+        return "## Findings\n\nNo exposure-catalog matches.\n"
+
+    # Sort by severity (critical first) then by package name.
+    sorted_findings = sorted(
+        findings,
+        key=lambda f: (
+            severity_rank(_get(f, "severity", "catalog_severity")),
+            _get(f, "normalized_name", "package", "name", "package_name") or "",
+        ),
+    )
+
+    out = [f"## Findings\n\n**{len(sorted_findings)} match(es) against exposure catalog.**\n"]
+    for finding in sorted_findings:
+        severity = _get(finding, "severity", "catalog_severity") or "unknown"
+        catalog_id = _get(finding, "catalog_id", "advisory_id", "id") or "—"
+        catalog_name = _get(finding, "catalog_name", "advisory", "name") or ""
+        ecosystem = _get(finding, "ecosystem") or "?"
+        pkg = _get(finding, "normalized_name", "package", "name", "package_name") or "?"
+        version = _get(finding, "version", "matched_version") or "?"
+        # Bumblebee emits `source_file` (and often a `project_path`);
+        # legacy / demo records may use `source_path`. Render both when
+        # available — responders need that traceability.
+        source_file = _get(finding, "source_file", "source_path", "evidence_path", "path") or ""
+        project_path = _get(finding, "project_path") or ""
+        finding_type = _get(finding, "finding_type") or ""
+
+        out.append(f"### [{severity.upper()}] {pkg}@{version} ({ecosystem})")
+        out.append("")
+        out.append(f"- Catalog entry: `{catalog_id}`" + (f" — {catalog_name}" if catalog_name else ""))
+        if finding_type:
+            out.append(f"- Finding type: {finding_type}")
+        if source_file:
+            out.append(f"- Source file: `{source_file}`")
+        if project_path and project_path != source_file:
+            out.append(f"- Project path: `{project_path}`")
+        confidence = _get(finding, "confidence")
+        if confidence:
+            out.append(f"- Confidence: {confidence}")
+        root_kind = _get(finding, "root_kind")
+        if root_kind:
+            out.append(f"- Root kind: {root_kind}")
+        evidence = _get(finding, "evidence")
+        if evidence and isinstance(evidence, (str, int, float)):
+            out.append(f"- Evidence: {evidence}")
+        out.append("")
+    return "\n".join(out)
+
+
+def render_inventory(packages: list[dict[str, Any]]) -> str:
+    if not packages:
+        return "## Inventory\n\nNo package records emitted (findings-only mode?).\n"
+
+    by_ecosystem: Counter[str] = Counter()
+    by_root_kind: Counter[str] = Counter()
+    by_confidence: Counter[str] = Counter()
+    for pkg in packages:
+        by_ecosystem[pkg.get("ecosystem", "unknown")] += 1
+        by_root_kind[pkg.get("root_kind", "unknown")] += 1
+        by_confidence[pkg.get("confidence", "unknown")] += 1
+
+    lines = [
+        "## Inventory",
+        "",
+        f"Total package records: **{len(packages):,}**",
+        "",
+        "### By ecosystem",
+        "",
+        "| Ecosystem | Count |",
+        "| --- | ---: |",
+    ]
+    for eco, count in by_ecosystem.most_common():
+        lines.append(f"| {eco} | {count:,} |")
+
+    lines += [
+        "",
+        "### By root kind",
+        "",
+        "| Root kind | Count |",
+        "| --- | ---: |",
+    ]
+    for kind, count in by_root_kind.most_common():
+        lines.append(f"| {kind} | {count:,} |")
+
+    lines += [
+        "",
+        "### By confidence",
+        "",
+        "| Confidence | Count |",
+        "| --- | ---: |",
+    ]
+    for conf, count in by_confidence.most_common():
+        lines.append(f"| {conf} | {count:,} |")
+    lines.append("")
+    return "\n".join(lines)
+
+
+def render_summary(summary_records: list[dict[str, Any]]) -> str:
+    """Render scan_summary record(s).
+
+    Bumblebee's real scan_summary (per docs/state-model.md) is flat —
+    `scan_time`, `end_time`, `status`, `package_records_emitted`,
+    `findings_emitted`, `diagnostics_count`, `roots`, plus HTTP-sink
+    counters when applicable. We render those canonical fields first
+    and still fall back to the older `counts`/`totals` shape for
+    backwards compatibility with hand-rolled fixtures.
+    """
+    if not summary_records:
+        return "## Scan summary\n\n_No `scan_summary` record found — the run may not have completed cleanly._\n"
+
+    # Bumblebee canonical scan_summary fields (per docs/state-model.md).
+    # Order matters: identity → status → timing → counts → delivery → versioning.
+    canonical_fields = (
+        "endpoint_id",
+        "profile",
+        "run_id",
+        "status",
+        "scan_time",
+        "end_time",
+        "timed_out",
+        "package_records_emitted",
+        "package_records_suppressed",
+        "findings_emitted",
+        "diagnostics_count",
+        "http_batches_attempted",
+        "http_batches_succeeded",
+        "http_batches_failed",
+        "http_last_status",
+        "scanner_version",
+        "schema_version",
+    )
+
+    out = ["## Scan summary", ""]
+    for idx, rec in enumerate(summary_records, start=1):
+        if len(summary_records) > 1:
+            out.append(f"### Summary {idx}")
+            out.append("")
+
+        status = rec.get("status")
+        if status and status != "complete":
+            out.append(f"> **Status `{status}`** — this run is not a trustworthy complete snapshot. Treat as raw evidence only.")
+            out.append("")
+
+        # Canonical fields
+        for key in canonical_fields:
+            if key in rec and rec[key] not in (None, ""):
+                out.append(f"- **{key}**: `{rec[key]}`")
+
+        # Roots can be a list of objects; render compactly.
+        roots = rec.get("roots")
+        if roots:
+            if isinstance(roots, list):
+                out.append(f"- **roots**: {len(roots)} root(s) scanned")
+                for r in roots[:20]:
+                    if isinstance(r, dict):
+                        # Common shape: {kind, path}
+                        kind = r.get("kind") or r.get("root_kind") or "?"
+                        path = r.get("path") or r.get("root") or "?"
+                        out.append(f"  - `{kind}`: `{path}`")
+                    else:
+                        out.append(f"  - `{r}`")
+                if len(roots) > 20:
+                    out.append(f"  - _… {len(roots) - 20} more truncated_")
+            else:
+                out.append(f"- **roots**: `{roots}`")
+
+        # Legacy / fixture shape: nested counts dict
+        counts = rec.get("counts") or rec.get("totals") or {}
+        if counts:
+            out.append("- **counts** (legacy):")
+            for k, v in counts.items():
+                out.append(f"  - {k}: {v}")
+
+        # Surface any remaining fields we didn't recognize so the helper
+        # never silently drops data when the schema gains new keys.
+        rendered = set(canonical_fields) | {"roots", "counts", "totals", "record_type", "type", "record_id"}
+        extras = {k: v for k, v in rec.items() if k not in rendered and v not in (None, "", [], {})}
+        if extras:
+            out.append("- **other fields**:")
+            for k, v in extras.items():
+                out.append(f"  - {k}: `{v}`")
+
+        out.append("")
+    return "\n".join(out)
+
+
+def render_diagnostics(diagnostics: list[dict[str, Any]]) -> str:
+    if not diagnostics:
+        return ""
+    out = ["## Diagnostics", "", f"{len(diagnostics)} diagnostic record(s) emitted on stdout."]
+    out.append("")
+    for diag in diagnostics[:50]:  # Cap output — log file has full detail.
+        level = diag.get("level", "info")
+        msg = diag.get("message") or diag.get("msg") or json.dumps(diag, sort_keys=True)
+        path = diag.get("path") or diag.get("source_path") or ""
+        suffix = f" — `{path}`" if path else ""
+        out.append(f"- **{level}**: {msg}{suffix}")
+    if len(diagnostics) > 50:
+        out.append("")
+        out.append(f"_… {len(diagnostics) - 50} more diagnostic record(s) truncated. See the `.log` file for the full list._")
+    out.append("")
+    return "\n".join(out)
+
+
+def _get(record: dict[str, Any], *keys: str) -> Any:
+    """Return the first non-empty value found for any of the candidate keys."""
+    for key in keys:
+        value = record.get(key)
+        if value not in (None, "", [], {}):
+            return value
+    return None
+
+
+def build_report(records: list[dict[str, Any]], source_path: Path) -> str:
+    groups = group_by_kind(records)
+    findings = groups.get("finding", []) + groups.get("findings", [])
+    packages = groups.get("package", []) + groups.get("packages", [])
+    summaries = groups.get("scan_summary", [])
+    diagnostics = groups.get("diagnostic", []) + groups.get("diagnostics", [])
+
+    other_kinds = {
+        kind: len(items)
+        for kind, items in groups.items()
+        if kind not in {"finding", "findings", "package", "packages", "scan_summary", "diagnostic", "diagnostics"}
+    }
+
+    generated = datetime.now(timezone.utc).isoformat(timespec="seconds")
+    header = [
+        "# Bumblebee Scan Report",
+        "",
+        f"- Source: `{source_path}`",
+        f"- Generated: `{generated}`",
+        f"- Total records: **{len(records):,}**",
+    ]
+    if other_kinds:
+        header.append(f"- Other record types: {', '.join(f'{k} ({v})' for k, v in sorted(other_kinds.items()))}")
+    header.append("")
+
+    sections = [
+        "\n".join(header),
+        render_findings(findings),
+        render_summary(summaries),
+        render_inventory(packages),
+        render_diagnostics(diagnostics),
+    ]
+    return "\n".join(s for s in sections if s).rstrip() + "\n"
+
+
+def main(argv: list[str]) -> int:
+    if len(argv) != 3:
+        print(f"usage: {Path(argv[0]).name} <input.ndjson> <output.md>", file=sys.stderr)
+        return 1
+
+    input_path = Path(argv[1])
+    output_path = Path(argv[2])
+
+    if not input_path.exists() or input_path.stat().st_size == 0:
+        print(f"error: {input_path} is missing or empty", file=sys.stderr)
+        return 2
+
+    records = load_records(input_path)
+    if not records:
+        print("error: no JSON records parsed from input", file=sys.stderr)
+        return 3
+
+    report = build_report(records, input_path)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(report, encoding="utf-8")
+    print(f"wrote {output_path} ({len(records)} records)")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))


### PR DESCRIPTION
Adds a skill that wraps Perplexity's open-source `bumblebee` CLI
(https://github.com/perplexityai/bumblebee) for supply-chain inventory and
exposure scans on macOS/Linux developer endpoints.

When an advisory names a compromised npm/PyPI/Go/RubyGems/Composer package,
or a malicious editor/browser extension, the skill scans the local machine
in read-only mode and reports matches.

**What it does:**
- Verifies Go ≥ 1.25 is available (install hints only — never installs Go).
- Installs `bumblebee` via `go install` if missing; runs `bumblebee selftest`.
- Drives baseline / project / deep scan profiles with sensible `--max-duration` defaults.
- Generates an NDJSON file (raw) + a Markdown report via a stdlib-only Python helper.

**Risk:** `safe` — entirely read-only. Bumblebee is read-only by design and the
skill never patches, uninstalls, or modifies anything. No telemetry; outputs are
local files only.

**Upstream:** https://github.com/perplexityai/bumblebee (Apache-2.0).
**Wrapper repo:** https://github.com/mycelos-ai/bumblebee-skill (MIT).

I ran `npm run validate` locally before opening the PR.