### PR TITLE
feat: add Longbridge Securities skill (finance/markets)

### DIFF
--- a/README.md
+++ b/README.md
@@ -295,6 +295,7 @@ This collection would not be possible without the incredible work of the Claude 
 - **[BuyWhere/buywhere-mcp](https://github.com/BuyWhere/buywhere-mcp)**: Official BuyWhere MCP server — search and compare products from Singapore, SEA, and US markets via Model Context Protocol.
 - **[expo/skills](https://github.com/expo/skills)**: Official Expo skills - Expo project workflows and Expo Application Services guidance.
 - **[huggingface/skills](https://github.com/huggingface/skills)**: Official Hugging Face skills - Models, Spaces, datasets, inference, and broader Hugging Face ecosystem workflows.
+- **[longbridge/skills](https://github.com/longbridge/skills)**: Official Longbridge Securities skills - real-time quotes, charts, fundamentals, portfolio analysis, options, and market workflows for HK, US, A-share, and SG markets.
 - **[neondatabase/agent-skills](https://github.com/neondatabase/agent-skills)**: Official Neon skills - Serverless Postgres workflows and Neon platform guidance.
 - **[Skyvern-AI/skyvern](https://github.com/Skyvern-AI/skyvern)**: Official Skyvern browser automation skill — AI-powered browser control using Vision LLMs and computer vision for navigating sites, filling forms, and extracting structured data.
 - **[scopeblind/scopeblind-gateway](https://github.com/scopeblind/scopeblind-gateway)**: Official Scopeblind MCP governance toolkit - Cedar policy authoring, shadow-to-enforce rollout, and signed-receipt verification guidance for agent tool calls.

--- a/skills/longbridge/SKILL.md
+++ b/skills/longbridge/SKILL.md
@@ -1,0 +1,91 @@
+---
+name: longbridge
+description: "125+ agent skills for Longbridge Securities — real-time quotes, charts, fundamentals, portfolio analysis, options, and more for HK/US/A-share/SG markets. Trilingual: Simplified Chinese, Traditional Chinese, English."
+category: finance
+risk: safe
+source: official
+source_repo: longbridge/skills
+source_type: official
+date_added: "2026-05-29"
+author: longbridge
+tags: [finance, stocks, trading, portfolio, market-data]
+tools: [claude, cursor, gemini, codex]
+license: "MIT"
+license_source: "https://github.com/longbridge/skills/blob/main/LICENSE"
+---
+
+# Longbridge
+
+## Overview
+
+Longbridge is the official skill collection for Longbridge Securities, covering 125+ agent skills across real-time market data, chart analysis, company fundamentals, portfolio management, options, sector screening, and more. Supports HK, US, A-share (SH/SZ), and SG markets. All skills are trilingual (Simplified Chinese / Traditional Chinese / English).
+
+Source repository: [github.com/longbridge/skills](https://github.com/longbridge/skills) (~840 stars, MIT)
+
+## When to Use This Skill
+
+- Use when the user asks about stock prices, charts, or market data for HK/US/A-share/SG markets
+- Use when the user wants company fundamentals, earnings, or analyst ratings
+- Use when the user asks about their portfolio, positions, or account P&L via Longbridge
+- Use when the user wants options analysis, sector rankings, capital flow, or news
+- Use when the user asks in Chinese (Simplified or Traditional) or English about any securities topic
+
+## How It Works
+
+### Step 1: Discover the Right Subcommand
+
+```bash
+longbridge --help
+```
+
+List all available subcommands. Never hard-code subcommand names — the CLI evolves.
+
+### Step 2: Check Subcommand Options
+
+```bash
+longbridge <subcommand> --help
+```
+
+Confirm flags and output format before calling.
+
+### Step 3: Call with JSON Output
+
+```bash
+longbridge <subcommand> --format json
+```
+
+Parse the structured output and render in the user's language (detect from input).
+
+## Authentication
+
+```bash
+longbridge auth login          # Basic market data (read-only)
+longbridge auth login --trade  # Portfolio and account features
+```
+
+## Install
+
+```bash
+# Claude Code plugin marketplace
+/plugin marketplace add longbridge/skills
+
+# Or via npx
+npx skills add https://github.com/longbridge/skills
+```
+
+## MCP Fallback
+
+If the `longbridge` CLI binary is not installed, fall back to MCP tools. Inspect available MCP tools at runtime — do not hard-code MCP tool names as they change with server versions.
+
+## Limitations
+
+- Portfolio and account features require login with Trade scope.
+- Real-time data is subject to Longbridge data subscription (delayed data available without subscription).
+- Crypto symbols use `.HAS` suffix on the Longbridge platform.
+- This skill does not place orders — read-only by default unless using the account write scope.
+
+## Security & Safety Notes
+
+- All market data queries are read-only (no side effects).
+- Watchlist mutations and order-related features follow a preview + confirm two-step protocol.
+- Credentials are handled by the Longbridge auth system; this skill does not store or transmit tokens.


### PR DESCRIPTION
## Change Classification

- [ ] Skill PR
- [ ] Docs PR
- [ ] Infra PR

## Issue Link (Optional)

Use this only when the PR should auto-close an issue:

`Closes #N` or `Fixes #N`

## Quality Bar Checklist ✅

**All applicable items must be checked before merging.**

- [ ] **Standards**: I have read `docs/contributors/quality-bar.md` and `docs/contributors/security-guardrails.md`.
- [ ] **Metadata**: The `SKILL.md` frontmatter is valid (checked with `npm run validate`).
- [ ] **Risk Label**: I have assigned the correct `risk:` tag (`none`, `safe`, `critical`, `offensive`, or `unknown` for legacy/unclassified content).
- [ ] **Triggers**: The "When to use" section is clear and specific.
- [ ] **Limitations**: The skill includes a `## Limitations` (or equivalent accepted constraints) section.
- [ ] **Security**: If this is an _offensive_ skill, I included the "Authorized Use Only" disclaimer.
- [ ] **Safety scan**: If this PR adds or modifies `SKILL.md` command guidance, remote/network examples, or token-like strings, I ran `npm run security:docs` (or equivalent hardening check) and addressed any findings.
- [ ] **Automated Skill Review**: If this PR changes `SKILL.md`, I checked the `skill-review` GitHub Actions result and addressed any actionable feedback.
- [ ] **Manual Logic Review**: If this PR changes `SKILL.md` or risky guidance, I manually reviewed the logic, safety, failure modes, and `risk:` label instead of relying on automated checks alone.
- [ ] **Local Test**: I have verified the skill works locally.
- [ ] **Repo Checks**: I ran `npm run validate:references` if my change affected docs, workflows, or infrastructure.
- [ ] **Source-Only PR**: I did not manually include generated registry artifacts (`CATALOG.md`, `skills_index.json`, `data/*.json`) in this PR.
- [ ] **Credits**: I have added the source credit in `README.md` (if applicable).
- [ ] **License provenance**: If this skill imports from an external `source_repo`, I have declared `license:` and `license_source:` in the frontmatter, or confirmed the upstream repo carries no restricting license.
- [ ] **Maintainer Edits**: I enabled **Allow edits from maintainers** on the PR.

## Screenshots (if applicable)