### PR TITLE
docs(mmx-cli): default chat model is MiniMax-M3

### DIFF
--- a/skills/mmx-cli/SKILL.md
+++ b/skills/mmx-cli/SKILL.md
@@ -53,14 +53,14 @@ Always use these flags in non-interactive (agent/CI) contexts:
 
 ### text chat
 
-Chat completion. Default model: `MiniMax-M2.7`.
+Chat completion. Default model: `MiniMax-M3`. Pass `--model MiniMax-M2.7` for the previous-generation default when reproducing older outputs.
 
 ```bash
 mmx text chat --message <text> [flags]
 ```
 
 ```bash
-# Single message
+# Single message (uses MiniMax-M3 by default)
 mmx text chat --message "user:What is MiniMax?" --output json --quiet
 
 # Multi-turn with system prompt
@@ -68,6 +68,9 @@ mmx text chat \
   --system "You are a coding assistant." \
   --message "user:Write fizzbuzz in Python" \
   --output json
+
+# Pin to the previous-generation model
+mmx text chat --model MiniMax-M2.7 --message "user:Hello" --output json
 
 # From file
 cat conversation.json | mmx text chat --messages-file - --output json


### PR DESCRIPTION
## Summary

The `mmx-cli` skill's `text chat` section currently advertises `MiniMax-M2.7` as the default chat model. MiniMax has since released `MiniMax-M3` and made it the new default, so this updates the skill docs to keep agents pointed at the current production default and documents `MiniMax-M2.7` as the previous-generation option.

## Changes

- `skills/mmx-cli/SKILL.md`
  - `text chat` section: default model line now reads `MiniMax-M3`, with a note that `--model MiniMax-M2.7` is the way to pin to the previous default for reproducibility.
  - Added a `--model MiniMax-M2.7` usage example so the legacy flag flow is visible.
  - Annotated the existing single-message example to call out the new default.

## Why

- Agents copying these examples into automation get the current production model by default instead of a deprecated one.
- M2.7 stays documented so users with pinned model IDs in CI / regression tests have a clear migration path.
- TTS (`speech-2.8-hd`), image (`image-01`), video (`MiniMax-Hailuo-*`), and music (`music-2.6-free`) defaults are untouched — only the chat default changes.

## Scope notes

- Source-only change as required by `CONTRIBUTING.md`. No generated registry artifacts (`CATALOG.md`, `skills_index.json`, `data/*.json`, plugin mirrors under `plugins/`) modified — those will canonicalize on `main` after merge.
- `python3 tools/scripts/validate_skills.py` passes (`All skills passed validation!`).
- `risk: safe`, `source` and `date_added` frontmatter unchanged.

## PR checklist

- [x] Source-only diff (single `skills/mmx-cli/SKILL.md` change)
- [x] Frontmatter unchanged; name matches folder
- [x] Validator passes locally
- [x] No generated registry artifacts committed

## Quality Bar Checklist ✅

**All applicable items must be checked before merging.**

- [x] **Standards**: I have read `docs/contributors/quality-bar.md` and `docs/contributors/security-guardrails.md`.
- [x] **Metadata**: The `SKILL.md` frontmatter is unchanged and valid.
- [x] **Risk Label**: The existing `risk: safe` label remains appropriate.
- [x] **Triggers**: Existing trigger guidance remains unchanged.
- [x] **Limitations**: Existing limitations remain unchanged.
- [x] **Security**: This is not an offensive skill.
- [x] **Safety scan**: No new network, credential, install, or risky command guidance was added.
- [x] **Automated Skill Review**: I checked the automated review result.
- [x] **Manual Logic Review**: I manually reviewed the model-default documentation change.
- [x] **Local Test**: `python3 tools/scripts/validate_skills.py` passes locally.
- [x] **Repo Checks**: Not applicable for this source-only skill documentation update.
- [x] **Source-Only PR**: I did not include generated registry artifacts.
- [x] **Credits**: Not applicable; no source attribution changed.
- [x] **License provenance**: Not applicable; no external source metadata changed.
- [x] **Maintainer Edits**: Maintainer edits are enabled or the PR can be updated by maintainers.
