### PR TITLE
feat(cli-agent-interop): add robust agent bridge

### DIFF
--- a/cli-agent-interop/README.md
+++ b/cli-agent-interop/README.md
@@ -1,0 +1,80 @@
+# cli-agent-interop
+
+统一的命令行智能体互调技能。
+
+目标：让任意本地 agent 用一套共享脚本与交接契约，去调用 Claude Code、Codex、GitHub Copilot CLI、Gemini CLI、OpenCode、Qwen / Qwen Code；同时把 Windows / WSL 的调用边界明确固化下来。
+
+## 核心策略
+
+- Windows 侧 agent：默认只调用 Windows 侧 agent。
+- WSL 侧 agent：默认只调用 WSL 侧 agent。
+- 只有在人工明确要求“用 Windows 侧 / 用 WSL 侧”时，才允许跨 runtime。
+- 当前 agent 不优先调用自己；自己只作为同 runtime 内的最后 fallback。
+- 这是常驻技能，但默认不自动触发；只有人工明确要求“调用别的 agent / 比较 agent / 切换到 Windows 或 WSL 侧 agent”时才启用。
+
+## 包内内容
+
+- `SKILL.md`：主技能说明
+- `scripts/agent_bridge.py`：统一 wrapper，支持 `list / route / check / run`
+- `references/command-matrix.md`：各 agent 的命令矩阵、runtime 规则、当前环境观察
+- `references/handoff-contract.md`：跨 agent 交接 prompt 模板
+- `examples/handoff-prompts.md`：示例提示词
+
+## 常用命令
+
+```bash
+python scripts/agent_bridge.py list --runtime current
+python scripts/agent_bridge.py route --current-agent codex --runtime current
+python scripts/agent_bridge.py check gemini --runtime current --smoke --workdir .
+python scripts/agent_bridge.py check codex --runtime current --smoke --workdir . --timeout 120
+python scripts/agent_bridge.py run claude --prompt "Review the current diff and report bugs" --runtime current --workdir .
+python scripts/agent_bridge.py run copilot --prompt "Summarize the current branch in five bullets" --runtime windows --workdir .
+```
+
+## Codex / OpenCode 注意事项
+
+- `check` 只证明快速探测命令可用；真实交接以 `run` 的退出码和输出为准。
+- Codex `exec` 会把管道 stdin 追加进 prompt。wrapper 对 Codex 使用 `codex exec ... -` 加受控 stdin，不要改回“位置 prompt + 继承 stdin”。
+- Codex 会加载用户配置、skills、plugins、MCP、memory 和 shutdown hooks；smoke/run 建议用 `--timeout 120` 或更高。
+- OpenCode 当前 `opencode run ... --dir <workdir>` 是主要 one-shot 路径；`opencode auth list` 只能证明凭据可见。OpenCode smoke 如果退出 0 但没有固定 token，要用明确的 `run` 复验。
+
+## 已内置的别名
+
+- `qwen` / `qwencode` / `qwen-code` / `qwen-code-cli`
+- `copilot` / `github-copilot` / `gh-copilot`
+- `claude` / `claude-code`
+- `codex` / `openai-codex`
+
+## 当前环境观察（本次重构时）
+
+- 当前 WSL shell: `node -v` -> `v22.22.2`
+- 当前 WSL shell: `copilot --version` 仍直接报 “requires Node.js v24 or higher”
+- 当前 WSL shell 可见：claude / codex / gemini / opencode / qwen / copilot
+- 显式查看 Windows runtime 时，也能看到 Windows 侧的 claude / codex / gemini / opencode / qwen / copilot
+- 这版技能不会再因为 Windows 侧更健康就自动跳过去；除非明确写 `--runtime windows`
+
+## 建议安装位置
+
+全局共享技能库：
+- `C:\Users\11\.agents\skills\cli-agent-interop`
+
+安装/更新后重建索引：
+
+```bash
+node /mnt/c/Users/11/.agents/skills/scripts/build-skill-index.js
+node /mnt/c/Users/11/.agents/skills/scripts/build-catalog.js
+```
+
+## 适用场景
+
+- “让 gemini / codex / qwen / claude / copilot 去做这个任务”
+- “把同一个 prompt 分别交给多个 agent 做 AB 对比”
+- “如果当前 agent 是 codex，先看同 runtime 下还有哪些 peer agent 可以调”
+- “明确要求切到 Windows 侧 agent / WSL 侧 agent”
+- “需要统一 one-shot 调用接口、检查环境、规范交接 prompt”
+
+## 不适用场景
+
+- 普通编码任务，但用户没有明确要求调用其他 agent
+- 当前 agent 自己就能完成，且不需要外部 agent 参与
+- 仅仅因为另一个 runtime 更健康，就想偷偷绕过去

--- a/cli-agent-interop/SKILL.md
+++ b/cli-agent-interop/SKILL.md
@@ -1,0 +1,216 @@
+---
+name: cli-agent-interop
+description: Explicit cross-agent CLI routing for local coding agents. Use this skill only when the human explicitly asks to call, switch, compare, route, or hand work to another agent such as Claude, Codex, Copilot, Gemini, OpenCode, or Qwen/Qwen Code, or explicitly asks for Windows-side versus WSL-side agent execution. Do not trigger it for ordinary coding tasks. Default policy keeps Windows agents on Windows, WSL agents on WSL, and places the current agent itself last as a same-runtime fallback.
+compatibility: Requires terminal access plus at least one installed CLI agent. Bundled wrapper supports claude, codex, copilot, gemini, opencode, qwen, qwencode, qwen-code, qwen-code-cli, and github-copilot aliases across current-runtime and explicit Windows/WSL routing.
+license: MIT
+---
+
+# CLI Agent Interop
+
+This is a resident skill for explicit agent-to-agent delegation. Keep it installed globally, but keep it dormant until the human explicitly asks to use another agent.
+
+Prefer the bundled `scripts/agent_bridge.py` for routing, readiness checks, and bounded one-shot runs. Escalate to native interactive sessions only when the task genuinely needs follow-up turns, TUI state, or session persistence.
+
+## Activation boundary (critical)
+
+Load this skill when the human explicitly asks for one of these behaviors:
+- use another agent
+- call Gemini / Codex / Claude / Copilot / OpenCode / Qwen
+- compare two or more agents
+- switch execution to Windows-side or WSL-side agents
+- hand a task from the current agent to another agent
+
+Do not load this skill just because a coding task exists.
+
+Non-triggers:
+- ordinary implementation / debugging / refactoring requests with no explicit agent-routing request
+- normal subagent use inside the current agent when no external-agent handoff was requested
+- general “please solve this” prompts that do not mention another agent or another runtime
+
+## Quick start
+
+1. Inspect the current-runtime inventory:
+   - `python scripts/agent_bridge.py list --runtime current`
+2. Ask for the same-runtime peer order for the current agent:
+   - `python scripts/agent_bridge.py route --current-agent codex --runtime current`
+3. Check one agent before relying on it:
+   - `python scripts/agent_bridge.py check gemini --runtime current --smoke --workdir .`
+   - For Codex, use a longer smoke timeout when plugins or MCP servers are enabled: `python scripts/agent_bridge.py check codex --runtime current --smoke --workdir . --timeout 120`
+4. Run a bounded same-runtime delegation:
+   - `python scripts/agent_bridge.py run claude --prompt "Review the diff and report bugs" --runtime current --workdir .`
+5. Run an explicit cross-runtime delegation only when the human asked for it:
+   - `python scripts/agent_bridge.py run copilot --prompt "Summarize the current branch in five bullets" --runtime windows --workdir .`
+
+## Canonical workflow
+
+Follow this sequence whenever one local agent should invoke another.
+
+### 1) Confirm the human explicitly asked for another agent
+
+This skill exists for explicit routing, not silent substitution.
+
+If the human did not explicitly request another agent or another runtime, stay in the current agent and do not delegate externally.
+
+### 2) Resolve runtime policy before agent choice
+
+Use these rules first:
+- `--runtime current` is the default.
+- On Windows, `current` means Windows-side agents only.
+- In WSL, `current` means WSL-side agents only.
+- Cross-runtime routing happens only with an explicit `--runtime windows` or `--runtime wsl` choice that reflects the human’s request.
+- Never auto-jump to another runtime just because it looks healthier.
+
+### 3) Prefer other agents in the same runtime before self-agent fallback
+
+Ask the wrapper for the same-runtime route order:
+
+- `python scripts/agent_bridge.py route --current-agent codex --runtime current`
+
+Default behavior:
+- peer agents in the target runtime come first
+- the current agent itself is pushed to the end as a fallback
+- if the human explicitly requests a target agent, that requested agent moves to the front
+- if the human explicitly requests the same agent brand again, treat that as an override instead of blocking it
+
+This encodes the user’s preference that “Codex should know how to call Claude / Gemini / others first, and Codex itself becomes the lower fallback when dedicated subagent behavior is unavailable.”
+
+### 4) Use one handoff contract
+
+Build the delegated prompt using `references/handoff-contract.md`.
+
+The handoff must state:
+- host runtime and target runtime
+- current agent and requested target agent
+- objective
+- repo / workdir
+- files or directories in scope
+- constraints
+- expected deliverable
+- verification steps
+
+When comparing agents, keep the handoff text identical and change only the target agent.
+
+### 5) Default to bounded, non-interactive execution
+
+Prefer these modes first:
+- Claude Code: `claude -p`
+- Codex: `codex exec`
+- Gemini: `gemini -p`
+- OpenCode: `opencode run`
+- Qwen / Qwen Code: positional one-shot prompt
+- GitHub Copilot CLI: direct `copilot -p ...` in the selected runtime, or same-runtime `gh copilot -- -p ...` only if direct `copilot` is unavailable there
+
+The wrapper script already encodes these defaults.
+
+### 6) Start read-only or plan-first
+
+Do not grant write-capable execution by default.
+
+Use these defaults unless edits are intended:
+- Claude: `--permission-mode plan`
+- Codex: `--sandbox read-only`
+- Gemini: `--approval-mode plan`
+- Qwen: `--approval-mode plan`
+- OpenCode: one-shot run without extra write escalation
+- Copilot: keep the prompt narrow and verify runtime readiness first
+
+Then opt into `--allow-write` or `--yolo` only when the task actually needs it.
+
+### 7) Always set the working directory explicitly
+
+Pass `--workdir` every time.
+
+The wrapper normalizes Windows paths and WSL `/mnt/...` paths for the selected runtime so different agents can share one call surface without silently switching runtimes.
+
+### 8) Verify before you trust the result
+
+Use `python scripts/agent_bridge.py check <agent> --runtime <...> --smoke` when readiness matters.
+
+Interpret checks narrowly:
+- `list` proves only that a CLI binary is discoverable in the selected runtime.
+- `check` proves only that the fast native readiness command exits successfully.
+- `check --smoke` proves that the selected agent can answer a minimal one-shot prompt under the supplied timeout.
+- `run` is the actual delegation path; trust it only after checking its exit code and output.
+
+Codex-specific handling:
+- Codex `exec` can append stdin to the prompt when stdin is piped. The wrapper sends Codex prompts through controlled stdin with `codex exec ... -`; do not revert this to a positional prompt plus inherited stdin.
+- Codex loads user config, skills, plugins, MCP clients, memory hooks, and shutdown hooks during one-shot runs. Warnings from those layers can make smoke tests slower than other agents.
+- Use `--timeout 120` or higher for Codex smoke/run checks on plugin-heavy profiles.
+- If Codex prints the expected answer but exits with a timeout, inspect the wrapper's `partial_output` or `smoke_timeout.partial_output` field; treat it as an incomplete run until the timeout cause is fixed or the timeout is adjusted.
+- When Codex `check --smoke` times out but `run codex --prompt ...` succeeds, report the distinction: readiness smoke is inconclusive, while the actual delegation path worked.
+
+OpenCode-specific handling:
+- `opencode auth list` only checks credentials and environment visibility.
+- `opencode run` is the path that matters for delegation. Model/provider choice can make the smoke response take tens of seconds.
+- If OpenCode `check --smoke` exits 0 but does not include the expected token, do not call it healthy from smoke alone; immediately verify with an explicit `run opencode --prompt ...` and report both outcomes.
+- `--dir` is part of the OpenCode run command; keep passing `--workdir` to the wrapper so the selected runtime sees the intended project path.
+
+If a delegated command returns auth, rate-limit, or runtime errors, surface the real failure instead of pretending the target agent completed the task.
+
+## Runtime policy summary
+
+| Host side | Default target runtime | Automatic cross-runtime? | Explicit override |
+|---|---|---|---|
+| Windows agent | Windows | No | `--runtime wsl` |
+| WSL agent | WSL | No | `--runtime windows` |
+
+The important rule is behavioral, not technical: another runtime may exist, but it is not the default execution surface unless the human explicitly asked for it.
+
+## Agent selection guidance
+
+Use this rough decision rule after runtime policy is fixed.
+
+- `claude`: strong for multi-step editing, code review, and longer reasoning chains. Keep print mode for bounded delegation; use tmux only for true interactive sessions.
+- `codex`: strong for one-shot repo tasks, non-interactive implementation, and scripted automation. Outside a git repo, keep `--skip-git-repo-check`.
+- `gemini`: good for one-shot analysis / implementation and MCP-aware workflows. Use `-p` first.
+- `opencode`: good when provider flexibility matters or when you want a vendor-neutral coding worker. Use `opencode run` first.
+- `qwen`: use for Qwen / Qwen Code delegation. Re-check auth immediately if you see `401 invalid access token or token expired`.
+- `copilot`: stay inside the selected runtime. Prefer direct `copilot` in that runtime; use same-runtime `gh copilot` only if direct `copilot` is unavailable there.
+
+See `references/command-matrix.md` for exact command patterns, runtime policy notes, and current observed environment facts.
+
+## Interactive escalation rule
+
+Do not start an interactive TUI just because it exists.
+
+Escalate to native interactive sessions only if one of these is true:
+- the task needs multi-turn steering
+- the task needs slash commands or session resume semantics
+- the delegated agent must stay alive while another process changes state
+- the human explicitly asked for that agent’s TUI workflow
+
+When you do escalate, use the native agent-specific skills for that agent and keep this wrapper for runtime routing, readiness checks, and one-shot fallbacks.
+
+## Shared output discipline
+
+When one agent delegates to another, require the child agent to return:
+1. what it changed or found
+2. what it verified
+3. remaining risks or blockers
+4. exact failure messages if the run was incomplete
+
+This keeps inter-agent handoffs auditable and makes agent comparisons meaningful.
+
+## Bundled resources
+
+- `scripts/agent_bridge.py`
+  - canonical wrapper for listing, routing, checking, smoke-testing, and one-shot delegation
+- `references/command-matrix.md`
+  - per-agent command matrix, runtime policy, and current environment notes
+- `references/handoff-contract.md`
+  - reusable handoff template for cross-agent calls
+- `examples/handoff-prompts.md`
+  - ready-made prompt patterns for review, implementation, and runtime-explicit delegation
+
+## Rules
+
+1. Do not trigger this skill without an explicit human instruction to use another agent or another runtime.
+2. `--runtime current` is the default.
+3. Cross-runtime routing requires an explicit `--runtime windows` or `--runtime wsl` choice.
+4. Use `route` before ad-hoc peer selection when the current agent matters.
+5. Keep the current agent last as a same-runtime fallback unless the human explicitly requested that same agent.
+6. Prefer bounded one-shot delegation before interactive sessions.
+7. Pass `--workdir` explicitly every time.
+8. Report exact runtime failures; do not downgrade them into vague summaries.
+9. Never auto-hop from WSL to Windows or from Windows to WSL just because a tool looks healthier there.
+10. Do not let child agent CLIs inherit wrapper stdin; Codex prompts must use controlled stdin with `codex exec ... -`.

--- a/cli-agent-interop/examples/handoff-prompts.md
+++ b/cli-agent-interop/examples/handoff-prompts.md
@@ -1,0 +1,68 @@
+# Handoff Prompt Examples
+
+## 1) Ask for peer order before choosing a target
+
+```bash
+python scripts/agent_bridge.py route --current-agent codex --runtime current
+```
+
+This keeps the current agent last and shows which same-runtime peers are available first.
+
+## 2) Compare Codex vs Gemini on the same review task
+
+```text
+Runtime:
+- host runtime: wsl
+- target runtime: current
+
+Agents:
+- current agent: claude
+- target agent: codex or gemini
+- self-fallback policy: peer agents first; self only as fallback unless explicitly requested
+
+Objective:
+- Review the current diff for correctness, security issues, and missing tests.
+
+Workspace:
+- workdir: /mnt/c/Users/11/my-repo
+- repo or project: my-repo
+
+Scope:
+- files/directories in scope: current git diff only
+- inputs already available: `git diff main...HEAD`
+- do not touch: no file edits
+
+Constraints:
+- read-only only
+- keep the answer under 15 bullet points
+
+Deliverable:
+- prioritized findings with file references
+
+Verification:
+- every finding must cite the exact file and reason
+
+Failure handling:
+- return exact blocking error if the diff cannot be read
+```
+
+## 3) Delegate a narrow same-runtime implementation change
+
+```bash
+python scripts/agent_bridge.py run gemini           --prompt "Update src/parser.py so blank lines are ignored, then update the parser tests"           --runtime current           --workdir .           --allow-write
+```
+
+## 4) Explicitly use Windows-side Copilot from WSL
+
+```bash
+python scripts/agent_bridge.py check copilot --runtime windows --workdir .
+python scripts/agent_bridge.py run copilot           --prompt "Summarize the current branch in five bullets"           --runtime windows           --workdir .
+```
+
+## 5) Windows path example
+
+```bash
+python scripts/agent_bridge.py run codex           --prompt "Review src/auth.py for bugs"           --runtime current           --workdir 'C:\Users\11\project-x'
+```
+
+The wrapper will normalize the path for the selected runtime without silently changing runtimes.

--- a/cli-agent-interop/references/command-matrix.md
+++ b/cli-agent-interop/references/command-matrix.md
@@ -1,0 +1,118 @@
+# Command Matrix
+
+Use this file when choosing a target agent or when the bundled wrapper is not enough and you need the native command form.
+
+## Runtime-local routing policy
+
+| Host runtime | Default target runtime | Auto cross-runtime? | Explicit override |
+|---|---|---|---|
+| Windows | Windows | No | `--runtime wsl` |
+| WSL | WSL | No | `--runtime windows` |
+
+The wrapper follows policy, not convenience. If WSL-side Copilot is broken but the human did not explicitly ask for Windows-side execution, the correct outcome is to surface the WSL failure instead of silently hopping to Windows.
+
+## Peer-order policy
+
+Ask the wrapper for the route order whenever the current agent matters:
+
+```bash
+python scripts/agent_bridge.py route --current-agent codex --runtime current
+python scripts/agent_bridge.py route --current-agent claude --requested-agent gemini --runtime current
+```
+
+Default ordering rules:
+1. stay inside the selected runtime
+2. prefer other agents first
+3. push the current agent itself to the end as fallback
+4. if the human explicitly requests a specific target agent, move that agent to the front
+5. if the human explicitly requests the same agent brand again, allow it as an override
+
+## Canonical one-shot commands
+
+| Agent | Preferred bounded command | Safe default | Notes |
+|---|---|---|---|
+| Claude Code | `claude -p "<prompt>" --output-format text --no-session-persistence --permission-mode plan` | plan / read-only | Use tmux only for true interactive workflows. |
+| Codex | `codex exec --skip-git-repo-check --sandbox read-only -` with the prompt on controlled stdin | read-only sandbox | Do not use positional prompt plus inherited stdin; use longer timeouts when plugins/MCP/memory hooks are enabled. |
+| Gemini | `gemini -p "<prompt>" --output-format text --approval-mode plan` | plan / read-only | Good default for bounded delegation. |
+| OpenCode | `opencode run "<prompt>" --dir "<workdir>"` | one-shot run | Use interactive TUI only when follow-up turns matter. Provider/model choice can make smoke tests slow. |
+| Qwen / Qwen Code | `qwen "<prompt>" --output-format text --approval-mode plan` | plan / read-only | Positional prompt is preferred over deprecated `--prompt`. |
+| GitHub Copilot CLI | direct `copilot -p "<prompt>"` in the selected runtime; same-runtime `gh copilot -- -p "<prompt>"` only if direct `copilot` is unavailable there | narrow prompt + runtime check | Do not auto-hop runtimes. |
+
+## Cross-runtime examples
+
+From WSL to explicitly use Windows-side agent execution:
+
+```bash
+python scripts/agent_bridge.py run copilot           --prompt "Summarize the current branch in five bullets"           --runtime windows           --workdir .
+```
+
+From Windows to explicitly use WSL-side agent execution:
+
+```bash
+python scripts/agent_bridge.py run gemini           --prompt "Review the current diff and report bugs"           --runtime wsl           --workdir .
+```
+
+## Readiness checks
+
+| Agent | Fast check | Live smoke |
+|---|---|---|
+| Claude Code | `claude auth status --text` | `claude -p 'Respond with exactly: CLAUDE_SMOKE_OK' --output-format text --permission-mode plan --no-session-persistence` |
+| Codex | `codex exec --help` | `codex exec --skip-git-repo-check --sandbox read-only 'Respond with exactly: CODEX_SMOKE_OK'` |
+| Gemini | `gemini --help` | `gemini -p 'Respond with exactly: GEMINI_SMOKE_OK'` |
+| OpenCode | `opencode auth list` | `opencode run 'Respond with exactly: OPENCODE_SMOKE_OK'` |
+| Qwen | `qwen auth status` | `qwen 'Respond with exactly: QWEN_SMOKE_OK' --output-format text` |
+| Copilot | `copilot --help` or same-runtime `gh copilot -- --help` | `copilot -p 'Respond with exactly: COPILOT_SMOKE_OK' --allow-all-tools` |
+
+## Wrapper behavior notes
+
+- On Windows, npm-installed agents often expose `.CMD` shims. The wrapper keeps `shell=True` for these commands because direct `CreateProcess` execution is not reliable for every agent shim.
+- The wrapper passes `stdin=subprocess.DEVNULL` to ordinary child commands. For Codex prompts it instead uses `codex exec ... -` and sends the prompt through controlled stdin, because `codex exec` appends piped stdin to the prompt when both stdin and a prompt argument are present.
+- `check` and `run` do not mean the same thing. `check` verifies the fast native readiness command; `run` is the real delegation path.
+- Codex one-shot runs include user config, skill loading, plugin/MCP startup, memory hooks, and shutdown hooks. A valid answer can appear before the final process exit. Use `--timeout 120` or higher when diagnosing Codex wrapper behavior, and inspect timeout JSON `partial_output` or `smoke_timeout.partial_output` before deciding whether the model itself failed.
+- OpenCode `opencode auth list` verifies credentials only. Validate delegation with `opencode run` through the wrapper. If OpenCode smoke exits 0 without the expected token, treat smoke as inconclusive and verify `run` directly.
+
+## Current observed environment for this rebuild
+
+Observed from the active WSL host shell during the initial refactor:
+
+WSL runtime:
+- `node -v` -> `v22.22.2`
+- `copilot --version` -> `GitHub Copilot CLI requires Node.js v24 or higher. Currently using v22.22.2.`
+- `gh --version` -> `2.89.0`
+- `qwen --version` -> `0.14.4`
+- `gemini --version` -> `0.37.2`
+- `codex --version` -> `codex-cli 0.121.0`
+- `opencode --version` -> `1.2.6`
+- `claude --version` -> `2.1.116 (Claude Code)`
+
+Windows runtime, observed explicitly via `--runtime windows` from WSL at the initial refactor:
+- `claude` -> `2.1.114 (Claude Code)`
+- `codex` -> `codex-cli 0.121.0`
+- `gemini` -> `0.37.1`
+- `opencode` -> `1.2.27`
+- `qwen` -> `0.14.3`
+- `copilot` -> `GitHub Copilot CLI 1.0.34`
+
+Windows runtime, rechecked from PowerShell on 2026-06-04:
+- `claude` -> `2.1.145 (Claude Code)`
+- `codex` -> `codex-cli 0.128.0`
+- `gemini` -> `0.40.1`
+- `opencode` -> `1.15.13`
+- `qwen` -> `0.14.3`
+- `copilot` -> `GitHub Copilot CLI 1.0.34`
+
+Implication:
+- the Windows side is available as an explicit alternative runtime
+- the wrapper must still stay in WSL by default for WSL-side agents
+- switching to Windows remains an explicit policy choice, not an automatic health-based fallback
+
+## Comparison discipline
+
+When comparing two or more agents:
+
+1. Keep the prompt identical.
+2. Keep the working directory identical.
+3. Keep file scope and constraints identical.
+4. Start with read-only / plan-first mode.
+5. Record failures as real outcomes. A runtime failure still counts as a comparison result.
+6. Only escalate a subset of agents into write-capable mode if that is the explicit test.

--- a/cli-agent-interop/references/handoff-contract.md
+++ b/cli-agent-interop/references/handoff-contract.md
@@ -1,0 +1,156 @@
+# Handoff Contract
+
+Use the same structure whenever one agent delegates to another. The goal is to remove ambiguity, preserve runtime intent, and make agent-to-agent comparisons fair.
+
+## Minimal contract
+
+```text
+Runtime:
+- host runtime: <windows|wsl>
+- target runtime: <current|windows|wsl>
+
+Agents:
+- current agent: <codex|claude|gemini|opencode|qwen|copilot>
+- target agent: <target agent name>
+- self-fallback policy: peer agents first; self only as fallback unless explicitly requested
+
+Objective:
+- <one sentence describing the task>
+
+Workspace:
+- workdir: <absolute path>
+- repo or project: <name or path>
+
+Scope:
+- files/directories in scope: <paths>
+- inputs already available: <files, logs, diffs, URLs>
+- do not touch: <paths or systems>
+
+Constraints:
+- <style / safety / dependency / time constraints>
+- <whether external network use is allowed>
+- <whether file edits are allowed>
+
+Deliverable:
+- <what the child agent must return>
+
+Verification:
+- <tests, smoke checks, or evidence the child agent must provide>
+
+Failure handling:
+- If blocked, return the exact command/output/error and stop.
+```
+
+## JSON-shaped variant
+
+Use this when a coordinator agent wants a machine-readable handoff.
+
+```json
+{
+  "runtime": {
+    "host": "wsl",
+    "target": "current"
+  },
+  "agents": {
+    "current": "codex",
+    "target": "gemini",
+    "self_fallback_policy": "peer-first-self-last"
+  },
+  "objective": "...",
+  "workdir": "/absolute/path",
+  "scope": {
+    "include": ["src", "tests/test_auth.py"],
+    "exclude": ["secrets", ".env"]
+  },
+  "inputs": ["git diff", "pytest output"],
+  "constraints": [
+    "prefer read-only first",
+    "no dependency upgrades unless required"
+  ],
+  "deliverable": [
+    "summary of changes or findings",
+    "verification performed",
+    "remaining risks"
+  ],
+  "failure_handling": "return exact blocking error"
+}
+```
+
+## Example: same-runtime review handoff
+
+```text
+Runtime:
+- host runtime: wsl
+- target runtime: current
+
+Agents:
+- current agent: codex
+- target agent: gemini
+- self-fallback policy: peer agents first; self only as fallback unless explicitly requested
+
+Objective:
+- Review the current diff for bugs, security risks, and missing tests.
+
+Workspace:
+- workdir: /mnt/c/Users/11/project-x
+- repo or project: project-x
+
+Scope:
+- files/directories in scope: current git diff only
+- inputs already available: `git diff --stat`, `git diff`
+- do not touch: no file edits
+
+Constraints:
+- read-only only
+- no network use unless the prompt explicitly says so
+
+Deliverable:
+- concise review with severity, file / line references, and concrete fixes
+
+Verification:
+- cite the exact diff hunk or file location for every issue
+
+Failure handling:
+- if the agent cannot access the repo or diff, return the exact failure
+```
+
+## Example: explicit Windows-side implementation handoff
+
+```text
+Runtime:
+- host runtime: wsl
+- target runtime: windows
+
+Agents:
+- current agent: claude
+- target agent: copilot
+- self-fallback policy: peer agents first; self only as fallback unless explicitly requested
+
+Objective:
+- Refactor `src/auth.py` to centralize token parsing and update tests.
+
+Workspace:
+- workdir: /mnt/c/Users/11/project-x
+- repo or project: project-x
+
+Scope:
+- files/directories in scope: `src/auth.py`, `tests/test_auth.py`
+- inputs already available: failing pytest output
+- do not touch: CI, deployment, unrelated modules
+
+Constraints:
+- edits allowed only inside listed files
+- preserve public API
+- do not add new dependencies
+
+Deliverable:
+- changed files summary
+- tests run and results
+- remaining edge cases
+
+Verification:
+- run the relevant test file or equivalent smoke check
+
+Failure handling:
+- if blocked, return the exact test failure or permission problem
+```

--- a/cli-agent-interop/scripts/agent_bridge.py
+++ b/cli-agent-interop/scripts/agent_bridge.py
@@ -1,0 +1,744 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import shlex
+import shutil
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Dict, List, Optional, Tuple
+
+ALIASES = {
+    'claude': 'claude',
+    'claude-code': 'claude',
+    'codex': 'codex',
+    'openai-codex': 'codex',
+    'gemini': 'gemini',
+    'gemini-cli': 'gemini',
+    'opencode': 'opencode',
+    'qwen': 'qwen',
+    'qwencode': 'qwen',
+    'qwen-code': 'qwen',
+    'qwen-code-cli': 'qwen',
+    'copilot': 'copilot',
+    'github-copilot': 'copilot',
+    'gh-copilot': 'copilot',
+}
+
+DEFAULT_AGENT_ORDER = ['claude', 'codex', 'gemini', 'opencode', 'qwen', 'copilot']
+
+AGENTS: Dict[str, Dict[str, object]] = {
+    'claude': {
+        'binary': 'claude',
+        'version_cmd': ['claude', '--version'],
+        'check_cmd': ['claude', 'auth', 'status', '--text'],
+        'smoke_cmd': ['claude', '-p', 'Respond with exactly: CLAUDE_SMOKE_OK', '--output-format', 'text', '--permission-mode', 'plan', '--no-session-persistence'],
+        'smoke_token': 'CLAUDE_SMOKE_OK',
+        'note': 'Claude Code print mode is preferred for bounded delegation.',
+    },
+    'codex': {
+        'binary': 'codex',
+        'version_cmd': ['codex', '--version'],
+        'check_cmd': ['codex', 'exec', '--help'],
+        'smoke_cmd': ['codex', 'exec', '--skip-git-repo-check', '--sandbox', 'read-only', 'Respond with exactly: CODEX_SMOKE_OK'],
+        'smoke_token': 'CODEX_SMOKE_OK',
+        'note': 'Codex non-interactive exec is the default; keep --skip-git-repo-check for non-repo work.',
+    },
+    'gemini': {
+        'binary': 'gemini',
+        'version_cmd': ['gemini', '--version'],
+        'check_cmd': ['gemini', '--help'],
+        'smoke_cmd': ['gemini', '-p', 'Respond with exactly: GEMINI_SMOKE_OK'],
+        'smoke_token': 'GEMINI_SMOKE_OK',
+        'note': 'Gemini -p is the preferred bounded mode.',
+    },
+    'opencode': {
+        'binary': 'opencode',
+        'version_cmd': ['opencode', '--version'],
+        'check_cmd': ['opencode', 'auth', 'list'],
+        'smoke_cmd': ['opencode', 'run', 'Respond with exactly: OPENCODE_SMOKE_OK'],
+        'smoke_token': 'OPENCODE_SMOKE_OK',
+        'note': 'OpenCode run is the preferred bounded mode.',
+    },
+    'qwen': {
+        'binary': 'qwen',
+        'version_cmd': ['qwen', '--version'],
+        'check_cmd': ['qwen', 'auth', 'status'],
+        'smoke_cmd': ['qwen', 'Respond with exactly: QWEN_SMOKE_OK', '--output-format', 'text'],
+        'smoke_token': 'QWEN_SMOKE_OK',
+        'note': 'Use positional prompts for one-shot Qwen runs.',
+    },
+    'copilot': {
+        'binary': 'copilot',
+        'version_cmd': ['copilot', '--version'],
+        'note': 'Stay inside the selected runtime. Prefer direct copilot there; use same-runtime gh copilot only if direct copilot is unavailable there.',
+    },
+}
+
+WINDOWS_PATH_RE = re.compile(r'^(?P<drive>[a-zA-Z]):[\\/](?P<rest>.*)$')
+MNT_PATH_RE = re.compile(r'^/mnt/(?P<drive>[a-zA-Z])/(?P<rest>.*)$')
+
+
+@dataclass
+class WorkdirContext:
+    host_runtime: str
+    target_runtime: str
+    host_path: Path
+    target_path: str
+
+
+def is_wsl() -> bool:
+    if os.environ.get('WSL_DISTRO_NAME'):
+        return True
+    if os.name == 'nt':
+        return False
+    try:
+        return 'microsoft' in Path('/proc/sys/kernel/osrelease').read_text().lower()
+    except Exception:
+        return False
+
+
+def current_runtime() -> str:
+    if os.name == 'nt':
+        return 'windows'
+    if is_wsl():
+        return 'wsl'
+    return 'linux'
+
+
+def default_target_runtime() -> str:
+    runtime = current_runtime()
+    if runtime == 'windows':
+        return 'windows'
+    if runtime == 'wsl':
+        return 'wsl'
+    return 'linux'
+
+
+def ps_quote(text: str) -> str:
+    return "'" + text.replace("'", "''") + "'"
+
+
+def canonical_agent(name: str) -> str:
+    key = name.strip().lower()
+    if key not in ALIASES:
+        raise SystemExit(f'Unknown agent {name!r}. Known names: {", ".join(sorted(ALIASES))}')
+    return ALIASES[key]
+
+
+def effective_runtime(requested: str) -> str:
+    requested = requested.strip().lower()
+    host = current_runtime()
+    if requested == 'current':
+        return default_target_runtime()
+    if requested == 'windows':
+        if host == 'windows' or shutil.which('powershell.exe'):
+            return 'windows'
+        raise SystemExit('Windows runtime requested but powershell.exe is not available from this host runtime.')
+    if requested == 'wsl':
+        if host == 'wsl' or shutil.which('wsl.exe'):
+            return 'wsl'
+        raise SystemExit('WSL runtime requested but wsl.exe is not available from this host runtime.')
+    raise SystemExit(f'Unsupported runtime policy: {requested}')
+
+
+def windows_to_wsl_path(raw: str) -> Optional[str]:
+    match = WINDOWS_PATH_RE.match(raw.strip())
+    if not match:
+        return None
+    drive = match.group('drive').lower()
+    rest = match.group('rest').replace('\\', '/').lstrip('/')
+    return f'/mnt/{drive}/{rest}' if rest else f'/mnt/{drive}'
+
+
+def wsl_to_windows_path(path: Path) -> Optional[str]:
+    match = MNT_PATH_RE.match(str(path))
+    if not match:
+        return None
+    drive = match.group('drive').upper()
+    rest = match.group('rest').replace('/', '\\')
+    return f'{drive}:\\{rest}' if rest else f'{drive}:\\'
+
+
+def normalize_host_path(raw: str) -> Path:
+    host = current_runtime()
+    raw = raw.strip()
+    if host == 'windows':
+        match = MNT_PATH_RE.match(raw)
+        if match:
+            drive = match.group('drive').upper()
+            rest = match.group('rest').replace('/', '\\')
+            raw = f'{drive}:\\{rest}' if rest else f'{drive}:\\'
+        return Path(raw).expanduser().resolve()
+    converted = windows_to_wsl_path(raw)
+    if converted:
+        raw = converted
+    return Path(raw).expanduser().resolve()
+
+
+def resolve_workdir(raw: str, target_runtime: str) -> WorkdirContext:
+    host = current_runtime()
+    host_path = normalize_host_path(raw)
+    if target_runtime == 'windows':
+        if host == 'windows':
+            target_path = str(host_path)
+        else:
+            target_path = wsl_to_windows_path(host_path)
+            if not target_path:
+                raise SystemExit(f'Path {host_path} has no Windows translation. Use a path under /mnt/<drive>/... for Windows runtime execution.')
+    elif target_runtime in {'wsl', 'linux'}:
+        if host == 'windows':
+            target_path = windows_to_wsl_path(str(host_path))
+            if not target_path:
+                raise SystemExit(f'Path {host_path} has no WSL translation.')
+        else:
+            target_path = str(host_path)
+    else:
+        raise SystemExit(f'Unsupported target runtime: {target_runtime}')
+    return WorkdirContext(host_runtime=host, target_runtime=target_runtime, host_path=host_path, target_path=target_path)
+
+
+def summarize_output(cp: subprocess.CompletedProcess, limit: int = 800) -> str:
+    text = '\n'.join(part for part in [(cp.stdout or '').strip(), (cp.stderr or '').strip()] if part).strip()
+    return text[:limit]
+
+
+def _text_from_timeout_part(part: object) -> str:
+    if part is None:
+        return ''
+    if isinstance(part, bytes):
+        return part.decode('utf-8', errors='replace')
+    return str(part)
+
+
+def timeout_summary(exc: subprocess.TimeoutExpired, limit: int = 4000) -> dict:
+    partial = '\n'.join(
+        part.strip()
+        for part in [
+            _text_from_timeout_part(getattr(exc, 'output', None)),
+            _text_from_timeout_part(getattr(exc, 'stderr', None)),
+        ]
+        if part and part.strip()
+    ).strip()
+    return {
+        'timed_out_after': exc.timeout,
+        'partial_output_emitted': bool(partial),
+        'partial_output': partial[:limit],
+    }
+
+
+def windows_command_source(name: str) -> Optional[str]:
+    ps = shutil.which('powershell.exe') or shutil.which('powershell')
+    if not ps:
+        return None
+    script = f"& {{ $cmd = Get-Command {ps_quote(name)} -ErrorAction SilentlyContinue; if ($cmd) {{ Write-Output $cmd.Source }} }}"
+    try:
+        cp = subprocess.run([ps, '-NoProfile', '-Command', script], capture_output=True, text=True, timeout=20)
+        lines = (cp.stdout or '').strip().splitlines()
+        return lines[0].strip() if cp.returncode == 0 and lines else None
+    except Exception:
+        return None
+
+
+def wsl_command_source(name: str) -> Optional[str]:
+    wsl = shutil.which('wsl.exe')
+    if not wsl:
+        return None
+    try:
+        cp = subprocess.run([wsl, 'bash', '-lc', f'command -v {shlex.quote(name)}'], capture_output=True, text=True, timeout=20)
+        lines = (cp.stdout or '').strip().splitlines()
+        return lines[0].strip() if cp.returncode == 0 and lines else None
+    except Exception:
+        return None
+
+
+def runtime_command_source(name: str, runtime: str) -> Optional[str]:
+    host = current_runtime()
+    native = default_target_runtime()
+    if runtime == native:
+        return shutil.which(name)
+    if host == 'wsl' and runtime == 'windows':
+        return windows_command_source(name)
+    if host == 'windows' and runtime == 'wsl':
+        return wsl_command_source(name)
+    return None
+
+
+def build_windows_wrapper(native_cmd: List[str], workdir: Optional[str]) -> List[str]:
+    script_parts: List[str] = []
+    if workdir:
+        script_parts.append(f'Set-Location {ps_quote(workdir)}')
+    script_parts.append('& ' + ' '.join(ps_quote(arg) for arg in native_cmd))
+    return ['powershell.exe', '-NoProfile', '-Command', '& { ' + '; '.join(script_parts) + ' }']
+
+
+def build_wsl_wrapper(native_cmd: List[str], workdir: Optional[str]) -> List[str]:
+    command = ''
+    if workdir:
+        command += f'cd {shlex.quote(workdir)} && '
+    command += ' '.join(shlex.quote(arg) for arg in native_cmd)
+    return ['wsl.exe', 'bash', '-lc', command]
+
+
+def wrap_command_for_runtime(native_cmd: List[str], runtime: str, workdir: Optional[WorkdirContext] = None) -> Tuple[List[str], Optional[str]]:
+    host = current_runtime()
+    native = default_target_runtime()
+    if runtime == native:
+        return native_cmd, str(workdir.host_path) if workdir else None
+    if host == 'wsl' and runtime == 'windows':
+        return build_windows_wrapper(native_cmd, workdir.target_path if workdir else None), None
+    if host == 'windows' and runtime == 'wsl':
+        return build_wsl_wrapper(native_cmd, workdir.target_path if workdir else None), None
+    raise SystemExit(f'Cross-runtime execution from {host} to {runtime} is not supported here.')
+
+
+def prepare_subprocess_command(native_cmd: List[str]) -> Tuple[List[str], Optional[str]]:
+    if len(native_cmd) >= 3 and native_cmd[0] == 'codex' and native_cmd[1] == 'exec' and native_cmd[-1] != '-' and not native_cmd[-1].startswith('-'):
+        prompt = native_cmd[-1]
+        return native_cmd[:-1] + ['-'], prompt
+    return native_cmd, None
+
+
+def terminate_process_tree(pid: int) -> None:
+    if sys.platform == 'win32':
+        subprocess.run(['taskkill', '/PID', str(pid), '/T', '/F'], capture_output=True, text=True)
+        return
+    try:
+        os.kill(pid, 15)
+    except OSError:
+        pass
+
+
+def run_capture(native_cmd: List[str], runtime: str, workdir: Optional[WorkdirContext] = None, timeout: int = 30) -> subprocess.CompletedProcess:
+    native_cmd, controlled_input = prepare_subprocess_command(native_cmd)
+    wrapped_cmd, cwd = wrap_command_for_runtime(native_cmd, runtime, workdir)
+    # Detach stdin so agent CLIs do not append the wrapper's input stream to the prompt.
+    # Keep shell=True on Windows because npm .CMD shims are not reliably executable via CreateProcess.
+    use_shell = sys.platform == 'win32'
+    stdin_value = subprocess.PIPE if controlled_input is not None else subprocess.DEVNULL
+    proc = subprocess.Popen(
+        wrapped_cmd,
+        cwd=cwd,
+        stdin=stdin_value,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        encoding='utf-8',
+        shell=use_shell,
+    )
+    try:
+        stdout, stderr = proc.communicate(input=controlled_input, timeout=timeout)
+    except subprocess.TimeoutExpired as exc:
+        terminate_process_tree(proc.pid)
+        try:
+            stdout, stderr = proc.communicate(timeout=10)
+        except subprocess.TimeoutExpired:
+            stdout = _text_from_timeout_part(exc.output)
+            stderr = _text_from_timeout_part(exc.stderr)
+        exc.output = stdout if stdout is not None else _text_from_timeout_part(exc.output)
+        exc.stderr = stderr if stderr is not None else _text_from_timeout_part(exc.stderr)
+        raise
+    return subprocess.CompletedProcess(wrapped_cmd, proc.returncode, stdout=stdout, stderr=stderr)
+
+
+def run_live(native_cmd: List[str], runtime: str, workdir: Optional[WorkdirContext], timeout: Optional[int]) -> subprocess.CompletedProcess:
+    native_cmd, controlled_input = prepare_subprocess_command(native_cmd)
+    wrapped_cmd, cwd = wrap_command_for_runtime(native_cmd, runtime, workdir)
+    # Detach stdin so agent CLIs do not append the wrapper's input stream to the prompt.
+    # Keep shell=True on Windows because npm .CMD shims are not reliably executable via CreateProcess.
+    use_shell = sys.platform == 'win32'
+    stdin_arg = {} if controlled_input is not None else {'stdin': subprocess.DEVNULL}
+    return subprocess.run(wrapped_cmd, cwd=cwd, input=controlled_input, text=True, encoding='utf-8', **stdin_arg, timeout=timeout, shell=use_shell)
+
+
+def resolve_copilot_runner(runtime: str) -> dict:
+    direct = runtime_command_source('copilot', runtime)
+    if direct:
+        return {
+            'mode': 'direct',
+            'binary': 'copilot',
+            'path': direct,
+            'note': f'Using direct copilot inside {runtime}.',
+        }
+    gh = runtime_command_source('gh', runtime)
+    if gh:
+        return {
+            'mode': 'gh',
+            'binary': 'gh copilot',
+            'path': gh,
+            'note': f'Falling back to same-runtime gh copilot inside {runtime} because direct copilot is unavailable there.',
+        }
+    return {
+        'mode': 'missing',
+        'binary': 'copilot',
+        'path': None,
+        'note': f'No direct copilot or gh fallback found inside {runtime}.',
+    }
+
+
+def copilot_native_command(runtime: str, base_args: List[str]) -> List[str]:
+    runner = resolve_copilot_runner(runtime)
+    if runner['mode'] == 'direct':
+        return ['copilot'] + base_args
+    if runner['mode'] == 'gh':
+        return ['gh', 'copilot', '--'] + base_args
+    return ['copilot'] + base_args
+
+
+def detect(agent: str, runtime: str) -> dict:
+    info = AGENTS[agent]
+    meta = {
+        'agent': agent,
+        'aliases': sorted([alias for alias, canon in ALIASES.items() if canon == agent]),
+        'host_runtime': current_runtime(),
+        'target_runtime': runtime,
+        'cross_runtime': runtime != default_target_runtime(),
+        'note': info['note'],
+    }
+    if agent == 'copilot':
+        runner = resolve_copilot_runner(runtime)
+        version = None
+        if runner['path']:
+            try:
+                cp = run_capture(copilot_native_command(runtime, ['--version']), runtime=runtime, timeout=20)
+                version = summarize_output(cp, limit=200)
+            except Exception as exc:
+                version = f'version check failed: {exc}'
+        return {
+            **meta,
+            'binary': runner['binary'],
+            'path': runner['path'],
+            'installed': bool(runner['path']),
+            'version': version,
+            'runner_mode': runner['mode'],
+            'runner_note': runner['note'],
+        }
+
+    binary = str(info['binary'])
+    path = runtime_command_source(binary, runtime)
+    version = None
+    if path:
+        try:
+            cp = run_capture(list(info['version_cmd']), runtime=runtime, timeout=20)
+            version = summarize_output(cp, limit=200)
+        except Exception as exc:
+            version = f'version check failed: {exc}'
+    return {
+        **meta,
+        'binary': binary,
+        'path': path,
+        'installed': bool(path),
+        'version': version,
+    }
+
+
+def do_check(agent: str, smoke: bool, workdir: WorkdirContext, timeout: int, runtime: str) -> dict:
+    result = detect(agent, runtime)
+    if not result['installed']:
+        result['check_ok'] = False
+        result['check_output'] = 'binary not found'
+        result['smoke_ok'] = None
+        return result
+
+    if agent == 'copilot':
+        try:
+            cp = run_capture(copilot_native_command(runtime, ['--help']), runtime=runtime, workdir=workdir, timeout=timeout)
+            result['check_ok'] = cp.returncode == 0
+            result['check_output'] = summarize_output(cp)
+            result['check_exit_code'] = cp.returncode
+        except Exception as exc:
+            result['check_ok'] = False
+            result['check_output'] = str(exc)
+            result['check_exit_code'] = None
+
+        if smoke:
+            try:
+                cp = run_capture(copilot_native_command(runtime, ['-p', 'Respond with exactly: COPILOT_SMOKE_OK', '--allow-all-tools']), runtime=runtime, workdir=workdir, timeout=timeout)
+                output = summarize_output(cp, limit=2000)
+                result['smoke_ok'] = (cp.returncode == 0 and 'COPILOT_SMOKE_OK' in output)
+                result['smoke_output'] = output
+                result['smoke_exit_code'] = cp.returncode
+            except subprocess.TimeoutExpired as exc:
+                result['smoke_ok'] = False
+                result['smoke_output'] = f'timed out after {timeout} seconds'
+                result['smoke_timeout'] = timeout_summary(exc)
+                result['smoke_exit_code'] = None
+            except Exception as exc:
+                result['smoke_ok'] = False
+                result['smoke_output'] = str(exc)
+                result['smoke_exit_code'] = None
+        else:
+            result['smoke_ok'] = None
+        return result
+
+    info = AGENTS[agent]
+    try:
+        cp = run_capture(list(info['check_cmd']), runtime=runtime, workdir=workdir, timeout=timeout)
+        result['check_ok'] = cp.returncode == 0
+        result['check_output'] = summarize_output(cp)
+        result['check_exit_code'] = cp.returncode
+    except Exception as exc:
+        result['check_ok'] = False
+        result['check_output'] = str(exc)
+        result['check_exit_code'] = None
+
+    if smoke:
+        try:
+            cp = run_capture(list(info['smoke_cmd']), runtime=runtime, workdir=workdir, timeout=timeout)
+            output = summarize_output(cp, limit=2000)
+            token = str(info['smoke_token'])
+            result['smoke_ok'] = (cp.returncode == 0 and token in output)
+            result['smoke_output'] = output
+            result['smoke_exit_code'] = cp.returncode
+        except subprocess.TimeoutExpired as exc:
+            result['smoke_ok'] = False
+            result['smoke_output'] = f'timed out after {timeout} seconds'
+            result['smoke_timeout'] = timeout_summary(exc)
+            result['smoke_exit_code'] = None
+        except Exception as exc:
+            result['smoke_ok'] = False
+            result['smoke_output'] = str(exc)
+            result['smoke_exit_code'] = None
+    else:
+        result['smoke_ok'] = None
+    return result
+
+
+def build_run_command(agent: str, prompt: str, output_format: str, model: Optional[str], allow_write: bool, yolo: bool, extra_args: List[str], workdir: WorkdirContext, runtime: str) -> List[str]:
+    if agent == 'claude':
+        cmd = ['claude', '-p', prompt, '--output-format', output_format, '--no-session-persistence']
+        if model:
+            cmd += ['--model', model]
+        if yolo:
+            cmd += ['--permission-mode', 'bypassPermissions']
+        elif allow_write:
+            cmd += ['--permission-mode', 'acceptEdits']
+        else:
+            cmd += ['--permission-mode', 'plan']
+        cmd += extra_args
+        return cmd
+
+    if agent == 'codex':
+        cmd = ['codex', 'exec', '--skip-git-repo-check']
+        if model:
+            cmd += ['--model', model]
+        if yolo:
+            cmd += ['--dangerously-bypass-approvals-and-sandbox']
+        else:
+            cmd += ['--sandbox', 'workspace-write' if allow_write else 'read-only']
+        if output_format == 'json':
+            cmd += ['--json']
+        cmd += extra_args
+        cmd += [prompt]
+        return cmd
+
+    if agent == 'gemini':
+        cmd = ['gemini', '-p', prompt, '--output-format', output_format]
+        if model:
+            cmd += ['--model', model]
+        if yolo:
+            cmd += ['--yolo']
+        else:
+            cmd += ['--approval-mode', 'auto_edit' if allow_write else 'plan']
+        cmd += extra_args
+        return cmd
+
+    if agent == 'opencode':
+        cmd = ['opencode', 'run', prompt, '--dir', workdir.target_path]
+        if model:
+            cmd += ['--model', model]
+        if output_format == 'json':
+            cmd += ['--format', 'json']
+        if allow_write or yolo:
+            cmd += ['--dangerously-skip-permissions']
+        cmd += extra_args
+        return cmd
+
+    if agent == 'qwen':
+        cmd = ['qwen', prompt, '--output-format', output_format]
+        if model:
+            cmd += ['--model', model]
+        if yolo:
+            cmd += ['--yolo']
+        else:
+            cmd += ['--approval-mode', 'auto-edit' if allow_write else 'plan']
+        cmd += extra_args
+        return cmd
+
+    if agent == 'copilot':
+        cmd = ['-p', prompt, '--add-dir', workdir.target_path]
+        if output_format != 'text':
+            cmd += ['--output-format', 'json']
+        if yolo or allow_write:
+            cmd += ['--allow-all']
+        else:
+            cmd += ['--allow-all-tools']
+        if model:
+            cmd += ['--model', model]
+        cmd += extra_args
+        return copilot_native_command(runtime, cmd)
+
+    raise SystemExit(f'Unsupported agent: {agent}')
+
+
+def route_candidates(current_agent: str, runtime: str, requested_agent: Optional[str] = None) -> dict:
+    requested = canonical_agent(requested_agent) if requested_agent else None
+    order = [agent for agent in DEFAULT_AGENT_ORDER if agent != current_agent]
+    if requested and requested != current_agent:
+        order = [requested] + [agent for agent in order if agent != requested]
+        order.append(current_agent)
+    elif requested and requested == current_agent:
+        order = [current_agent] + [agent for agent in DEFAULT_AGENT_ORDER if agent != current_agent]
+    else:
+        order.append(current_agent)
+
+    detections = {agent: detect(agent, runtime) for agent in DEFAULT_AGENT_ORDER}
+    candidates = []
+    for agent in order:
+        if requested and requested == current_agent and agent == current_agent:
+            reason = 'explicit-self-override'
+        elif requested and agent == requested:
+            reason = 'explicit-target'
+        elif agent == current_agent:
+            reason = 'self-fallback'
+        else:
+            reason = 'peer-first'
+        candidates.append({
+            'agent': agent,
+            'installed': bool(detections[agent]['installed']),
+            'reason': reason,
+            'path': detections[agent]['path'],
+        })
+    return {
+        'host_runtime': current_runtime(),
+        'target_runtime': runtime,
+        'cross_runtime': runtime != default_target_runtime(),
+        'current_agent': current_agent,
+        'requested_agent': requested,
+        'policy': {
+            'same_runtime_default': True,
+            'cross_runtime_requires_explicit_choice': True,
+            'peer_first': True,
+            'self_fallback_last': requested != current_agent,
+        },
+        'ordered_candidates': candidates,
+    }
+
+
+def print_json(data: object) -> None:
+    # Ensure UTF-8 output on Windows
+    if sys.platform == 'win32':
+        import io
+        # Reconfigure stdout to use UTF-8 encoding
+        if hasattr(sys.stdout, 'reconfigure'):
+            sys.stdout.reconfigure(encoding='utf-8')
+        else:
+            sys.stdout = io.TextIOWrapper(sys.stdout.buffer, encoding='utf-8')
+    json.dump(data, sys.stdout, ensure_ascii=False, indent=2)
+    sys.stdout.write('\n')
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description='Unified wrapper for explicit local CLI agent interop with runtime-local routing by default.')
+    sub = parser.add_subparsers(dest='command', required=True)
+
+    p_list = sub.add_parser('list', help='List known agents and installation status for the selected runtime.')
+    p_list.add_argument('--runtime', choices=['current', 'windows', 'wsl'], default='current', help='Target runtime. Default keeps execution in the current runtime.')
+
+    p_route = sub.add_parser('route', help='Show peer-first route order for the current agent inside the selected runtime.')
+    p_route.add_argument('--current-agent', required=True, help='Current/orchestrator agent name')
+    p_route.add_argument('--requested-agent', help='Optional explicit target agent to move to the front')
+    p_route.add_argument('--runtime', choices=['current', 'windows', 'wsl'], default='current', help='Target runtime. Cross-runtime requires explicit choice.')
+
+    p_check = sub.add_parser('check', help='Run readiness checks for one agent or all agents in the selected runtime.')
+    p_check.add_argument('agent', nargs='?', default='all', help='Agent name or all')
+    p_check.add_argument('--smoke', action='store_true', help='Run live smoke prompts in addition to fast checks')
+    p_check.add_argument('--workdir', default='.', help='Workdir for checks/smoke tests')
+    p_check.add_argument('--timeout', type=int, default=90, help='Timeout per check in seconds. Codex smoke can take longer because plugin/MCP shutdown is part of the CLI lifecycle.')
+    p_check.add_argument('--runtime', choices=['current', 'windows', 'wsl'], default='current', help='Target runtime. Cross-runtime requires explicit choice.')
+
+    p_run = sub.add_parser('run', help='Run one bounded non-interactive task through a target agent.')
+    p_run.add_argument('agent', help='Target agent name or alias')
+    p_run.add_argument('--prompt', required=True, help='Prompt to send to the target agent')
+    p_run.add_argument('--workdir', default='.', help='Working directory (Windows path or WSL path)')
+    p_run.add_argument('--runtime', choices=['current', 'windows', 'wsl'], default='current', help='Target runtime. Default stays in the current runtime.')
+    p_run.add_argument('--current-agent', help='Optional current/orchestrator agent name for metadata')
+    p_run.add_argument('--output-format', choices=['text', 'json', 'stream-json'], default='text')
+    p_run.add_argument('--model', help='Optional model override where the target agent supports it')
+    p_run.add_argument('--allow-write', action='store_true', help='Allow edit-capable execution where supported')
+    p_run.add_argument('--yolo', action='store_true', help='Opt into broad auto-approval / low-friction mode where supported')
+    p_run.add_argument('--extra-arg', action='append', default=[], help='Repeatable extra native CLI arg appended after the wrapper defaults')
+    p_run.add_argument('--timeout', type=int, default=0, help='Optional timeout in seconds (0 = no timeout). Prefer at least 120 for Codex runs that load plugins or MCP servers.')
+    p_run.add_argument('--dry-run', action='store_true', help='Print the resolved command instead of executing it')
+
+    args = parser.parse_args()
+    runtime = effective_runtime(getattr(args, 'runtime', 'current'))
+
+    if args.command == 'list':
+        print_json([detect(agent, runtime) for agent in DEFAULT_AGENT_ORDER])
+        return 0
+
+    if args.command == 'route':
+        current_agent = canonical_agent(args.current_agent)
+        print_json(route_candidates(current_agent=current_agent, runtime=runtime, requested_agent=args.requested_agent))
+        return 0
+
+    if args.command == 'check':
+        workdir = resolve_workdir(args.workdir, runtime)
+        targets = DEFAULT_AGENT_ORDER if args.agent == 'all' else [canonical_agent(args.agent)]
+        data = [do_check(agent, smoke=args.smoke, workdir=workdir, timeout=args.timeout, runtime=runtime) for agent in targets]
+        print_json(data)
+        return 0 if all(item.get('check_ok') or not item.get('installed') for item in data) else 1
+
+    if args.command == 'run':
+        agent = canonical_agent(args.agent)
+        current_agent = canonical_agent(args.current_agent) if args.current_agent else None
+        workdir = resolve_workdir(args.workdir, runtime)
+        cmd = build_run_command(
+            agent=agent,
+            prompt=args.prompt,
+            output_format=args.output_format,
+            model=args.model,
+            allow_write=args.allow_write,
+            yolo=args.yolo,
+            extra_args=args.extra_arg,
+            workdir=workdir,
+            runtime=runtime,
+        )
+        wrapped_cmd, _ = wrap_command_for_runtime(cmd, runtime, workdir)
+        printable = ' '.join(shlex.quote(part) for part in wrapped_cmd)
+        meta = {
+            'agent': agent,
+            'current_agent': current_agent,
+            'host_runtime': current_runtime(),
+            'target_runtime': runtime,
+            'cross_runtime': runtime != default_target_runtime(),
+            'workdir_host_path': str(workdir.host_path),
+            'workdir_target_path': workdir.target_path,
+            'command': printable,
+            'dry_run': args.dry_run,
+        }
+        if args.dry_run:
+            print_json(meta)
+            return 0
+        if not workdir.host_path.exists():
+            print_json({**meta, 'error': f'workdir does not exist: {workdir.host_path}'})
+            return 2
+        timeout = None if args.timeout == 0 else args.timeout
+        try:
+            completed = run_live(cmd, runtime=runtime, workdir=workdir, timeout=timeout)
+            return completed.returncode
+        except subprocess.TimeoutExpired as exc:
+            print_json({**meta, 'error': f'timed out after {args.timeout} seconds', **timeout_summary(exc)})
+            return 124
+
+    return 0
+
+
+if __name__ == '__main__':
+    raise SystemExit(main())

--- a/cli-agent-interop/tests/test_agent_bridge.py
+++ b/cli-agent-interop/tests/test_agent_bridge.py
@@ -1,0 +1,115 @@
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+
+SCRIPT_DIR = Path(__file__).resolve().parents[1] / "scripts"
+sys.path.insert(0, str(SCRIPT_DIR))
+
+import agent_bridge  # noqa: E402
+
+
+class FakePopen:
+    calls = []
+
+    def __init__(self, cmd, **kwargs):
+        self.cmd = cmd
+        self.kwargs = kwargs
+        self.pid = 12345
+        self.returncode = 0
+        FakePopen.calls.append(self)
+
+    def communicate(self, input=None, timeout=None):
+        self.input = input
+        self.timeout = timeout
+        return ("ok", "")
+
+
+def test_run_capture_detaches_child_stdin_on_windows(monkeypatch):
+    FakePopen.calls = []
+    monkeypatch.setattr(agent_bridge.sys, "platform", "win32")
+    monkeypatch.setattr(agent_bridge, "wrap_command_for_runtime", lambda cmd, runtime, workdir=None: (cmd, None))
+    monkeypatch.setattr(agent_bridge.subprocess, "Popen", FakePopen)
+
+    cp = agent_bridge.run_capture(["opencode", "run", "prompt"], runtime="windows")
+
+    assert cp.returncode == 0
+    assert FakePopen.calls[0].kwargs["shell"] is True
+    assert FakePopen.calls[0].kwargs["stdin"] is subprocess.DEVNULL
+
+
+def test_run_live_detaches_child_stdin_on_windows(monkeypatch):
+    calls = []
+
+    def fake_run(cmd, **kwargs):
+        calls.append((cmd, kwargs))
+        return subprocess.CompletedProcess(cmd, 0)
+
+    monkeypatch.setattr(agent_bridge.sys, "platform", "win32")
+    monkeypatch.setattr(agent_bridge, "wrap_command_for_runtime", lambda cmd, runtime, workdir=None: (cmd, None))
+    monkeypatch.setattr(agent_bridge.subprocess, "run", fake_run)
+
+    cp = agent_bridge.run_live(["opencode", "run", "prompt"], runtime="windows", workdir=None, timeout=60)
+
+    assert cp.returncode == 0
+    assert calls[0][1]["shell"] is True
+    assert calls[0][1]["stdin"] is subprocess.DEVNULL
+
+
+def test_codex_exec_prompt_uses_controlled_stdin(monkeypatch):
+    FakePopen.calls = []
+    monkeypatch.setattr(agent_bridge.sys, "platform", "win32")
+    monkeypatch.setattr(agent_bridge, "wrap_command_for_runtime", lambda cmd, runtime, workdir=None: (cmd, None))
+    monkeypatch.setattr(agent_bridge.subprocess, "Popen", FakePopen)
+
+    agent_bridge.run_capture(["codex", "exec", "--sandbox", "read-only", "hello"], runtime="windows")
+
+    assert FakePopen.calls[0].cmd == ["codex", "exec", "--sandbox", "read-only", "-"]
+    assert FakePopen.calls[0].input == "hello"
+    assert FakePopen.calls[0].kwargs["stdin"] == subprocess.PIPE
+
+
+def test_codex_exec_option_is_not_treated_as_prompt(monkeypatch):
+    FakePopen.calls = []
+    monkeypatch.setattr(agent_bridge.sys, "platform", "win32")
+    monkeypatch.setattr(agent_bridge, "wrap_command_for_runtime", lambda cmd, runtime, workdir=None: (cmd, None))
+    monkeypatch.setattr(agent_bridge.subprocess, "Popen", FakePopen)
+
+    agent_bridge.run_capture(["codex", "exec", "--help"], runtime="windows")
+
+    assert FakePopen.calls[0].cmd == ["codex", "exec", "--help"]
+    assert FakePopen.calls[0].kwargs["stdin"] is subprocess.DEVNULL
+    assert FakePopen.calls[0].input is None
+
+
+def test_run_capture_kills_process_tree_on_timeout(monkeypatch):
+    class TimeoutPopen(FakePopen):
+        def communicate(self, input=None, timeout=None):
+            raise subprocess.TimeoutExpired(self.cmd, timeout, output="partial", stderr="late")
+
+    killed = []
+    FakePopen.calls = []
+    monkeypatch.setattr(agent_bridge.sys, "platform", "win32")
+    monkeypatch.setattr(agent_bridge, "wrap_command_for_runtime", lambda cmd, runtime, workdir=None: (cmd, None))
+    monkeypatch.setattr(agent_bridge.subprocess, "Popen", TimeoutPopen)
+    monkeypatch.setattr(agent_bridge, "terminate_process_tree", lambda pid: killed.append(pid))
+
+    with pytest.raises(subprocess.TimeoutExpired) as exc:
+        agent_bridge.run_capture(["codex", "exec", "hello"], runtime="windows", timeout=10)
+
+    assert killed == [12345]
+    assert exc.value.output == "partial"
+    assert exc.value.stderr == "late"
+
+
+def test_timeout_summary_includes_captured_partial_output():
+    exc = subprocess.TimeoutExpired(["codex"], timeout=60, output="final answer\n", stderr="shutdown warning\n")
+
+    summary = agent_bridge.timeout_summary(exc, limit=200)
+
+    assert summary["timed_out_after"] == 60
+    assert summary["partial_output_emitted"] is True
+    assert "final answer" in summary["partial_output"]
+    assert "shutdown warning" in summary["partial_output"]


### PR DESCRIPTION
## Summary
- Add the cli-agent-interop skill with a bounded cross-agent wrapper.
- Route Codex prompts through controlled stdin using `codex exec ... -` to avoid inherited-stdin prompt contamination.
- Add Windows process-tree cleanup and structured timeout diagnostics for smoke checks.
- Document Codex/OpenCode readiness semantics and runtime-specific caveats.

## Verification
- `python -m pytest C:\Users\11\.agents\worktrees\cli-agent-interop-pr-20260604011143\cli-agent-interop\tests\test_agent_bridge.py` -> 6 passed
- `agent_bridge.py run codex --prompt "Respond with exactly: CODEX_DELEGATION_FIXED_OK" --runtime current --workdir . --timeout 120` -> returned `CODEX_DELEGATION_FIXED_OK` locally
- `agent_bridge.py run opencode --prompt "Respond with exactly: OPENCODE_DELEGATION_OK" --runtime current --workdir . --timeout 120` -> returned `OPENCODE_DELEGATION_OK` locally
