### PR TITLE
feat: add RunAPI CLI skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -327,7 +327,7 @@ Key source families include:
 - **[huggingface/skills](https://github.com/huggingface/skills)**: Official Hugging Face skills - Models, Spaces, datasets, inference, and broader Hugging Face ecosystem workflows.
 - **[longbridge/skills](https://github.com/longbridge/skills)**: Official Longbridge Securities skills - real-time quotes, charts, fundamentals, portfolio analysis, options, and market workflows for HK, US, A-share, and SG markets.
 - **[HasData/hasdata-cli](https://github.com/HasData/hasdata-cli)**: Official HasData CLI and API guidance for search, scraping, ecommerce, travel, jobs, local business, and structured web data workflows.
-- **[runapi-ai/cli-skill](https://github.com/runapi-ai/cli-skill)**: Official RunAPI CLI skill - run AI image, video, music, audio, and other model API jobs from agent workflows.
+- **[runapi-ai/cli-skill](https://github.com/runapi-ai/cli-skill)**: Official RunAPI CLI skill - generate AI images, videos, and music/audio from agent workflows, plus run other model API jobs.
 - **[neondatabase/agent-skills](https://github.com/neondatabase/agent-skills)**: Official Neon skills - Serverless Postgres workflows and Neon platform guidance.
 - **[Skyvern-AI/skyvern](https://github.com/Skyvern-AI/skyvern)**: Official Skyvern browser automation skill — AI-powered browser control using Vision LLMs and computer vision for navigating sites, filling forms, and extracting structured data.
 - **[scopeblind/scopeblind-gateway](https://github.com/scopeblind/scopeblind-gateway)**: Official Scopeblind MCP governance toolkit - Cedar policy authoring, shadow-to-enforce rollout, and signed-receipt verification guidance for agent tool calls.

--- a/README.md
+++ b/README.md
@@ -327,6 +327,7 @@ Key source families include:
 - **[huggingface/skills](https://github.com/huggingface/skills)**: Official Hugging Face skills - Models, Spaces, datasets, inference, and broader Hugging Face ecosystem workflows.
 - **[longbridge/skills](https://github.com/longbridge/skills)**: Official Longbridge Securities skills - real-time quotes, charts, fundamentals, portfolio analysis, options, and market workflows for HK, US, A-share, and SG markets.
 - **[HasData/hasdata-cli](https://github.com/HasData/hasdata-cli)**: Official HasData CLI and API guidance for search, scraping, ecommerce, travel, jobs, local business, and structured web data workflows.
+- **[runapi-ai/cli-skill](https://github.com/runapi-ai/cli-skill)**: Official RunAPI CLI skill - run AI image, video, music, audio, and other model API jobs from agent workflows.
 - **[neondatabase/agent-skills](https://github.com/neondatabase/agent-skills)**: Official Neon skills - Serverless Postgres workflows and Neon platform guidance.
 - **[Skyvern-AI/skyvern](https://github.com/Skyvern-AI/skyvern)**: Official Skyvern browser automation skill — AI-powered browser control using Vision LLMs and computer vision for navigating sites, filling forms, and extracting structured data.
 - **[scopeblind/scopeblind-gateway](https://github.com/scopeblind/scopeblind-gateway)**: Official Scopeblind MCP governance toolkit - Cedar policy authoring, shadow-to-enforce rollout, and signed-receipt verification guidance for agent tool calls.

--- a/docs/sources/sources.md
+++ b/docs/sources/sources.md
@@ -11,6 +11,7 @@ If you recognize your work here and it is not properly attributed, please open a
 | `burp-suite-testing`        | [PortSwigger](https://portswigger.net/burp)                                | N/A            | Usage guide only (no binary). |
 | `crewai`                    | [CrewAI](https://github.com/joaomdmoura/crewAI)                            | MIT            | Framework guides.             |
 | `hasdata`, `hasdata-cli`    | [HasData CLI](https://github.com/HasData/hasdata-cli)                      | MIT            | Official HasData API and CLI guidance. |
+| `runapi-cli`                | [RunAPI CLI Skill](https://github.com/runapi-ai/cli-skill)                 | Apache-2.0     | Official RunAPI CLI skill for model API jobs. |
 | `langgraph`                 | [LangGraph](https://github.com/langchain-ai/langgraph)                     | MIT            | Framework guides.             |
 | `react-patterns`            | [React Docs](https://react.dev/)                                           | CC-BY          | Official patterns.            |
 | **All Official Skills**     | [Anthropic / Google / OpenAI / Microsoft / Supabase / Apify / Vercel Labs] | Proprietary    | Usage encouraged by vendors.  |

--- a/docs/sources/sources.md
+++ b/docs/sources/sources.md
@@ -11,7 +11,7 @@ If you recognize your work here and it is not properly attributed, please open a
 | `burp-suite-testing`        | [PortSwigger](https://portswigger.net/burp)                                | N/A            | Usage guide only (no binary). |
 | `crewai`                    | [CrewAI](https://github.com/joaomdmoura/crewAI)                            | MIT            | Framework guides.             |
 | `hasdata`, `hasdata-cli`    | [HasData CLI](https://github.com/HasData/hasdata-cli)                      | MIT            | Official HasData API and CLI guidance. |
-| `runapi-cli`                | [RunAPI CLI Skill](https://github.com/runapi-ai/cli-skill)                 | Apache-2.0     | Official RunAPI CLI skill for AI image, video, music, audio, and other model API jobs. |
+| `runapi-cli`                | [RunAPI CLI Skill](https://github.com/runapi-ai/cli-skill)                 | Apache-2.0     | Official RunAPI CLI skill for generating AI images, videos, and music/audio, plus other model API jobs. |
 | `langgraph`                 | [LangGraph](https://github.com/langchain-ai/langgraph)                     | MIT            | Framework guides.             |
 | `react-patterns`            | [React Docs](https://react.dev/)                                           | CC-BY          | Official patterns.            |
 | **All Official Skills**     | [Anthropic / Google / OpenAI / Microsoft / Supabase / Apify / Vercel Labs] | Proprietary    | Usage encouraged by vendors.  |

--- a/docs/sources/sources.md
+++ b/docs/sources/sources.md
@@ -11,7 +11,7 @@ If you recognize your work here and it is not properly attributed, please open a
 | `burp-suite-testing`        | [PortSwigger](https://portswigger.net/burp)                                | N/A            | Usage guide only (no binary). |
 | `crewai`                    | [CrewAI](https://github.com/joaomdmoura/crewAI)                            | MIT            | Framework guides.             |
 | `hasdata`, `hasdata-cli`    | [HasData CLI](https://github.com/HasData/hasdata-cli)                      | MIT            | Official HasData API and CLI guidance. |
-| `runapi-cli`                | [RunAPI CLI Skill](https://github.com/runapi-ai/cli-skill)                 | Apache-2.0     | Official RunAPI CLI skill for model API jobs. |
+| `runapi-cli`                | [RunAPI CLI Skill](https://github.com/runapi-ai/cli-skill)                 | Apache-2.0     | Official RunAPI CLI skill for AI image, video, music, audio, and other model API jobs. |
 | `langgraph`                 | [LangGraph](https://github.com/langchain-ai/langgraph)                     | MIT            | Framework guides.             |
 | `react-patterns`            | [React Docs](https://react.dev/)                                           | CC-BY          | Official patterns.            |
 | **All Official Skills**     | [Anthropic / Google / OpenAI / Microsoft / Supabase / Apify / Vercel Labs] | Proprietary    | Usage encouraged by vendors.  |

--- a/skills/runapi-cli/SKILL.md
+++ b/skills/runapi-cli/SKILL.md
@@ -1,0 +1,138 @@
+---
+name: runapi-cli
+description: Run RunAPI model jobs from agents using the RunAPI CLI.
+category: development
+risk: safe
+source: official
+source_repo: runapi-ai/cli-skill
+source_type: official
+date_added: "2026-06-07"
+author: runapi-ai
+tags: [runapi, cli, models, automation, codex, claude, gemini]
+tools: [claude, codex, gemini, cursor, antigravity]
+license: "Apache-2.0"
+license_source: "https://github.com/runapi-ai/cli-skill/blob/main/LICENSE"
+---
+
+# RunAPI CLI
+
+## Overview
+
+The `runapi` CLI is the execution layer for RunAPI model tasks. Use it when an agent needs to run a one-off model job, pass a JSON request body, wait for an async task, or script RunAPI from a terminal, server, or CI job.
+
+Source repository: [github.com/runapi-ai/cli-skill](https://github.com/runapi-ai/cli-skill) (Apache-2.0)
+
+## When to Use This Skill
+
+- Use when the user asks to run a RunAPI model from an agent.
+- Use when the user needs to inspect RunAPI CLI auth or account status.
+- Use when the user wants to pass JSON request bodies to RunAPI services.
+- Use when the user wants to submit async RunAPI tasks and wait for completion.
+- Use when the user wants to install the RunAPI CLI on a local machine, server, or CI runner.
+
+## Install
+
+### macOS / Linux
+
+```shell
+brew install runapi-ai/tap/runapi
+```
+
+### Server / CI
+
+Download the installer, inspect it, then run it locally.
+
+```shell
+curl -fsSL https://runapi.ai/cli/install.sh -o runapi-install.sh
+less runapi-install.sh
+sh runapi-install.sh
+```
+
+To pin a specific version:
+
+```shell
+sh runapi-install.sh --version v0.1.0
+```
+
+The installer detects OS and architecture, verifies the SHA-256 checksum from `https://runapi.ai/cli/latest.json`, and refuses to write the binary if verification fails.
+
+## Authentication
+
+Check the current state first:
+
+```shell
+runapi auth status
+```
+
+| Source | How |
+|---|---|
+| Environment | Read `RUNAPI_API_KEY` from the environment |
+| Saved config | `printf '%s' "$RUNAPI_API_KEY" \| runapi auth import-token --token -` |
+| Browser login | `runapi login` only when the user explicitly wants browser auth |
+
+`RUNAPI_BASE_URL` overrides the default base URL.
+
+Avoid passing secrets directly in command arguments. Prefer `RUNAPI_API_KEY` or stdin token import with `--token -`.
+
+## Discover Services, Commands, and Fields
+
+The CLI is JSON-first. Every service exposes typed commands, and each command documents its request fields through `--help`. Inspect command help before composing a request.
+
+```shell
+runapi --help
+runapi suno --help
+runapi suno text-to-music --help
+```
+
+## Run a Model
+
+Pass the request body as JSON through `--input-file`, `--input`, or stdin. The default flow is synchronous and polls until the task completes.
+
+```shell
+runapi suno text-to-music --input-file request.json
+
+runapi suno text-to-music --async --input-file request.json
+runapi wait <task-id> --service suno --action text-to-music
+
+runapi get <task-id> --service suno --action text-to-music
+```
+
+JSON responses go to stdout; progress lines go to stderr. Pipe to `jq` for downstream parsing.
+
+## Account
+
+```shell
+runapi account info
+runapi account balance
+```
+
+## Install the Skill Into Another Agent Runtime
+
+```shell
+runapi agent install-skill --target claude
+runapi agent install-skill --target codex
+runapi agent install-skill --target gemini
+runapi agent install-skill --target openclaw
+runapi agent list-targets
+runapi agent install-skill --target-dir <path>
+```
+
+## Limitations
+
+- RunAPI model calls require a valid RunAPI account or API key.
+- Some model tasks are long-running and should use `--async` plus `runapi wait`.
+- Browser login is interactive and should not be the default path for agents.
+- This skill does not replace model-specific parameter validation; inspect command help before building request JSON.
+
+## Security & Safety Notes
+
+- Never paste API keys into example commands or PR text.
+- Prefer `RUNAPI_API_KEY` or stdin token import instead of command-line secrets.
+- Do not run interactive `runapi login` by default from an agent.
+- Check the CLI exit code before assuming a task succeeded.
+
+## References
+
+- RunAPI CLI skill: https://github.com/runapi-ai/cli-skill
+- RunAPI CLI repository: https://github.com/runapi-ai/cli
+- RunAPI model catalog: https://runapi.ai/models.md

--- a/skills/runapi-cli/SKILL.md
+++ b/skills/runapi-cli/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: runapi-cli
-description: Run RunAPI model jobs from agents using the RunAPI CLI.
+description: Generate AI images, videos, and music/audio from agents using the RunAPI CLI.
 category: development
 risk: safe
 source: official
@@ -18,7 +18,7 @@ license_source: "https://github.com/runapi-ai/cli-skill/blob/main/LICENSE"
 
 ## Overview
 
-The `runapi` CLI is the execution layer for RunAPI model tasks. Use it when an agent needs to run a one-off model job, pass a JSON request body, wait for an async task, or script RunAPI from a terminal, server, or CI job.
+The `runapi` CLI is the execution layer for RunAPI model tasks. Use it when an agent needs to generate AI images, videos, or music/audio, run a one-off model job, pass a JSON request body, wait for an async task, or script RunAPI from a terminal, server, or CI job.
 
 Source repository: [github.com/runapi-ai/cli-skill](https://github.com/runapi-ai/cli-skill) (Apache-2.0)
 


### PR DESCRIPTION
Adds the official RunAPI CLI skill as a source-only skill entry. It covers generating AI images, videos, and music/audio from agent workflows, plus other model API jobs.

Validation: markdown-only copy update; no install or build run.

## Change Classification

- [ ] Skill PR
- [ ] Docs PR
- [ ] Infra PR

## Issue Link (Optional)

Use this only when the PR should auto-close an issue:

`Closes #N` or `Fixes #N`

## Quality Bar Checklist ✅

**All applicable items must be checked before merging.**

- [ ] **Standards**: I have read `docs/contributors/quality-bar.md` and `docs/contributors/security-guardrails.md`.
- [ ] **Metadata**: The `SKILL.md` frontmatter is valid (checked with `npm run validate`).
- [ ] **Risk Label**: I have assigned the correct `risk:` tag (`none`, `safe`, `critical`, `offensive`, or `unknown` for legacy/unclassified content).
- [ ] **Triggers**: The "When to use" section is clear and specific.
- [ ] **Limitations**: The skill includes a `## Limitations` (or equivalent accepted constraints) section.
- [ ] **Security**: If this is an _offensive_ skill, I included the "Authorized Use Only" disclaimer.
- [ ] **Safety scan**: If this PR adds or modifies `SKILL.md` command guidance, remote/network examples, or token-like strings, I ran `npm run security:docs` (or equivalent hardening check) and addressed any findings.
- [ ] **Automated Skill Review**: If this PR changes `SKILL.md`, I checked the `skill-review` GitHub Actions result and addressed any actionable feedback.
- [ ] **Manual Logic Review**: If this PR changes `SKILL.md` or risky guidance, I manually reviewed the logic, safety, failure modes, and `risk:` label instead of relying on automated checks alone.
- [ ] **Local Test**: I have verified the skill works locally.
- [ ] **Repo Checks**: I ran `npm run validate:references` if my change affected docs, workflows, or infrastructure.
- [ ] **Source-Only PR**: I did not manually include generated registry artifacts (`CATALOG.md`, `skills_index.json`, `data/*.json`) in this PR.
- [ ] **Credits**: I have added the source credit in `README.md` (if applicable).
- [ ] **License provenance**: If this skill imports from an external `source_repo`, I have declared `license:` and `license_source:` in the frontmatter, or confirmed the upstream repo carries no restricting license.
- [ ] **Maintainer Edits**: I enabled **Allow edits from maintainers** on the PR.

## Screenshots (if applicable)