### PR TITLE
update(polis-protocol): v2 — always-latest install via PyPI, polis CLI, corrected skill path

### DIFF
--- a/skills/polis-protocol/SKILL.md
+++ b/skills/polis-protocol/SKILL.md
@@ -37,19 +37,18 @@ In Antigravity specifically, this turns Manager View's fixed pipeline into a tea
 
 ### Step 1: Found a polis
 
-Clone a reviewed revision of the repo and run the scaffolder directly (review `install.sh` first if you prefer the one-line installer):
+Run the published CLI — `uvx` fetches the latest release from PyPI ([polis-protocol](https://pypi.org/project/polis-protocol/)), so you always get the current version:
 
 ```bash
-git clone https://github.com/yehudalevy-collab/polis-protocol.git
-cd polis-protocol
-git checkout <reviewed-commit-sha>
-python3 scripts/init_polis.py \
+uvx polis-protocol init \
   --project-root . \
   --agent-id gemini-antigravity-yourproject \
   --vendor google --model gemini-3 --tool antigravity
 ```
 
-This writes `_polis/` plus the skill into `.antigravity/skills/`, and bridge pointers (`GEMINI.md`, `AGENTS.md`) that point every tool at `_polis/CONSTITUTION.md`. Tip: add `--dry-run` to preview every file before anything is written.
+(Prefer a pinned, reviewed install? `pipx install polis-protocol==<version>`, or clone the repo and run `python3 scripts/init_polis.py` with the same flags.)
+
+This writes `_polis/` plus the skill into `.agents/skills/` (the path Antigravity reads), and bridge pointers (`GEMINI.md`, `AGENTS.md`) that point every tool at `_polis/CONSTITUTION.md`. Tip: add `--dry-run` to preview every file before anything is written; init never overwrites existing files, and `polis init --repair` restores missing ones.
 
 ### Step 2: Register citizens and open contracts
 
@@ -58,15 +57,20 @@ Each agent publishes a capability card under `_polis/citizens/`. Work is opened 
 ### Step 3: Route by track record
 
 ```bash
-python3 polis-protocol/scripts/route_contract.py --polis-root _polis \
+polis route --polis-root _polis \
   --contract _polis/contracts/open/your-task.md --explain
 ```
 
-The router prints a score breakdown (history / self-rating / cost / availability) and recommends the citizen with the strongest record on the task's tags.
+The router prints a score breakdown (history / self-rating / cost / availability / applied lessons) and recommends the citizen with the strongest record on the task's tags. Agents can also reserve files (`polis reserve src/auth --as <citizen>`) so two agents never edit the same path at once — overlapping claims are rejected with the holder named.
 
 ### Step 4: Settle, learn, and amend
 
-A settled contract files a lesson; `--reconcile` folds it into `routing_stats.yml` so the next similar task routes better. When a rule stops working, a citizen proposes an amendment and the others vote.
+```bash
+polis contract settle <contract-id> --quality 5
+polis reconcile --polis-root _polis
+```
+
+A settled contract files a lesson; accepted lessons carry a bounded `routing_effect` the router reads — and names in `--explain` — on the next similar task. Failures become guardrails (`polis guardrail add …`) that future contracts on those tags inherit as must-pass acceptance criteria. When a rule stops working, a citizen proposes an amendment and the others vote. Reproduce the learning claim yourself: `polis bench --mode learning`.
 
 ## Examples
 


### PR DESCRIPTION
Updates the existing `polis-protocol` skill (added in #648) to track the v2 release.

**What changed upstream:** polis-protocol shipped 2.0.0a0 on [PyPI](https://pypi.org/project/polis-protocol/) with a `polis` CLI, file reservations (deterministic collision prevention), lessons that measurably influence routing, guardrails, and a reproducible benchmark.

**Changes in this skill:**
- Install is now `uvx polis-protocol init` — users always get the latest release automatically (a pinned `pipx install polis-protocol==<version>` / repo-clone path is kept for reviewed installs).
- **Path correction:** the skill copy is written to `.agents/skills/` — the directory Antigravity actually reads (`.antigravity/skills/` was never read).
- Steps 3–4 use the v2 CLI: `polis route --explain` (now lists applied lessons), `polis contract settle` + `polis reconcile`, `polis reserve` (no two agents on the same file), `polis guardrail`, and `polis bench --mode learning` so users can reproduce the learning claim themselves.

No frontmatter/schema changes; same source repo and license.

## Change Classification

- [ ] Skill PR
- [ ] Docs PR
- [ ] Infra PR

## Issue Link (Optional)

Use this only when the PR should auto-close an issue:

`Closes #N` or `Fixes #N`

## Quality Bar Checklist ✅

**All applicable items must be checked before merging.**

- [ ] **Standards**: I have read `docs/contributors/quality-bar.md` and `docs/contributors/security-guardrails.md`.
- [ ] **Metadata**: The `SKILL.md` frontmatter is valid (checked with `npm run validate`).
- [ ] **Risk Label**: I have assigned the correct `risk:` tag (`none`, `safe`, `critical`, `offensive`, or `unknown` for legacy/unclassified content).
- [ ] **Triggers**: The "When to use" section is clear and specific.
- [ ] **Limitations**: The skill includes a `## Limitations` (or equivalent accepted constraints) section.
- [ ] **Security**: If this is an _offensive_ skill, I included the "Authorized Use Only" disclaimer.
- [ ] **Safety scan**: If this PR adds or modifies `SKILL.md` command guidance, remote/network examples, or token-like strings, I ran `npm run security:docs` (or equivalent hardening check) and addressed any findings.
- [ ] **Automated Skill Review**: If this PR changes `SKILL.md`, I checked the `skill-review` GitHub Actions result and addressed any actionable feedback.
- [ ] **Manual Logic Review**: If this PR changes `SKILL.md` or risky guidance, I manually reviewed the logic, safety, failure modes, and `risk:` label instead of relying on automated checks alone.
- [ ] **Local Test**: I have verified the skill works locally.
- [ ] **Repo Checks**: I ran `npm run validate:references` if my change affected docs, workflows, or infrastructure.
- [ ] **Source-Only PR**: I did not manually include generated registry artifacts (`CATALOG.md`, `skills_index.json`, `data/*.json`) in this PR.
- [ ] **Credits**: I have added the source credit in `README.md` (if applicable).
- [ ] **License provenance**: If this skill imports from an external `source_repo`, I have declared `license:` and `license_source:` in the frontmatter, or confirmed the upstream repo carries no restricting license.
- [ ] **Maintainer Edits**: I enabled **Allow edits from maintainers** on the PR.

## Screenshots (if applicable)