### PR TITLE
feat: add dos-verify-done-claims skill (gate agent done-claims on git ground truth)

### DIFF
--- a/README.md
+++ b/README.md
@@ -461,6 +461,7 @@ Key source families include:
 - **[LambdaTest/agent-skills](https://github.com/LambdaTest/agent-skills)**: Production-grade agent skills for test automation — 46 skills covering E2E, unit, mobile, BDD, visual, and cloud testing across 15+ languages (MIT).
 - **[flyingsquirrel0419/squirrel-skill](https://github.com/flyingsquirrel0419/squirrel-skill)**: Full-cycle software development skill — plans, builds, tests, lints, fixes bugs, and writes production-grade docs. Auto-detects project state and adapts its 8-phase pipeline. Works on 9 AI coding agent platforms (Apache 2.0).
 - **[CodeShuX/tokenwise](https://github.com/CodeShuX/tokenwise)**: Source for the `tokenwise` skill — measurement-driven Haiku/Sonnet/Opus router for Claude Code with per-task NDJSON logging, A/B test mode, and verified $-saved reports (MIT).
+- **[anthony-chaudhary/dos-kernel](https://github.com/anthony-chaudhary/dos-kernel)**: Source for the `dos-verify-done-claims` skill — gates an agent's "done / shipped / fixed" claim on git ground truth (ancestry + the commit's own diff) via the deterministic DOS kernel's read-only `dos verify` / `dos commit-audit` verbs (MIT).
 
 </details>
 

--- a/skills/dos-verify-done-claims/SKILL.md
+++ b/skills/dos-verify-done-claims/SKILL.md
@@ -71,15 +71,20 @@ If the agent claims a specific plan/phase landed, confirm it from git history
 rather than the transcript:
 
 ```bash
-dos verify --workspace . PLAN PHASE --json
+dos verify --workspace . PLAN PHASE --json --no-ci
 ```
 
-With `--json` you get the `shipped` and `source` fields. (The default text form
-prints `SHIPPED PLAN PHASE (via grep)` or `NOT_SHIPPED PLAN PHASE (via none)` —
-the same verdict, and the process exit code is non-zero when not shipped.)
-`shipped: true` with a `source` of `registry` or `grep` is real evidence;
-`source: none` means there is no positive evidence — accept that as "not shipped",
-not as a failure of the tool.
+`--no-ci` keeps the verdict git-only (see the Security note below). With `--json`
+you get the `shipped` and `source` fields. (The default text form prints
+`SHIPPED PLAN PHASE (via grep)` or `NOT_SHIPPED PLAN PHASE (via none)` — the same
+verdict, and the process exit code is non-zero when not shipped.)
+
+`shipped: true` is real evidence when `source` is `registry` or any value
+**starting with `grep`** — git fallback grades itself by forgeability, so you may
+see bare `grep`, `grep-artifact` (a non-forgeable artefact/diff rung), or
+`grep-subject` (a commit subject carried the phase token — shipped, but forgeable,
+so weaker). `source: none` means there is no positive evidence — accept that as
+"not shipped", not as a failure of the tool.
 
 ### Step 4: Fold only confirmed effects
 
@@ -101,8 +106,9 @@ dos commit-audit --workspace . HEAD --json
 ### Example 2: confirm a feature phase shipped before closing a ticket
 
 ```bash
-dos verify --workspace . AUTH AUTH2 --json
-# shipped: true, source: grep  -> a real ship commit exists; safe to close
+dos verify --workspace . AUTH AUTH2 --json --no-ci
+# shipped: true, source: grep-artifact -> a real ship commit exists; safe to close
+#   (source: registry, grep, or any grep-* value all count as real evidence)
 # shipped: false, source: none -> no evidence; keep the ticket open
 ```
 
@@ -124,9 +130,12 @@ dos verify --workspace . AUTH AUTH2 --json
 ## Security & Safety Notes
 
 - This skill runs shell commands: `pip install dos-kernel` and the read-only
-  `dos` verbs (`dos commit-audit`, `dos verify`). The `dos` verbs only **read**
-  git history and the working tree — they do not mutate the repo, push, or
-  network.
+  `dos` verbs (`dos commit-audit`, `dos verify`). These verbs never **mutate**
+  the repo or push. `dos commit-audit` only reads git history and the working
+  tree (no network). `dos verify` is also git-only **unless** the workspace has
+  wired a CI oracle (`[verify] non_git_oracle` in its `dos.toml`), in which case
+  it may shell a network check (e.g. `gh api`) for the verdict — pass `--no-ci`
+  (as the examples above do) to force the git-only path and guarantee no network.
 - `pip install dos-kernel` installs from PyPI. The distribution name is
   `dos-kernel` (the bare `dos` on PyPI is an unrelated package — do not install
   it). Pin a version in locked environments.

--- a/skills/dos-verify-done-claims/SKILL.md
+++ b/skills/dos-verify-done-claims/SKILL.md
@@ -1,0 +1,144 @@
+---
+name: dos-verify-done-claims
+description: "Before accepting an agent's 'done / shipped / fixed' claim, verify it against ground truth (git ancestry + the commit's own diff) using the DOS kernel's `dos verify` and `dos commit-audit` — never the agent's own narration."
+category: quality
+risk: safe
+source: community
+source_repo: anthony-chaudhary/dos-kernel
+source_type: community
+date_added: "2026-06-12"
+author: anthony-chaudhary
+tags: [verification, git, ai-agents, trust, quality-gate]
+tools: [claude, cursor, gemini]
+license: "MIT"
+license_source: "https://github.com/anthony-chaudhary/dos-kernel/blob/master/LICENSE"
+---
+
+# Verify done-claims against ground truth, not the agent's word
+
+## Overview
+
+When an AI agent says "done", "shipped", or "fixed", that is a **claim**, not a
+fact — and a claim the agent checks by re-reading its own work is *consistency,
+not grounding*. This skill replaces that self-report with a verdict from a
+witness the agent did not author: it shells the **DOS kernel** (`dos verify`,
+`dos commit-audit`) to confirm the claimed effect from git ancestry and the
+commit's actual diff. DOS is deterministic — no API key, no LLM, no network.
+
+This skill adapts the DOS reference "witness-claim" pattern
+(`anthony-chaudhary/dos-kernel`) into a host-agnostic screenplay.
+
+## When to Use This Skill
+
+- Use when an agent reports a task/phase/feature as **complete** and you want
+  that "done" confirmed from evidence before building on it.
+- Use right after a commit, to confirm the commit's **message matches its diff**
+  (catch a `fix:` that only touched a README, or a "tests pass" that deleted the
+  assertions).
+- Use when folding many sub-agents' results — verify each claimed effect instead
+  of trusting the return string.
+- **Do not** use it to judge whether code is *correct* — that is what the test
+  suite is for. This skill checks did-the-claimed-thing-actually-ship.
+
+## How It Works
+
+### Step 1: Install the kernel (once)
+
+```bash
+pip install dos-kernel        # provides the `dos` CLI; deterministic, no key
+```
+
+### Step 2: Audit the latest commit's claim vs its diff
+
+A commit subject is forgeable (whoever wrote the message authored it); the files
+it touched are not (git did). `dos commit-audit` grades the subject against the
+actual diff:
+
+```bash
+dos commit-audit --workspace . HEAD
+```
+
+Read the `verdict` field: `OK` (the diff backs the claim's *kind*),
+`CLAIM_UNWITNESSED` (the subject's claim is not evidenced by the diff — treat the
+"done" as unproven), or `ABSTAIN`. This judges the *kind* of change, never
+correctness — run the tests for that.
+
+### Step 3: Verify a named phase actually shipped
+
+If the agent claims a specific plan/phase landed, confirm it from git history
+rather than the transcript:
+
+```bash
+dos verify --workspace . PLAN PHASE
+```
+
+`shipped: true` with a `source` of `registry` or `grep` is real evidence;
+`source: none` means there is no positive evidence — accept that as "not shipped",
+not as a failure of the tool.
+
+### Step 4: Fold only confirmed effects
+
+Accept the agent's "done" **only** when Step 2/3 corroborate it. If
+`CLAIM_UNWITNESSED` or `shipped: false`, the work is not done regardless of how
+confidently the agent narrated it — send it back.
+
+## Examples
+
+### Example 1: gate an agent's "I fixed the bug" claim
+
+```bash
+# The agent committed and said it's fixed. Check the diff backs the claim:
+dos commit-audit --workspace . HEAD
+# verdict OK            -> the change is of the claimed kind; now run the tests
+# verdict CLAIM_UNWITNESSED -> the commit doesn't do what it says; reject
+```
+
+### Example 2: confirm a feature phase shipped before closing a ticket
+
+```bash
+dos verify --workspace . AUTH AUTH2
+# shipped: true, source: grep  -> a real ship commit exists; safe to close
+# shipped: false, source: none -> no evidence; keep the ticket open
+```
+
+## Best Practices
+
+- ✅ Run `dos commit-audit HEAD` immediately after every agent commit.
+- ✅ Treat `source: none` / `CLAIM_UNWITNESSED` as "not done", not as a tool error.
+- ✅ Keep the test suite as the separate correctness gate — this skill checks shipping, not correctness.
+- ❌ Don't accept a "done" because the agent's prose was confident.
+- ❌ Don't use this to replace code review or testing.
+
+## Limitations
+
+- This skill does not replace environment-specific validation, testing, or expert review.
+- It checks whether a claimed change *shipped* / matches its diff — not whether the code is *correct*.
+- `dos verify` reads git history; in a repo with no commits there is nothing to witness (it will honestly report `source: none`).
+- Stop and ask for clarification if required inputs (a git repo, the `dos` CLI) are missing.
+
+## Security & Safety Notes
+
+- This skill runs shell commands: `pip install dos-kernel` and the read-only
+  `dos` verbs (`dos commit-audit`, `dos verify`). The `dos` verbs only **read**
+  git history and the working tree — they do not mutate the repo, push, or
+  network.
+- `pip install dos-kernel` installs from PyPI. The distribution name is
+  `dos-kernel` (the bare `dos` on PyPI is an unrelated package — do not install
+  it). Pin a version in locked environments.
+- Run in the repository you intend to adjudicate; the `--workspace .` argument
+  scopes every verdict to that repo.
+
+## Common Pitfalls
+
+- **Problem:** `dos verify` returns `source: none` and it looks like a failure.
+  **Solution:** That is the honest "no evidence" verdict — it means the phase has
+  no ship commit, so the claim is unproven. Re-stamp the real commit or keep the
+  task open.
+- **Problem:** Installing the wrong package.
+  **Solution:** The PyPI name is `dos-kernel`, not `dos`.
+
+## Related Skills
+
+- The upstream DOS reference screenplays (`dos-witness-claim`, `dos-goal-gate`)
+  in `anthony-chaudhary/dos-kernel` cover the multi-agent fan-out and
+  self-stopping-agent variants of this same witness discipline.

--- a/skills/dos-verify-done-claims/SKILL.md
+++ b/skills/dos-verify-done-claims/SKILL.md
@@ -23,7 +23,10 @@ fact — and a claim the agent checks by re-reading its own work is *consistency
 not grounding*. This skill replaces that self-report with a verdict from a
 witness the agent did not author: it shells the **DOS kernel** (`dos verify`,
 `dos commit-audit`) to confirm the claimed effect from git ancestry and the
-commit's actual diff. DOS is deterministic — no API key, no LLM, no network.
+commit's actual diff. DOS is deterministic — no API key, no LLM. The verdict is
+git-only and offline as used here; the one exception is `dos verify` in a
+workspace that wires a CI oracle, which `--no-ci` suppresses (see Security &
+Safety Notes).
 
 This skill adapts the DOS reference "witness-claim" pattern
 (`anthony-chaudhary/dos-kernel`) into a host-agnostic screenplay.
@@ -58,12 +61,14 @@ actual diff:
 dos commit-audit --workspace . HEAD --json
 ```
 
-Read the `verdict` field — the `--json` flag emits it. (Without `--json` the
-same verdict prints as a one-line text row: `· OK …`, `⚑ UNWITNESSED …`, or
-`· abstain …`; the JSON form is the one to parse.) The verdicts are: `OK` (the
-diff backs the claim's *kind*), `CLAIM_UNWITNESSED` (the subject's claim is not
-evidenced by the diff — treat the "done" as unproven), or `ABSTAIN`. This judges
-the *kind* of change, never correctness — run the tests for that.
+`commit-audit --json` prints a JSON **array** of audited commits (one element
+even for a single `HEAD`), so read `verdict` from the first element — e.g.
+`dos commit-audit --workspace . HEAD --json | jq -r '.[0].verdict'`. (Without
+`--json` the same verdict prints as a one-line text row: `· OK …`,
+`⚑ UNWITNESSED …`, or `· abstain …`.) The verdicts are: `OK` (the diff backs the
+claim's *kind*), `CLAIM_UNWITNESSED` (the subject's claim is not evidenced by the
+diff — treat the "done" as unproven), or `ABSTAIN`. This judges the *kind* of
+change, never correctness — run the tests for that.
 
 ### Step 3: Verify a named phase actually shipped
 
@@ -97,10 +102,11 @@ confidently the agent narrated it — send it back.
 ### Example 1: gate an agent's "I fixed the bug" claim
 
 ```bash
-# The agent committed and said it's fixed. Check the diff backs the claim:
-dos commit-audit --workspace . HEAD --json
-# verdict OK                -> the change is of the claimed kind; now run the tests
-# verdict CLAIM_UNWITNESSED -> the commit doesn't do what it says; reject
+# The agent committed and said it's fixed. Check the diff backs the claim.
+# commit-audit --json returns an array, so read the first element's verdict:
+dos commit-audit --workspace . HEAD --json | jq -r '.[0].verdict'
+# OK                -> the change is of the claimed kind; now run the tests
+# CLAIM_UNWITNESSED -> the commit doesn't do what it says; reject
 ```
 
 ### Example 2: confirm a feature phase shipped before closing a ticket

--- a/skills/dos-verify-done-claims/SKILL.md
+++ b/skills/dos-verify-done-claims/SKILL.md
@@ -84,12 +84,17 @@ you get the `shipped` and `source` fields. (The default text form prints
 `SHIPPED PLAN PHASE (via grep)` or `NOT_SHIPPED PLAN PHASE (via none)` — the same
 verdict, and the process exit code is non-zero when not shipped.)
 
-`shipped: true` is real evidence when `source` is `registry` or any value
-**starting with `grep`** — git fallback grades itself by forgeability, so you may
-see bare `grep`, `grep-artifact` (a non-forgeable artefact/diff rung), or
-`grep-subject` (a commit subject carried the phase token — shipped, but forgeable,
-so weaker). `source: none` means there is no positive evidence — accept that as
-"not shipped", not as a failure of the tool.
+Grade `shipped: true` by the `source`, because git fallback grades itself by
+**forgeability** — and forgeable evidence is exactly what this skill exists to
+distrust:
+
+- `registry` or `grep-artifact` — **non-forgeable** (a registry row, or an
+  artefact/diff rung). This closes the claim.
+- `grep-subject` (or bare `grep`) — **forgeable**: a commit *subject* or body
+  carried the phase token, which an agent can write without doing the work (even
+  on an empty commit). Treat this as *shipped-per-the-subject*, not confirmed —
+  corroborate it (run `dos commit-audit` on that commit, below) before you close.
+- `none` — no positive evidence; accept as "not shipped", not as a tool failure.
 
 ### Step 4: Fold only confirmed effects
 
@@ -113,8 +118,9 @@ dos commit-audit --workspace . HEAD --json | jq -r '.[0].verdict'
 
 ```bash
 dos verify --workspace . AUTH AUTH2 --json --no-ci
-# shipped: true, source: grep-artifact -> a real ship commit exists; safe to close
-#   (source: registry, grep, or any grep-* value all count as real evidence)
+# shipped: true, source: registry|grep-artifact -> non-forgeable; safe to close
+# shipped: true, source: grep-subject|grep       -> forgeable subject/body match;
+#   shipped-per-the-subject only -> corroborate with commit-audit before closing
 # shipped: false, source: none -> no evidence; keep the ticket open
 ```
 
@@ -122,6 +128,9 @@ dos verify --workspace . AUTH AUTH2 --json --no-ci
 
 - ✅ Run `dos commit-audit HEAD` immediately after every agent commit.
 - ✅ Treat `source: none` / `CLAIM_UNWITNESSED` as "not done", not as a tool error.
+- ✅ Close a claim on a **non-forgeable** `source` (`registry`, `grep-artifact`).
+  Treat `grep-subject` / bare `grep` as forgeable (an agent can write the subject
+  text) — corroborate before closing.
 - ✅ Keep the test suite as the separate correctness gate — this skill checks shipping, not correctness.
 - ❌ Don't accept a "done" because the agent's prose was confident.
 - ❌ Don't use this to replace code review or testing.

--- a/skills/dos-verify-done-claims/SKILL.md
+++ b/skills/dos-verify-done-claims/SKILL.md
@@ -55,13 +55,15 @@ it touched are not (git did). `dos commit-audit` grades the subject against the
 actual diff:
 
 ```bash
-dos commit-audit --workspace . HEAD
+dos commit-audit --workspace . HEAD --json
 ```
 
-Read the `verdict` field: `OK` (the diff backs the claim's *kind*),
-`CLAIM_UNWITNESSED` (the subject's claim is not evidenced by the diff — treat the
-"done" as unproven), or `ABSTAIN`. This judges the *kind* of change, never
-correctness — run the tests for that.
+Read the `verdict` field — the `--json` flag emits it. (Without `--json` the
+same verdict prints as a one-line text row: `· OK …`, `⚑ UNWITNESSED …`, or
+`· abstain …`; the JSON form is the one to parse.) The verdicts are: `OK` (the
+diff backs the claim's *kind*), `CLAIM_UNWITNESSED` (the subject's claim is not
+evidenced by the diff — treat the "done" as unproven), or `ABSTAIN`. This judges
+the *kind* of change, never correctness — run the tests for that.
 
 ### Step 3: Verify a named phase actually shipped
 
@@ -69,9 +71,12 @@ If the agent claims a specific plan/phase landed, confirm it from git history
 rather than the transcript:
 
 ```bash
-dos verify --workspace . PLAN PHASE
+dos verify --workspace . PLAN PHASE --json
 ```
 
+With `--json` you get the `shipped` and `source` fields. (The default text form
+prints `SHIPPED PLAN PHASE (via grep)` or `NOT_SHIPPED PLAN PHASE (via none)` —
+the same verdict, and the process exit code is non-zero when not shipped.)
 `shipped: true` with a `source` of `registry` or `grep` is real evidence;
 `source: none` means there is no positive evidence — accept that as "not shipped",
 not as a failure of the tool.
@@ -88,15 +93,15 @@ confidently the agent narrated it — send it back.
 
 ```bash
 # The agent committed and said it's fixed. Check the diff backs the claim:
-dos commit-audit --workspace . HEAD
-# verdict OK            -> the change is of the claimed kind; now run the tests
+dos commit-audit --workspace . HEAD --json
+# verdict OK                -> the change is of the claimed kind; now run the tests
 # verdict CLAIM_UNWITNESSED -> the commit doesn't do what it says; reject
 ```
 
 ### Example 2: confirm a feature phase shipped before closing a ticket
 
 ```bash
-dos verify --workspace . AUTH AUTH2
+dos verify --workspace . AUTH AUTH2 --json
 # shipped: true, source: grep  -> a real ship commit exists; safe to close
 # shipped: false, source: none -> no evidence; keep the ticket open
 ```


### PR DESCRIPTION
## What

Adds `skills/dos-verify-done-claims/SKILL.md` — a cross-host skill that gates an AI agent's "done / shipped / fixed" claim on **ground truth** instead of the agent's own narration. It shells the deterministic [DOS kernel](https://github.com/anthony-chaudhary/dos-kernel) (`dos verify`, `dos commit-audit`) to confirm a claimed effect from git ancestry and the commit's own diff.

## Why

When an agent says "done", that is a *claim*, not a fact — and a claim the agent checks by re-reading its own work is consistency, not grounding. This skill replaces the self-report with a verdict from a witness the agent did not author. A commit subject is forgeable (whoever wrote the message authored it); the files it touched are not (git did), so a `fix:` that only touched a README is caught.

DOS is deterministic: no API key, no LLM, no network. The skill's verbs are read-only (they read git history and the working tree; they never mutate, push, or reach the network).

## Validation

- `name` matches the folder, `description` is 223 chars (< 300), `risk: safe`, `source_type: community`, `date_added` is `YYYY-MM-DD`, a `## When to Use This Skill` section is present, and there are no dangling local links.
- It is shell-bearing, so it carries the required **Security & Safety Notes** section documenting the read-only `dos` verbs and the `pip install dos-kernel` provenance (the PyPI name is `dos-kernel`, not the unrelated `dos`).
- Adapted from the DOS reference witness-claim discipline; `source_repo: anthony-chaudhary/dos-kernel`, `source_type: community`, license MIT credited.

## Codex review — addressed (commit `df3d20e`)

- **P1 (README credit, CI-blocking):** added `anthony-chaudhary/dos-kernel` to README's `### Community Contributors`. `tools/scripts/check_readme_credits.py` now exits 0 for this change (`--base origin/main --head HEAD`).
- **P2 (JSON vs text output):** the example `dos commit-audit` / `dos verify` commands now pass `--json`, so the `verdict` / `shipped` / `source` fields the skill tells the reader to inspect are actually emitted. I also documented the default text-form verdict and the non-zero exit on not-shipped, verified against the upstream CLI.

## Change Classification

- [x] Skill PR
- [ ] Docs PR
- [ ] Infra PR

## Issue Link (Optional)

N/A — this PR does not close an issue.

## Quality Bar Checklist ✅

**All applicable items must be checked before merging.**

- [x] **Standards**: I have read `docs/contributors/quality-bar.md` and `docs/contributors/security-guardrails.md`.
- [x] **Metadata**: The `SKILL.md` frontmatter is valid (checked with `npm run validate` — passes).
- [x] **Risk Label**: I have assigned the correct `risk:` tag (`safe` — the `dos` verbs are read-only: they read git history and the working tree, and never mutate, push, or network).
- [x] **Triggers**: The "When to Use This Skill" section is clear and specific.
- [x] **Limitations**: The skill includes a `## Limitations` section.
- [ ] **Security**: If this is an _offensive_ skill, I included the "Authorized Use Only" disclaimer. _(N/A — not an offensive skill.)_
- [x] **Safety scan**: This PR modifies `SKILL.md` command guidance, so I ran `npm run security:docs` (exit 0).
- [x] **Automated Skill Review**: I reviewed the Codex `skill-review` feedback and addressed both findings (P1 README credit, P2 `--json` on the example commands) in commit `df3d20e`.
- [x] **Manual Logic Review**: I manually reviewed the logic, safety, failure modes, and `risk:` label.
- [x] **Local Test**: I verified the skill's verbs (`dos commit-audit --json`, `dos verify --json`) work locally and produce the documented fields and exit codes.
- [x] **Repo Checks**: I ran `npm run validate:references` (this PR touches README.md) — passes.
- [x] **Source-Only PR**: I did not manually include generated registry artifacts (`CATALOG.md`, `skills_index.json`, `data/*.json`).
- [x] **Credits**: I added the source credit in `README.md` under `### Community Contributors`.
- [x] **License provenance**: The skill imports from an external `source_repo`, so I declared `license: MIT` and `license_source:` in the frontmatter.
- [x] **Maintainer Edits**: I enabled **Allow edits from maintainers** on the PR.
