### PR TITLE
feat: add efficient-web-research skill

### DIFF
--- a/skills/efficient-web-research/SKILL.md
+++ b/skills/efficient-web-research/SKILL.md
@@ -1,13 +1,8 @@
 ---
 name: efficient-web-research
+risk: safe
 description: >
-  Use this skill whenever you need to access, fetch, or research content from the web —
-  including specific URLs, GitHub repos, documentation sites, articles, or topic-based queries.
-  Trigger this skill when the user gives a link, asks you to "look up", "check", "read", "research",
-  "summarize", or "find information" from any web source. Also triggers for: "what does this repo do",
-  "find me info on X", "check the docs for Y", "browse this page", or any task where retrieving
-  live web content is necessary. Always use this skill before fetching any URL — it ensures
-  token-efficient, accurate, and layered web access rather than naive full-page dumps.
+  Protocol for token-efficient web research. Use when accessing URLs, GitHub repos, or running search queries. Prevents full-page fetching waste.
 ---
 
 # Efficient Web Research Skill
@@ -315,3 +310,11 @@ Never output:
 | Search snippet scan | ~300–500 tokens | Always before fetching |
 
 **Rule of thumb:** If you're about to spend >2000 tokens on a fetch, ask yourself if there's a cheaper path first.
+
+---
+
+## Limitations
+
+- **JavaScript Reliance**: Standard fetching may not fully render Single Page Applications (SPAs). You must fallback to `browser_subagent` for these, which is slower and more expensive.
+- **Paywalls & Protections**: This skill cannot bypass CAPTCHAs, bot protections (e.g., strict Cloudflare rules), or hard paywalls.
+- **GitHub API Limits**: Frequent GitHub API requests without authentication may hit rate limits.

--- a/skills/efficient-web-research/SKILL.md
+++ b/skills/efficient-web-research/SKILL.md
@@ -58,10 +58,10 @@ Always prefer the GitHub API. It returns clean JSON — no HTML parsing needed.
 GET https://api.github.com/repos/{owner}/{repo}
 
 # File tree (see what files exist — very cheap)
-GET https://api.github.com/repos/{owner}/{repo}/git/trees/HEAD?recursive=1
+GET https://api.github.com/repos/{owner}/{repo}/git/trees/{ref}?recursive=1
 
 # Single file content (base64 encoded)
-GET https://api.github.com/repos/{owner}/{repo}/contents/{path}
+GET https://api.github.com/repos/{owner}/{repo}/contents/{path}?ref={ref}
 
 # README only (usually enough to understand the repo)
 GET https://api.github.com/repos/{owner}/{repo}/readme

--- a/skills/efficient-web-research/SKILL.md
+++ b/skills/efficient-web-research/SKILL.md
@@ -1,0 +1,317 @@
+---
+name: efficient-web-research
+description: >
+  Use this skill whenever you need to access, fetch, or research content from the web —
+  including specific URLs, GitHub repos, documentation sites, articles, or topic-based queries.
+  Trigger this skill when the user gives a link, asks you to "look up", "check", "read", "research",
+  "summarize", or "find information" from any web source. Also triggers for: "what does this repo do",
+  "find me info on X", "check the docs for Y", "browse this page", or any task where retrieving
+  live web content is necessary. Always use this skill before fetching any URL — it ensures
+  token-efficient, accurate, and layered web access rather than naive full-page dumps.
+---
+
+# Efficient Web Research Skill
+
+A protocol for accessing web content in the most token-efficient, accurate, and structured way —
+using the right tool at the right depth, and stopping as soon as the question is answerable.
+
+---
+
+## Core Principle
+
+> **Fetch the minimum needed to answer. Skim before you dive. Stop when you can answer.**
+
+Every unnecessary fetch wastes tokens and adds noise. This skill enforces a layered approach
+where you escalate fetch depth only when shallower layers fail.
+
+---
+
+## Step 1 — Classify the Input
+
+Before fetching anything, identify what kind of input you received:
+
+| Input Type | Example | Go To |
+|---|---|---|
+| GitHub repo URL | `github.com/user/repo` | [GitHub Protocol](#github-protocol) |
+| Specific page URL | `docs.python.org/3/library/os` | [URL Protocol](#url-protocol) |
+| Topic / query (no URL) | "how does RAFT consensus work" | [Search Protocol](#search-protocol) |
+| Multiple URLs | List of links | [Multi-URL Protocol](#multi-url-protocol) |
+| PDF / file link | `.pdf`, `.txt`, `.md` URL | [File Protocol](#file-protocol) |
+
+---
+
+## GitHub Protocol
+
+Use when input is a GitHub URL (repo, file, PR, issue, etc.)
+
+### Step 1 — Parse the URL
+
+```
+github.com/{owner}/{repo}                → Repo root
+github.com/{owner}/{repo}/tree/{branch}  → Directory
+github.com/{owner}/{repo}/blob/{branch}/{path} → Single file
+github.com/{owner}/{repo}/issues/{n}     → Issue
+github.com/{owner}/{repo}/pull/{n}       → Pull request
+```
+
+### Step 2 — Use GitHub API (preferred over scraping)
+
+Always prefer the GitHub API. It returns clean JSON — no HTML parsing needed.
+
+```
+# Repo metadata (name, description, language, stars, topics)
+GET https://api.github.com/repos/{owner}/{repo}
+
+# File tree (see what files exist — very cheap)
+GET https://api.github.com/repos/{owner}/{repo}/git/trees/HEAD?recursive=1
+
+# Single file content (base64 encoded)
+GET https://api.github.com/repos/{owner}/{repo}/contents/{path}
+
+# README only (usually enough to understand the repo)
+GET https://api.github.com/repos/{owner}/{repo}/readme
+```
+
+### Step 3 — Layered Fetch for Repos
+
+```
+Layer 1 (always do first):
+  → Fetch repo metadata + README only
+  → Can you answer the user's question now? YES → STOP. NO → continue.
+
+Layer 2 (only if needed):
+  → Fetch file tree to understand structure
+  → Identify the 1-3 most relevant files based on the question
+  → Can you answer now? YES → STOP. NO → continue.
+
+Layer 3 (last resort):
+  → Fetch specific relevant files only (never fetch all files)
+  → Prioritize: main entry point, config files, key modules
+```
+
+### Token Rules for GitHub
+
+- README alone answers ~70% of "what does this repo do" questions — always try it first
+- Never fetch more than 3 files in a single research turn
+- If a file exceeds ~300 lines, read only the top (imports + class/function signatures)
+- Decode base64 content from API before passing to context
+
+---
+
+## URL Protocol
+
+Use when the user gives a specific non-GitHub URL (docs, articles, blogs, etc.)
+
+### Step 1 — Assess the URL type
+
+| Site type | Likely works with | Notes |
+|---|---|---|
+| Static docs / MDN / ReadTheDocs | `read_url_content` | Fast, clean, cheap |
+| News articles / blogs | `read_url_content` | Usually fine |
+| SPAs / React/Next.js apps | `browser_subagent` | JS-rendered |
+| Auth-gated pages | `browser_subagent` | Needs login |
+| Raw GitHub files (raw.githubusercontent) | `read_url_content` | Direct text |
+
+### Step 2 — Layered Fetch
+
+```
+Layer 1 — Skim
+  → Fetch the URL with read_url_content
+  → Read only headings (H1, H2, H3) and first paragraph
+  → Does this page contain what the user needs? NO → try a different URL or search. YES → continue.
+
+Layer 2 — Targeted Extract
+  → If the page has anchor links (e.g. /docs/page#section), fetch with the anchor
+  → Extract only the relevant section (200–500 tokens max)
+  → Can you answer? YES → STOP.
+
+Layer 3 — Full Fetch
+  → Fetch full page, strip boilerplate (nav, footer, ads, cookie banners, sidebars)
+  → Cap at 2000 tokens. Summarize before passing to answer.
+
+Layer 4 — Browser Subagent (last resort only)
+  → Use ONLY if read_url_content returns empty, garbled, or JS-placeholder content
+  → Instruct subagent: "Navigate to [URL], wait for content to load, extract [specific section]"
+  → Do NOT use browser_subagent for static pages — it's expensive
+```
+
+### What to Strip from Fetched Pages
+
+Always remove before using fetched content:
+- Navigation menus and breadcrumbs
+- Cookie banners and GDPR notices
+- "Related articles" / "You might also like" blocks
+- Footer content (copyright, links)
+- Social share buttons
+- Ads and sponsored content
+
+Extract and keep:
+- Main article / documentation body
+- Code blocks
+- Tables with data
+- Numbered steps or procedures
+
+---
+
+## Search Protocol
+
+Use when the user gives a topic, question, or query — not a specific URL.
+
+### Step 1 — Sharpen the Query Before Searching
+
+Do NOT search the raw user query. Transform it first:
+
+```
+Raw: "how to deploy fastapi on aws"
+Sharpened: "fastapi AWS deployment tutorial 2024"
+
+Raw: "python async vs threads"
+Sharpened: "Python asyncio vs threading performance comparison"
+
+Raw: "best way to structure react project"
+Sharpened: "React project folder structure best practices"
+```
+
+**Query sharpening rules:**
+- Add specificity: version numbers, technology names, "tutorial" / "guide" / "comparison"
+- Add recency if relevant: current year
+- Remove filler words: "how do I", "what is the", "can you explain"
+- For code questions: add the language + framework name explicitly
+
+### Step 2 — Search and Select
+
+```
+1. Run search_web with the sharpened query
+2. Get results (titles + snippets)
+3. Scan titles + snippets ONLY — do not fetch yet
+4. Pick the TOP 1-2 most relevant results (max 3 in complex cases)
+5. Skip results from: forums (if docs exist), aggregator blogs, paywalled sites
+6. Prefer: official docs, GitHub repos, well-known tech blogs, academic sources
+```
+
+### Step 3 — Fetch Selected Results
+
+Apply the URL Protocol (above) to each selected URL.
+Process results one at a time — only fetch the second URL if the first didn't answer the question.
+
+### Token Rules for Search
+
+- Never read more than 3 URLs per search query
+- If the snippet already contains the answer → do NOT fetch the full page, use the snippet
+- For factual questions (dates, names, simple facts) → snippet is usually enough
+- For procedural questions (how to do X) → fetch 1 relevant page, targeted section only
+
+---
+
+## Multi-URL Protocol
+
+Use when the user provides a list of URLs to compare or summarize.
+
+```
+1. Skim all URLs first (Layer 1 fetch for each)
+2. Group by relevance to the user's question
+3. Deep-fetch only the most relevant 1-3 URLs
+4. Summarize each in 3-5 sentences before combining
+5. Never dump raw content from multiple pages — always summarize per-source first
+```
+
+---
+
+## File Protocol
+
+Use when URL points directly to a file (PDF, .txt, .md, .csv, etc.)
+
+- `.md` / `.txt` / `.csv` → `read_url_content` works directly, read full content
+- `.pdf` → Use browser_subagent or a PDF extraction tool; extract text only
+- `.json` / `.yaml` → `read_url_content`, parse structure, summarize schema + key values
+- Large files (>500 lines) → Read first 100 lines + last 20 lines + search for relevant sections
+
+---
+
+## Anti-Patterns (Never Do These)
+
+| Anti-pattern | Why it's bad | Do this instead |
+|---|---|---|
+| Fetching full page for a simple fact | Wastes 1000s of tokens | Use snippet or targeted anchor |
+| Using browser_subagent for static sites | Very expensive | Use read_url_content first |
+| Searching with the raw user query | Vague results | Sharpen query first |
+| Fetching 5+ search results | Token explosion | Max 3, stop when answered |
+| Dumping raw HTML into context | Noisy, wasteful | Always strip to Markdown |
+| Fetching "just in case" | Unnecessary tokens | Only fetch what's needed to answer |
+| Re-fetching the same URL | Redundant | Cache result in context, reuse |
+| Fetching entire GitHub repo | Extremely wasteful | README + targeted files only |
+
+---
+
+## Decision Flowchart (Quick Reference)
+
+```
+Input received
+│
+├─ GitHub URL?
+│   ├─ Fetch README + metadata via API
+│   ├─ Answered? → STOP
+│   ├─ Need more? → Fetch file tree, pick 1-3 files
+│   └─ Still need more? → Fetch specific files only
+│
+├─ Specific URL?
+│   ├─ Try read_url_content → skim headings
+│   ├─ Answered? → STOP
+│   ├─ Need more? → Targeted section fetch
+│   ├─ Still need more? → Full fetch, stripped
+│   └─ JS-rendered / broken? → browser_subagent (last resort)
+│
+├─ Topic/query?
+│   ├─ Sharpen query
+│   ├─ search_web → scan snippets
+│   ├─ Snippet enough? → Answer from snippet, STOP
+│   ├─ Need more? → Fetch top 1 result (targeted)
+│   └─ Still need more? → Fetch top 2nd result (targeted)
+│
+└─ List of URLs?
+    ├─ Skim all (Layer 1 each)
+    ├─ Deep fetch top 1-3 relevant ones
+    └─ Summarize per-source, then combine
+```
+
+---
+
+## Output Format Rules
+
+After fetching, structure your response as:
+
+```
+Source: [URL or "Web search for: query"]
+Summary: [2-5 sentences of what was found]
+Answer: [Direct answer to user's question]
+Confidence: [High / Medium / Low — based on source quality]
+```
+
+For multiple sources:
+```
+Source 1: ...
+Source 2: ...
+Combined Answer: ...
+```
+
+Never output:
+- Raw HTML fragments
+- Full page dumps
+- Unattributed information
+- More than needed to answer the question
+
+---
+
+## Token Budget Guide
+
+| Operation | Approximate token cost | When to use |
+|---|---|---|
+| GitHub README fetch | ~300–800 tokens | Always first for repos |
+| GitHub API metadata | ~200 tokens | Always for repos |
+| Skim (headings only) | ~100–200 tokens | Always first for URLs |
+| Targeted section fetch | ~300–600 tokens | When skim isn't enough |
+| Full page fetch (stripped) | ~1000–2000 tokens | Only when targeted fails |
+| browser_subagent | ~2000–5000 tokens | Last resort only |
+| Search snippet scan | ~300–500 tokens | Always before fetching |
+
+**Rule of thumb:** If you're about to spend >2000 tokens on a fetch, ask yourself if there's a cheaper path first.

--- a/skills/sharp-coder/SKILL.md
+++ b/skills/sharp-coder/SKILL.md
@@ -1,12 +1,7 @@
 ---
 name: sharp-coder
 description: >
-  Two-layer performance skill: THINK layer (Karpathy coding discipline) + SPEAK layer (Caveman compression).
-  THINK: surfaces assumptions, enforces simplicity, surgical edits, goal-driven execution.
-  SPEAK: compresses every prose response ~65-75% by dropping fluff, keeping all technical substance exact.
-  Use when user says "caveman", "less tokens", "be brief", "/caveman", "karpathy", "think before coding",
-  "sharp coder", or wants both disciplined coding AND terse output. Both layers active simultaneously.
-  Auto-triggers for any coding task where disciplined thinking AND token efficiency both matter.
+  Two-layer performance skill combining disciplined THINK layer (surgical edits, simplicity) and terse SPEAK layer (caveman compression). Triggers on requests for brevity, token efficiency, or disciplined coding.
 risk: safe
 ---
 

--- a/skills/sharp-coder/SKILL.md
+++ b/skills/sharp-coder/SKILL.md
@@ -1,0 +1,130 @@
+---
+name: sharp-coder
+description: >
+  Two-layer performance skill: THINK layer (Karpathy coding discipline) + SPEAK layer (Caveman compression).
+  THINK: surfaces assumptions, enforces simplicity, surgical edits, goal-driven execution.
+  SPEAK: compresses every prose response ~65-75% by dropping fluff, keeping all technical substance exact.
+  Use when user says "caveman", "less tokens", "be brief", "/caveman", "karpathy", "think before coding",
+  "sharp coder", or wants both disciplined coding AND terse output. Both layers active simultaneously.
+  Auto-triggers for any coding task where disciplined thinking AND token efficiency both matter.
+risk: safe
+---
+
+# Sharp Coder
+
+Two orthogonal layers. Both always active. Neither overrides the other.
+
+| Layer | Governs | When active |
+|---|---|---|
+| **THINK** | Reasoning & coding behavior | Before/during any code task |
+| **SPEAK** | Prose output style | Every response |
+
+Shared philosophy: **no bloat**. Not in code. Not in words.
+
+---
+
+## SPEAK Layer — Caveman Compression
+
+Default: **full** mode. Switch: `/caveman lite|full|ultra`. Off: `stop caveman` / `normal mode`.
+
+**Drop:** articles (a/an/the), filler (just/really/basically/actually/simply), pleasantries (sure/certainly/of course/happy to), hedging. Fragments OK. Short synonyms (big not extensive, fix not "implement a solution for"). Pattern: `[thing] [action] [reason]. [next step].`
+
+**Keep exact:** technical terms, code blocks, error strings, API names, function names, symbols.
+
+### Intensity levels
+
+| Level | Rules |
+|---|---|
+| **lite** | Drop filler/hedging. Keep articles + full sentences. Tight but professional. |
+| **full** | Drop articles, fragments OK, short synonyms. Classic caveman. |
+| **ultra** | Abbreviate prose words (DB/auth/config/req/res/fn/impl), strip conjunctions, arrows for causality (X → Y). Code symbols/names/errors: never abbreviate. |
+| **wenyan-lite** | Classical Chinese register, light compression. Drop filler/hedging, keep grammar. |
+| **wenyan-full** | Full 文言文. 80-90% character reduction. Classical particles (之/乃/為/其), verbs before objects, subjects often omitted. |
+| **wenyan-ultra** | Extreme classical compression. Maximum terseness. |
+
+### Quick example — "Why React component re-render?"
+- **lite:** "Component re-renders because you create a new object reference each render. Wrap it in `useMemo`."
+- **full:** "New obj ref each render. Inline object prop = new ref = re-render. Wrap in `useMemo`."
+- **ultra:** "Inline obj prop → new ref → re-render. `useMemo`."
+
+### Auto-clarity — drop compression for:
+- Security warnings
+- Irreversible action confirmations (deletions, drops, overwrites)
+- Clarifying questions when confused (see THINK layer — always full prose)
+- Multi-step sequences where fragment order risks misread
+- When compression itself creates technical ambiguity
+
+Resume caveman immediately after the clear section ends.
+
+**Persistence:** Active every response until explicitly stopped. No drift back to verbose after many turns.
+
+---
+
+## THINK Layer — Coding Discipline
+
+### 1. Think Before Coding
+
+State assumptions explicitly before writing code. If multiple interpretations exist, present them — don't pick silently. If something is unclear, **stop and ask in full prose** (Auto-clarity applies here always).
+
+Ask: "Is there a simpler approach?" If yes, say so. Push back when warranted.
+
+### 2. Simplicity First
+
+Min code that solves the problem. Nothing speculative.
+
+- No features beyond what was asked
+- No abstractions for single-use code
+- No unrequested "flexibility" or "configurability"
+- No error handling for impossible scenarios
+
+If output is 200 lines and could be 50, rewrite it.
+
+### 3. Surgical Changes
+
+Touch only what the request requires.
+
+- Don't improve adjacent code, comments, or formatting
+- Don't refactor things that aren't broken
+- Match existing style even if you'd do it differently
+- Notice unrelated dead code → mention it, don't delete it
+
+When your changes create orphans: remove imports/variables/functions that **your** changes made unused. Don't remove pre-existing dead code unless asked.
+
+Every changed line must trace directly to the user's request.
+
+### 4. Goal-Driven Execution
+
+Transform tasks into verifiable goals before starting:
+
+```
+"Add validation"  →  write tests for invalid inputs, then make them pass
+"Fix the bug"     →  write a test that reproduces it, then make it pass
+"Refactor X"      →  ensure tests pass before and after
+```
+
+For multi-step tasks, state a terse plan first (SPEAK layer applies):
+
+```
+1. [step] → verify: [check]
+2. [step] → verify: [check]
+3. [step] → verify: [check]
+```
+
+Strong success criteria = loop independently. Weak criteria ("make it work") = constant clarification.
+
+---
+
+## Interaction Between Layers
+
+| Situation | THINK | SPEAK |
+|---|---|---|
+| Writing code | Active — discipline applies | Code blocks always normal; prose around them compressed |
+| Stating a plan | Active — terse plan format | Compressed (full mode) |
+| Asking a clarifying question | Active — stop and ask | **Full prose always** |
+| Security / destructive op warning | Active | **Full prose always** |
+| Explaining a concept | Not applicable | Compressed per level |
+
+Code and commits are always written normally regardless of SPEAK level. Only prose is compressed.
+
+## Limitations
+- Over-compression may lead to ambiguity. Use full mode if the context is lost.

--- a/skills/sharp-coder/SKILL.md
+++ b/skills/sharp-coder/SKILL.md
@@ -3,6 +3,8 @@ name: sharp-coder
 description: >
   Two-layer performance skill combining disciplined THINK layer (surgical edits, simplicity) and terse SPEAK layer (caveman compression). Triggers on requests for brevity, token efficiency, or disciplined coding.
 risk: safe
+source: self
+source_type: self
 ---
 
 # Sharp Coder
@@ -15,6 +17,10 @@ Two orthogonal layers. Both always active. Neither overrides the other.
 | **SPEAK** | Prose output style | Every response |
 
 Shared philosophy: **no bloat**. Not in code. Not in words.
+
+## When to Use
+
+Use when the user explicitly requests brevity ("caveman mode", "less tokens", "be brief") OR requests disciplined coding ("karpathy guidelines", "think before coding"). This skill combines extreme token efficiency in prose with rigorous engineering discipline in code generation.
 
 ---
 


### PR DESCRIPTION
# Pull Request Description

Adds the `efficient-web-research` skill, which provides a highly token-efficient, layered protocol for agents to retrieve and summarize web content (URLs, GitHub repos, search queries, multi-URL lists, and files) without wasting tokens on full-page fetches.

## Change Classification

- [x] Skill PR
- [ ] Docs PR
- [ ] Infra PR

## Issue Link (Optional)

N/A

## Quality Bar Checklist ✅

**All applicable items must be checked before merging.**

- [x] **Standards**: I have read `docs/contributors/quality-bar.md` and `docs/contributors/security-guardrails.md`.
- [x] **Metadata**: The `SKILL.md` frontmatter is valid (checked with `npm run validate`).
- [x] **Risk Label**: I have assigned the correct `risk:` tag (`none`, `safe`, `critical`, `offensive`, or `unknown` for legacy/unclassified content).
- [x] **Triggers**: The "When to use" section is clear and specific.
- [x] **Limitations**: The skill includes a `## Limitations` (or equivalent accepted constraints) section.
- [ ] **Security**: If this is an _offensive_ skill, I included the "Authorized Use Only" disclaimer.
- [x] **Safety scan**: If this PR adds or modifies `SKILL.md` command guidance, remote/network examples, or token-like strings, I ran `npm run security:docs` (or equivalent hardening check) and addressed any findings.
- [x] **Automated Skill Review**: If this PR changes `SKILL.md`, I checked the `skill-review` GitHub Actions result and addressed any actionable feedback.
- [x] **Manual Logic Review**: If this PR changes `SKILL.md` or risky guidance, I manually reviewed the logic, safety, failure modes, and `risk:` label instead of relying on automated checks alone.
- [x] **Local Test**: I have verified the skill works locally.
- [x] **Repo Checks**: I ran `npm run validate:references` if my change affected docs, workflows, or infrastructure.
- [x] **Source-Only PR**: I did not manually include generated registry artifacts (`CATALOG.md`, `skills_index.json`, `data/*.json`) in this PR.
- [ ] **Credits**: I have added the source credit in `README.md` (if applicable).
- [ ] **License provenance**: If this skill imports from an external `source_repo`, I have declared `license:` and `license_source:` in the frontmatter, or confirmed the upstream repo carries no restricting license.
- [x] **Maintainer Edits**: I enabled **Allow edits from maintainers** on the PR.

## Screenshots (if applicable)
N/A
