### PR TITLE
fix(astropy): add references/ stub directory with pointers to upstream astropy docs

### DIFF
--- a/skills/astropy/references/coordinates.md
+++ b/skills/astropy/references/coordinates.md
@@ -1,0 +1,9 @@
+# astropy.coordinates — Reference
+
+This file is a placeholder for the extended `astropy.coordinates` reference promised in the skill workflow.
+
+For detailed coordinate frame descriptions, transformations, observer-dependent frames (AltAz), catalog matching, and performance tips, see the upstream astropy docs:
+
+- https://docs.astropy.org/en/stable/coordinates/
+- https://docs.astropy.org/en/stable/coordinates/frames.html
+- https://docs.astropy.org/en/stable/coordinates/matchsep.html

--- a/skills/astropy/references/cosmology.md
+++ b/skills/astropy/references/cosmology.md
@@ -1,0 +1,8 @@
+# astropy.cosmology — Reference
+
+This file is a placeholder for the extended `astropy.cosmology` reference promised in the skill workflow.
+
+For available models, distance calculations, time calculations, density parameters, and neutrino effects, see the upstream astropy docs:
+
+- https://docs.astropy.org/en/stable/cosmology/
+- https://docs.astropy.org/en/stable/cosmology/realizations.html

--- a/skills/astropy/references/fits.md
+++ b/skills/astropy/references/fits.md
@@ -1,0 +1,8 @@
+# astropy.io.fits — Reference
+
+This file is a placeholder for the extended `astropy.io.fits` reference promised in the skill workflow.
+
+For file operations, header manipulation, image and table handling, multi-extension files, and performance considerations, see the upstream astropy docs:
+
+- https://docs.astropy.org/en/stable/io/fits/
+- https://docs.astropy.org/en/stable/io/fits/usage/headers.html

--- a/skills/astropy/references/tables.md
+++ b/skills/astropy/references/tables.md
@@ -1,0 +1,8 @@
+# astropy.table — Reference
+
+This file is a placeholder for the extended `astropy.table` reference promised in the skill workflow.
+
+For table creation, I/O operations, data manipulation, sorting, filtering, joins, grouping, and performance tips, see the upstream astropy docs:
+
+- https://docs.astropy.org/en/stable/table/
+- https://docs.astropy.org/en/stable/table/operations.html

--- a/skills/astropy/references/time.md
+++ b/skills/astropy/references/time.md
@@ -1,0 +1,7 @@
+# astropy.time — Reference
+
+This file is a placeholder for the extended `astropy.time` reference promised in the skill workflow.
+
+For time formats, time scales, conversions, arithmetic, observing features, and precision handling, see the upstream astropy docs:
+
+- https://docs.astropy.org/en/stable/time/

--- a/skills/astropy/references/units.md
+++ b/skills/astropy/references/units.md
@@ -1,0 +1,9 @@
+# astropy.units — Reference
+
+This file is a placeholder for the extended `astropy.units` reference promised in the skill workflow.
+
+For comprehensive documentation, unit systems, equivalencies, performance optimization, and unit arithmetic, see the upstream astropy docs:
+
+- https://docs.astropy.org/en/stable/units/
+- https://docs.astropy.org/en/stable/units/equivalencies.html
+- https://docs.astropy.org/en/stable/units/standards.html

--- a/skills/astropy/references/wcs_and_other_modules.md
+++ b/skills/astropy/references/wcs_and_other_modules.md
@@ -1,0 +1,9 @@
+# astropy.wcs and other modules — Reference
+
+This file is a placeholder for the extended `astropy.wcs` (and related modules) reference promised in the skill workflow.
+
+For WCS operations and transformations, plus related modules (`astropy.modeling`, `astropy.constants`, `astropy.convolution`, etc.), see the upstream astropy docs:
+
+- https://docs.astropy.org/en/stable/wcs/
+- https://docs.astropy.org/en/stable/modeling/
+- https://docs.astropy.org/en/stable/constants/


### PR DESCRIPTION
Fixes #707.

The astropy skill references seven `references/*.md` files that did not exist. This patch adds minimal reference stubs pointing to the matching upstream Astropy documentation, preserving the existing `SKILL.md` links and leaving room for richer notes later.

## Change Classification

- [x] Skill PR
- [ ] Docs PR
- [ ] Infra PR

## Issue Link

Fixes #707

## Quality Bar Checklist ✅

**All applicable items must be checked before merging.**

- [x] **Standards**: Maintainer reviewed against `docs/contributors/quality-bar.md` and `docs/contributors/security-guardrails.md`.
- [x] **Metadata**: Existing or added `SKILL.md` frontmatter remains valid; CI source validation is required before merge.
- [x] **Risk Label**: Existing or added risk labels are appropriate for this change.
- [x] **Triggers**: Existing or added "When to use" guidance remains clear.
- [x] **Limitations**: Existing or added limitations/constraints remain present where applicable.
- [x] **Security**: Not an offensive-skill change.
- [x] **Safety scan**: No unsafe command guidance is introduced beyond documented setup/source context; CI checks remain required.
- [x] **Automated Skill Review**: Skill Review workflow is required before merge.
- [x] **Manual Logic Review**: Maintainer reviewed the diff for scope, safety, and failure modes.
- [x] **Local Test**: Maintainer relies on required CI for this source-only PR.
- [x] **Repo Checks**: Required CI source-validation/artifact-preview must pass before merge.
- [x] **Source-Only PR**: No generated registry artifacts are included in this PR.
- [x] **Credits**: Upstream Astropy documentation links only; no external source import requiring README credit.
- [x] **License provenance**: Upstream Astropy documentation links only; no external source import requiring README credit.
- [x] **Maintainer Edits**: Maintainer can edit this PR branch or body as needed.
