### PR TITLE
fix(schema-markup): add scoring guidance per category before Eligibility Bands

### DIFF
--- a/skills/schema-markup/SKILL.md
+++ b/skills/schema-markup/SKILL.md
@@ -110,6 +110,17 @@ This is a **diagnostic score**, not a promise of rich results.
 
 ---
 
+### Scoring Guidance per Category
+
+For each of the six scoring categories, allot points within the category's weight band using these anchors:
+
+- **0–15% of band:** Schema describes none of the visible content (e.g. you would mark `description` for a `Recipe` page that has no recipe markup yet).
+- **16–40% of band:** Partial alignment — the schema describes some but not all of the visible content, OR maps to a less-common schema.org type.
+- **41–80% of band:** Strong alignment — the schema describes the bulk of the visible content with a common schema.org type.
+- **81–100% of band:** Exemplary — the schema covers all visible content, uses a Google-supported rich-result type, and includes all required properties.
+
+Sum the per-category scores to compute the Eligibility Index used in §"Eligibility Bands" below.
+
 ### Eligibility Bands (Required)
 
 | Score  | Verdict               | Interpretation                        |


### PR DESCRIPTION
Fixes #709.

Adds scoring guidance before the Schema Eligibility Bands so readers can consistently allocate points inside each weighted category before computing the 0-100 Schema Eligibility & Impact Index.

## Change Classification

- [x] Skill PR
- [ ] Docs PR
- [ ] Infra PR

## Issue Link

Fixes #709

## Quality Bar Checklist ✅

**All applicable items must be checked before merging.**

- [x] **Standards**: Maintainer reviewed against `docs/contributors/quality-bar.md` and `docs/contributors/security-guardrails.md`.
- [x] **Metadata**: Existing or added `SKILL.md` frontmatter remains valid; CI source validation is required before merge.
- [x] **Risk Label**: Existing or added risk labels are appropriate for this change.
- [x] **Triggers**: Existing or added "When to use" guidance remains clear.
- [x] **Limitations**: Existing or added limitations/constraints remain present where applicable.
- [x] **Security**: Not an offensive-skill change.
- [x] **Safety scan**: No unsafe command guidance is introduced beyond documented setup/source context; CI checks remain required.
- [x] **Automated Skill Review**: Skill Review workflow is required before merge.
- [x] **Manual Logic Review**: Maintainer reviewed the diff for scope, safety, and failure modes.
- [x] **Local Test**: Maintainer relies on required CI for this source-only PR.
- [x] **Repo Checks**: Required CI source-validation/artifact-preview must pass before merge.
- [x] **Source-Only PR**: No generated registry artifacts are included in this PR.
- [x] **Credits**: N/A.
- [x] **License provenance**: N/A.
- [x] **Maintainer Edits**: Maintainer can edit this PR branch or body as needed.
