### PR TITLE
fix(programmatic-seo): add scoring guidance per category before Feasibility Bands

### DIFF
--- a/skills/programmatic-seo/SKILL.md
+++ b/skills/programmatic-seo/SKILL.md
@@ -113,6 +113,17 @@ A high score indicates _structural suitability_, not guaranteed rankings.
 
 ---
 
+### Scoring Guidance per Category
+
+For each of the six scoring categories, allot points within the category's weight band using these anchors:
+
+- **0–15% of band:** No alignment — the site/topic clearly does not meet the criterion (e.g. fewer than 10 candidate entities for a directory-style PSEO).
+- **16–40% of band:** Partial alignment — the criterion is partially met, OR met for a small subset of pages only.
+- **41–80% of band:** Strong alignment — the criterion holds for most of the planned page set.
+- **81–100% of band:** Exemplary — the criterion holds universally and is reinforced by a structural data source (DB, API, validated CSV).
+
+Sum the per-category scores to compute the Feasibility Index used in §"Feasibility Bands" below.
+
 ### Feasibility Bands (Required)
 
 | Score  | Verdict            | Interpretation                    |


### PR DESCRIPTION
Fixes #711.

Adds scoring guidance before the Programmatic SEO Feasibility Bands so readers can consistently allocate points inside each weighted category before computing the 0-100 Feasibility Index.

## Change Classification

- [x] Skill PR
- [ ] Docs PR
- [ ] Infra PR

## Issue Link

Fixes #711

## Quality Bar Checklist ✅

**All applicable items must be checked before merging.**

- [x] **Standards**: Maintainer reviewed against `docs/contributors/quality-bar.md` and `docs/contributors/security-guardrails.md`.
- [x] **Metadata**: Existing or added `SKILL.md` frontmatter remains valid; CI source validation is required before merge.
- [x] **Risk Label**: Existing or added risk labels are appropriate for this change.
- [x] **Triggers**: Existing or added "When to use" guidance remains clear.
- [x] **Limitations**: Existing or added limitations/constraints remain present where applicable.
- [x] **Security**: Not an offensive-skill change.
- [x] **Safety scan**: No unsafe command guidance is introduced beyond documented setup/source context; CI checks remain required.
- [x] **Automated Skill Review**: Skill Review workflow is required before merge.
- [x] **Manual Logic Review**: Maintainer reviewed the diff for scope, safety, and failure modes.
- [x] **Local Test**: Maintainer relies on required CI for this source-only PR.
- [x] **Repo Checks**: Required CI source-validation/artifact-preview must pass before merge.
- [x] **Source-Only PR**: No generated registry artifacts are included in this PR.
- [x] **Credits**: N/A.
- [x] **License provenance**: N/A.
- [x] **Maintainer Edits**: Maintainer can edit this PR branch or body as needed.
