### PR TITLE
Add NotFair (open-source SEO & paid-ads skills) to Community list

### DIFF
--- a/README.md
+++ b/README.md
@@ -475,6 +475,7 @@ Key source families include:
 - **[CodeShuX/tokenwise](https://github.com/CodeShuX/tokenwise)**: Source for the `tokenwise` skill — measurement-driven Haiku/Sonnet/Opus router for Claude Code with per-task NDJSON logging, A/B test mode, and verified $-saved reports (MIT).
 - **[anthony-chaudhary/dos-kernel](https://github.com/anthony-chaudhary/dos-kernel)**: Source for the `dos-verify-done-claims` skill — gates an agent's "done / shipped / fixed" claim on git ground truth (ancestry + the commit's own diff) via the deterministic DOS kernel's read-only `dos verify` / `dos commit-audit` verbs (MIT).
 - **[maxbaluev/accreted-intelligence](https://github.com/maxbaluev/accreted-intelligence)**: Source for the `accint-solve` skill — routes coding-agent work through AccInt's MCP memory loop with retrieval, continuation frames, commitments, and outcome feedback (Apache 2.0).
+- **[nowork-studio/NotFair](https://github.com/nowork-studio/NotFair)**: Marketing skills for [SEO](https://github.com/nowork-studio/NotFair/tree/main/seo) (site analysis, keyword research, meta tags, schema markup, GEO, content writing), [Google Ads](https://github.com/nowork-studio/NotFair/tree/main/google-ads) (audits, wasted-spend and search-term cleanup, keyword and bid management), and [Meta Ads](https://github.com/nowork-studio/NotFair/tree/main/meta-ads) (ROAS, creative fatigue, audience overlap), wired to live data via the Google Ads MCP, Meta Ads MCP, Google Search Console MCP, and Google Analytics (GA4) MCP (MIT).
 
 </details>
 


### PR DESCRIPTION
Hi, and thanks for maintaining this list — it's a genuinely useful map of the agent-skills ecosystem.

I'd like to add **NotFair** ([nowork-studio/NotFair](https://github.com/nowork-studio/NotFair)), an open-source (MIT) set of Claude Code skills for marketing work: SEO (site analysis, keyword research, meta tags, schema markup, GEO, content writing), Google Ads (audits, wasted-spend detection, search-term cleanup, keyword and bid management), and Meta Ads (ROAS, creative fatigue, audience overlap). It connects to live data through the Google Ads MCP, Meta Ads MCP, Google Search Console MCP, and Google Analytics (GA4) MCP.

It sits naturally alongside the existing marketing/SEO/ads entries in the Community Contributors section (coreyhaines31/marketingskills, AgriciDaniel/claude-seo, jonathimer/devmarketing-skills, etc.), and it's at ~2.9k stars in case that's a useful signal. This is a README-only change — one line appended to that list.

Happy to reword, move, or trim the entry to fit your conventions. Thanks for taking a look!

## Change Classification

- [ ] Skill PR
- [ ] Docs PR
- [ ] Infra PR

## Issue Link (Optional)

Use this only when the PR should auto-close an issue:

`Closes #N` or `Fixes #N`

## Quality Bar Checklist ✅

**All applicable items must be checked before merging.**

- [ ] **Standards**: I have read `docs/contributors/quality-bar.md` and `docs/contributors/security-guardrails.md`.
- [ ] **Metadata**: The `SKILL.md` frontmatter is valid (checked with `npm run validate`).
- [ ] **Risk Label**: I have assigned the correct `risk:` tag (`none`, `safe`, `critical`, `offensive`, or `unknown` for legacy/unclassified content).
- [ ] **Triggers**: The "When to use" section is clear and specific.
- [ ] **Limitations**: The skill includes a `## Limitations` (or equivalent accepted constraints) section.
- [ ] **Security**: If this is an _offensive_ skill, I included the "Authorized Use Only" disclaimer.
- [ ] **Safety scan**: If this PR adds or modifies `SKILL.md` command guidance, remote/network examples, or token-like strings, I ran `npm run security:docs` (or equivalent hardening check) and addressed any findings.
- [ ] **Automated Skill Review**: If this PR changes `SKILL.md`, I checked the `skill-review` GitHub Actions result and addressed any actionable feedback.
- [ ] **Manual Logic Review**: If this PR changes `SKILL.md` or risky guidance, I manually reviewed the logic, safety, failure modes, and `risk:` label instead of relying on automated checks alone.
- [ ] **Local Test**: I have verified the skill works locally.
- [ ] **Repo Checks**: I ran `npm run validate:references` if my change affected docs, workflows, or infrastructure.
- [ ] **Source-Only PR**: I did not manually include generated registry artifacts (`CATALOG.md`, `skills_index.json`, `data/*.json`) in this PR.
- [ ] **Credits**: I have added the source credit in `README.md` (if applicable).
- [ ] **License provenance**: If this skill imports from an external `source_repo`, I have declared `license:` and `license_source:` in the frontmatter, or confirmed the upstream repo carries no restricting license.
- [ ] **Maintainer Edits**: I enabled **Allow edits from maintainers** on the PR.

## Screenshots (if applicable)