### PR TITLE
feat: add arrowspace spectral vector search skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -349,6 +349,7 @@ Key source families include:
 
 - **[mattpocock/skills](https://github.com/mattpocock/skills)**: Source for 17 Matt Pocock workflow skills - codebase design, TDD, bug diagnosis, triage, PRDs, issues, prototyping, handoff, teaching, and skill-writing guidance (MIT).
 - **[emilkowalski/skills](https://github.com/emilkowalski/skills)**: Source for Emil Kowalski design engineering skills - UI polish, motion review, animation standards, component craft, and high-taste frontend guidance (MIT).
+- **[Genefold/arrowspace-skills](https://github.com/Genefold/arrowspace-skills)**: Source for the `arrowspace` skill - spectral vector search using graph Laplacian eigenstructure for structurally aware retrieval (Apache-2.0).
 - **[yaojingang/yao-meta-skill](https://github.com/yaojingang/yao-meta-skill)**: Source for the `yao-meta-skill` skill - governed skill creation, refactoring, evaluation, packaging, review, and distribution workflows (MIT).
 - **[connerkward/ckw-design-skill](https://github.com/connerkward/ckw-design-skill)**: Source for the `ckw-design` skill - frontend design direction, design-system guidance, visual philosophy, spatial checks, usability review, and production UI polish workflows (MIT).
 - **[connerkward/deterministic-design-skill](https://github.com/connerkward/deterministic-design-skill)**: Source for the `deterministic-design` skill - rendered UI layout and usability audits using deterministic measurement plus vision-judged review loops (MIT).

--- a/skills/arrowspace/SKILL.md
+++ b/skills/arrowspace/SKILL.md
@@ -1,0 +1,114 @@
+---
+name: arrowspace
+description: "Spectral vector search using graph Laplacian eigenstructure. Use when cosine/L2 similarity misses latent structure in your embeddings."
+category: data
+risk: safe
+source: self
+source_repo: Genefold/arrowspace-skills
+source_type: community
+date_added: "2026-06-25"
+author: Genefold AI
+tags: [vector-search, spectral-analysis, graph-laplacian, embeddings, lambda-tau]
+tools: [claude, cursor, codex, gemini, opencode]
+---
+
+# ArrowSpace
+
+Spectral vector search that augments nearest-neighbour search with graph Laplacian features. Computes a Laplacian over the item graph and uses the Rayleigh quotient to produce a λτ (lambda-tau) score per item, enabling search that respects both semantic similarity and structural role.
+
+## When to Use This Skill
+
+- Cosine or L2 similarity misses latent structure in your embeddings
+- You want graph-based retrieval with spectral awareness
+- You need to characterise the spectral properties of an embedding space
+- You are building RAG pipelines where contextual role matters alongside semantic content
+
+## How It Works
+
+### Step 1: Install and import
+
+```bash
+pip install arrowspace
+```
+
+```python
+from arrowspace import ArrowSpaceBuilder
+import numpy as np
+```
+
+### Step 2: Prepare your data
+
+Pass an (N, d) float64 NumPy array of embedding vectors:
+
+```python
+items = np.array([[0.1, 0.2, 0.3],
+                  [0.0, 0.5, 0.1],
+                  [0.9, 0.1, 0.0]], dtype=np.float64)
+```
+
+### Step 3: Configure graph parameters
+
+```python
+graph_params = {"eps": 0.2, "k": 6, "topk": 3, "p": 2.0, "sigma": 1.0}
+builder = ArrowSpaceBuilder(items, graph_params=graph_params)
+aspace = builder.build()
+```
+
+### Step 4: Query
+
+```python
+lambdas = aspace.lambdas()           # array indexed by insertion order
+sorted_res = aspace.lambdas_sorted()  # (score, index) pairs ascending
+```
+
+Higher λτ values indicate items that are both semantically close and structurally central.
+
+## Examples
+
+### Example 1: Basic spectral retrieval
+
+```python
+items = np.random.randn(100, 64).astype(np.float64)
+builder = ArrowSpaceBuilder(items, graph_params={"eps": 0.5, "k": 10, "topk": 5, "p": 2.0, "sigma": None})
+aspace = builder.build()
+scores = aspace.lambdas()
+top_indices = np.argsort(scores)[-5:]
+```
+
+### Example 2: Compare spectral vs cosine ranking
+
+```python
+from sklearn.metrics.pairwise import cosine_similarity
+cos_sim = cosine_similarity(items)
+cosine_order = np.argsort(cos_sim[0])[::-1]
+spectral_order = np.argsort(aspace.lambdas())[::-1]
+```
+
+## Best Practices
+
+- ✅ Normalise embeddings to unit norm before passing to ArrowSpace
+- ✅ Start with eps proportional to 1/sqrt(dim) and tune from there
+- ✅ Use k between 3 and 25 depending on dataset size (rule: N/50)
+- ✅ Set sigma=None to auto-select kernel width from distance distribution
+- ❌ Don't use with fewer than 10 items (graph structure is not meaningful)
+- ❌ Don't use for real-time streaming data (ArrowSpace is batch-oriented)
+
+## Limitations
+
+- This skill does not replace environment-specific validation, testing, or expert review.
+- ArrowSpace is batch-oriented and not designed for real-time indexing of streaming data.
+
+## Common Pitfalls
+
+- **Problem:** eps is too small, producing a disconnected graph
+  **Solution:** Increase eps, or set it proportional to 1/sqrt(embedding_dim)
+
+- **Problem:** k is too large, producing a dense graph with washed-out spectral features
+  **Solution:** Keep k ≤ 25 for most datasets
+
+## Related Skills
+
+- `vector-database-engineer` — General vector database expertise
+- `embedding-strategies` — Embedding model selection and chunking
+- `similarity-search-patterns` — Semantic search implementation patterns
+- `hybrid-search-implementation` — Combined semantic + keyword search

--- a/skills/arrowspace/SKILL.md
+++ b/skills/arrowspace/SKILL.md
@@ -3,11 +3,13 @@ name: arrowspace
 description: "Spectral vector search using graph Laplacian eigenstructure. Use when cosine/L2 similarity misses latent structure in your embeddings."
 category: data
 risk: safe
-source: self
+source: community
 source_repo: Genefold/arrowspace-skills
 source_type: community
 date_added: "2026-06-25"
 author: Genefold AI
+license: Apache-2.0
+license_source: "https://github.com/Genefold/arrowspace-skills/blob/main/LICENSE"
 tags: [vector-search, spectral-analysis, graph-laplacian, embeddings, lambda-tau]
 tools: [claude, cursor, codex, gemini, opencode]
 ---


### PR DESCRIPTION
# Pull Request Description

This PR adds the `arrowspace` skill for spectral vector search using graph Laplacian eigenstructure for lambda-tau indexed retrieval.

## Change Classification

- [x] Skill PR
- [ ] Docs PR
- [ ] Infra PR

## Issue Link (Optional)

N/A

## Quality Bar Checklist ✅

**All applicable items must be checked before merging.**

- [x] **Standards**: I have read `docs/contributors/quality-bar.md` and `docs/contributors/security-guardrails.md`.
- [x] **Metadata**: The `SKILL.md` frontmatter is valid (checked with `npm run validate`).
- [x] **Risk Label**: I have assigned the correct `risk:` tag (`safe`).
- [x] **Triggers**: The "When to use" section is clear and specific.
- [x] **Limitations**: The skill includes a `## Limitations` (or equivalent accepted constraints) section.
- [ ] **Security**: If this is an _offensive_ skill, I included the "Authorized Use Only" disclaimer. *(N/A - not offensive)*
- [x] **Safety scan**: If this PR adds or modifies `SKILL.md` command guidance, remote/network examples, or token-like strings, I ran `npm run security:docs` (or equivalent hardening check) and addressed any findings.
- [x] **Automated Skill Review**: If this PR changes `SKILL.md`, I checked the `skill-review` GitHub Actions result and addressed any actionable feedback.
- [x] **Manual Logic Review**: If this PR changes `SKILL.md` or risky guidance, I manually reviewed the logic, safety, failure modes, and `risk:` label instead of relying on automated checks alone.
- [x] **Local Test**: I have verified the skill works locally.
- [ ] **Repo Checks**: I ran `npm run validate:references` if my change affected docs, workflows, or infrastructure. *(N/A)*
- [x] **Source-Only PR**: I did not manually include generated registry artifacts (`CATALOG.md`, `skills_index.json`, `data/*.json`) in this PR.
- [x] **Credits**: I have added the source credit in `README.md`.
- [x] **License provenance**: This skill declares Apache-2.0 license provenance from `Genefold/arrowspace-skills`.
- [x] **Maintainer Edits**: I enabled **Allow edits from maintainers** on the PR.

## Maintainer Notes

Maintainer patch added the README community source credit and Apache-2.0 license metadata from https://github.com/Genefold/arrowspace-skills/blob/main/LICENSE.
