### PR TITLE
feat: add ai-loop skill for autonomous dev cycle

### DIFF
--- a/skills/ai-loop/SKILL.md
+++ b/skills/ai-loop/SKILL.md
@@ -7,35 +7,112 @@ source: community
 
 # AI-Loop Skill
 
-## When to use
-Use this skill when you need a feature built from scratch or heavily modified, and you want the agent to autonomously handle the entire lifecycle (specification, implementation, and verification) in a single uninterrupted workflow.
+## Overview
 
-## Limitations
-- This skill requires sufficient context about the feature to be provided during the Spec phase.
-- It is best suited for isolated features or tasks with clear boundaries, rather than open-ended architectural refactoring.
-- The review phase relies on the agent's self-assessment against the generated spec; manual review is still recommended for critical systems.
+The `ai-loop` skill automates the complete development cycle for agentic workflows. By dividing the process into distinct planning (Spec), implementation (Build), and validation (Review) phases, it enables autonomous construction and correction of code features without requiring constant human intervention.
 
-## Instructions
-This skill executes a complete, autonomous development loop composed of three phases: Spec, Build, and Review. When invoked, act as an autonomous agent that transitions through these phases seamlessly to deliver a fully verified feature.
+## When to Use This Skill
 
-## Phase 1: Spec (Planning)
+- Use when you need a feature built from scratch or heavily modified, and you want the agent to autonomously handle the entire lifecycle (specification, implementation, and verification) in a single uninterrupted workflow.
+- Use when working with isolated components, modules, or features that have well-defined scopes and constraints.
+- Use when the user asks for a complete autonomous run of a feature development task.
+
+## How It Works
+
+This skill executes a complete, autonomous development loop composed of three phases: Spec, Build, and Review. When invoked, the agent transitions through these phases seamlessly to deliver a fully verified feature.
+
+### Phase 1: Spec (Planning)
+
 1. Interview the user about the feature or app they want to build. Ask one focused question at a time until you fully understand the goal, the must-have requirements, the constraints, and what "done" looks like.
 2. **Do not start building yet.**
 3. When you have enough information, write a clear, detailed specification and save it to `specs/<feature-name>.md`.
-4. The spec must include: 
+4. The spec must include:
    - The objective
    - The exact requirements
    - Edge cases to handle
    - A concrete definition of done that someone could check the build against.
 
-## Phase 2: Build (Implementation)
+### Phase 2: Build (Implementation)
+
 1. Read the spec you just created in `specs/<feature-name>.md`.
-2. Build exactly what it describes. 
+2. Build exactly what it describes.
 3. **Do not add features**, do not refactor unrelated code, and do not invent requirements that aren't in the spec.
 4. Focus strictly on fulfilling the spec. List which spec requirements you covered so the review step can check them.
 
-## Phase 3: Review (Verification)
+### Phase 3: Review (Verification)
+
 1. Compare your implementation against `specs/<feature-name>.md`.
 2. Go requirement by requirement and verify if it was met. List every gap, bug, or missing piece, naming the exact spec item each one fails.
 3. If anything fails, write the specific fixes needed and **loop back to Phase 2 (Build)** to address them.
 4. Only pass the build and conclude the skill execution when every requirement in the spec is fully met.
+
+## Examples
+
+### Example 1: Creating a Basic Statistics Helper
+
+**User:**
+> I want to add a utility for calculating basic statistics (mean, median, mode) of an array of numbers.
+
+**Agent (Phase 1 - Spec):**
+> I can help with that. To get started, what programming language should this statistics calculator be implemented in? Also, how should empty arrays or invalid inputs be handled?
+
+**User:**
+> JavaScript. If the array is empty, return null. If there are non-numbers, ignore them.
+
+**Agent (Phase 1 - Spec):**
+> Thank you. I have created the specification file at `specs/stats-calculator.md` with the requirements we discussed. Now, I will start implementing it.
+
+**Agent (Phase 2 - Build):**
+> *(Creates `stats_calculator.js` and implements `mean`, `median`, and `mode` matching the spec exactly)*
+> I have finished implementing the calculator. I will now verify the implementation.
+
+**Agent (Phase 3 - Review):**
+> Checking implementation against `specs/stats-calculator.md`:
+> - Requirement: mean calculation -> PASS
+> - Requirement: median calculation -> PASS
+> - Requirement: mode calculation -> PASS
+> - Requirement: empty array returns null -> PASS
+> - Requirement: non-numbers are ignored -> FAIL (I noticed `mode` doesn't filter out non-numbers).
+>
+> I will now loop back to Phase 2 to fix the `mode` function.
+
+**Agent (Phase 2 - Build Loop-Back):**
+> *(Fixes `mode` to filter out non-numbers)*
+> I have updated the implementation. Let's re-verify.
+
+**Agent (Phase 3 - Review):**
+> - Requirement: mode filters non-numbers -> PASS
+> 
+> All requirements passed! The statistics calculator is complete and verified.
+
+## Best Practices
+
+- ✅ Do ask clarifying questions one at a time to avoid overwhelming the user during the planning phase.
+- ✅ Do document edge cases explicitly in `specs/<feature-name>.md` before writing any code.
+- ✅ Do stick strictly to the approved specification during the build phase.
+- ❌ Don't implement extra features or perform unrelated refactorings that aren't specified.
+- ❌ Don't skip the review phase or pass it without verifying every single requirement.
+
+## Limitations
+
+- This skill requires sufficient context about the feature to be provided during the Spec phase.
+- It is best suited for isolated features or tasks with clear boundaries, rather than open-ended architectural refactoring.
+- The review phase relies on the agent's self-assessment against the generated spec; manual review is still recommended for critical systems.
+
+## Security & Safety Notes
+
+- Be cautious when running or testing code generated during the Build phase. Always run tests in a safe, sandboxed environment.
+- Avoid executing arbitrary shell commands provided directly by the user without validating their safety.
+- Make sure no hardcoded secrets, keys, or credentials are added to the code or specifications.
+
+## Common Pitfalls
+
+- **Problem:** The agent tries to build a huge system all at once, leading to an overcomplicated spec and incomplete implementation.
+  **Solution:** Keep the scope of `ai-loop` to small, modular features. Break larger systems into multiple independent loops.
+- **Problem:** The spec is vague, causing the build phase to rely on assumptions.
+  **Solution:** Spend extra time in the planning phase asking targeted questions to pin down requirements.
+
+## Related Skills
+
+- `@plan-writing` - For writing more detailed implementation plans for larger projects.
+- `@ask-questions-if-underspecified` - For standard guidelines on interviewing the user.

--- a/skills/ai-loop/SKILL.md
+++ b/skills/ai-loop/SKILL.md
@@ -1,0 +1,32 @@
+---
+name: ai-loop
+description: Executes a complete, autonomous development loop composed of three phases (Spec, Build, Review) without manual intervention.
+risk: safe
+source: community
+---
+
+# AI-Loop Skill
+
+This skill executes a complete, autonomous development loop composed of three phases: Spec, Build, and Review. When invoked, act as an autonomous agent that transitions through these phases seamlessly to deliver a fully verified feature.
+
+## Phase 1: Spec (Planning)
+1. Interview the user about the feature or app they want to build. Ask one focused question at a time until you fully understand the goal, the must-have requirements, the constraints, and what "done" looks like.
+2. **Do not start building yet.**
+3. When you have enough information, write a clear, detailed specification and save it to `specs/<feature-name>.md`.
+4. The spec must include: 
+   - The objective
+   - The exact requirements
+   - Edge cases to handle
+   - A concrete definition of done that someone could check the build against.
+
+## Phase 2: Build (Implementation)
+1. Read the spec you just created in `specs/<feature-name>.md`.
+2. Build exactly what it describes. 
+3. **Do not add features**, do not refactor unrelated code, and do not invent requirements that aren't in the spec.
+4. Focus strictly on fulfilling the spec. List which spec requirements you covered so the review step can check them.
+
+## Phase 3: Review (Verification)
+1. Compare your implementation against `specs/<feature-name>.md`.
+2. Go requirement by requirement and verify if it was met. List every gap, bug, or missing piece, naming the exact spec item each one fails.
+3. If anything fails, write the specific fixes needed and **loop back to Phase 2 (Build)** to address them.
+4. Only pass the build and conclude the skill execution when every requirement in the spec is fully met.

--- a/skills/ai-loop/SKILL.md
+++ b/skills/ai-loop/SKILL.md
@@ -7,6 +7,15 @@ source: community
 
 # AI-Loop Skill
 
+## When to use
+Use this skill when you need a feature built from scratch or heavily modified, and you want the agent to autonomously handle the entire lifecycle (specification, implementation, and verification) in a single uninterrupted workflow.
+
+## Limitations
+- This skill requires sufficient context about the feature to be provided during the Spec phase.
+- It is best suited for isolated features or tasks with clear boundaries, rather than open-ended architectural refactoring.
+- The review phase relies on the agent's self-assessment against the generated spec; manual review is still recommended for critical systems.
+
+## Instructions
 This skill executes a complete, autonomous development loop composed of three phases: Spec, Build, and Review. When invoked, act as an autonomous agent that transitions through these phases seamlessly to deliver a fully verified feature.
 
 ## Phase 1: Spec (Planning)

--- a/skills/ai-loop/SKILL.md
+++ b/skills/ai-loop/SKILL.md
@@ -1,25 +1,35 @@
 ---
 name: ai-loop
-description: Executes a complete, autonomous development loop composed of three phases (Spec, Build, Review) without manual intervention.
+description: Runs a bounded spec-build-review development loop with explicit scope, stop conditions, and human approval gates for risky or ambiguous work.
+category: workflow
 risk: safe
 source: community
+date_added: "2026-06-27"
+tags: [agent-workflow, specification, implementation, review, verification, feedback-loop]
+tools: [claude, cursor, codex, gemini]
 ---
 
 # AI-Loop Skill
 
 ## Overview
 
-The `ai-loop` skill automates the complete development cycle for agentic workflows. By dividing the process into distinct planning (Spec), implementation (Build), and validation (Review) phases, it enables autonomous construction and correction of code features without requiring constant human intervention.
+The `ai-loop` skill structures a bounded development cycle for agentic workflows. By dividing the process into distinct planning (Spec), implementation (Build), and validation (Review) phases, it helps an agent build and correct scoped code changes while keeping requirements, risk gates, and stop conditions explicit.
 
 ## When to Use This Skill
 
-- Use when you need a feature built from scratch or heavily modified, and you want the agent to autonomously handle the entire lifecycle (specification, implementation, and verification) in a single uninterrupted workflow.
+- Use when you need a feature built from scratch or heavily modified, and you want the agent to handle the lifecycle (specification, implementation, and verification) inside one clearly bounded workflow.
 - Use when working with isolated components, modules, or features that have well-defined scopes and constraints.
-- Use when the user asks for a complete autonomous run of a feature development task.
+- Use when the user asks for a complete development pass but the work still has clear success criteria, a reasonable verification path, and no unresolved safety or product decisions.
 
 ## How It Works
 
-This skill executes a complete, autonomous development loop composed of three phases: Spec, Build, and Review. When invoked, the agent transitions through these phases seamlessly to deliver a fully verified feature.
+This skill executes a controlled development loop composed of three phases: Spec, Build, and Review. When invoked, the agent moves through those phases until the scoped requirements pass verification, a stop condition is reached, or human approval is needed.
+
+Before starting, define:
+
+- The maximum number of build-review iterations.
+- The verification commands or manual checks that count as evidence.
+- The actions that require explicit approval, such as destructive commands, production changes, external service writes, or broad architectural pivots.
 
 ### Phase 1: Spec (Planning)
 
@@ -30,7 +40,8 @@ This skill executes a complete, autonomous development loop composed of three ph
    - The objective
    - The exact requirements
    - Edge cases to handle
-   - A concrete definition of done that someone could check the build against.
+   - A concrete definition of done that someone could check the build against
+   - The iteration budget, verification commands, and approval gates.
 
 ### Phase 2: Build (Implementation)
 
@@ -43,8 +54,9 @@ This skill executes a complete, autonomous development loop composed of three ph
 
 1. Compare your implementation against `specs/<feature-name>.md`.
 2. Go requirement by requirement and verify if it was met. List every gap, bug, or missing piece, naming the exact spec item each one fails.
-3. If anything fails, write the specific fixes needed and **loop back to Phase 2 (Build)** to address them.
-4. Only pass the build and conclude the skill execution when every requirement in the spec is fully met.
+3. If anything fails and the iteration budget is not exhausted, write the specific fixes needed and **loop back to Phase 2 (Build)** to address them.
+4. Stop and ask for human input when the next fix would change the spec, exceed the iteration budget, require risky operations, or depend on product decisions not captured in the spec.
+5. Only pass the build and conclude the skill execution when every requirement in the spec is fully met and the declared verification evidence has passed.
 
 ## Examples
 
@@ -90,20 +102,26 @@ This skill executes a complete, autonomous development loop composed of three ph
 - ✅ Do ask clarifying questions one at a time to avoid overwhelming the user during the planning phase.
 - ✅ Do document edge cases explicitly in `specs/<feature-name>.md` before writing any code.
 - ✅ Do stick strictly to the approved specification during the build phase.
+- ✅ Do cap the loop with a small iteration budget and report exactly what remains if the budget is exhausted.
+- ✅ Do pause for explicit approval before destructive, production, credentialed, or externally visible actions.
 - ❌ Don't implement extra features or perform unrelated refactorings that aren't specified.
 - ❌ Don't skip the review phase or pass it without verifying every single requirement.
+- ❌ Don't keep retrying the same failing fix without new evidence or a changed approach.
 
 ## Limitations
 
 - This skill requires sufficient context about the feature to be provided during the Spec phase.
 - It is best suited for isolated features or tasks with clear boundaries, rather than open-ended architectural refactoring.
 - The review phase relies on the agent's self-assessment against the generated spec; manual review is still recommended for critical systems.
+- It is not a replacement for human approval on security-sensitive, destructive, production, compliance, or externally visible changes.
+- It should stop rather than continue if requirements conflict, tests cannot run, or verification depends on unavailable credentials or systems.
 
 ## Security & Safety Notes
 
 - Be cautious when running or testing code generated during the Build phase. Always run tests in a safe, sandboxed environment.
 - Avoid executing arbitrary shell commands provided directly by the user without validating their safety.
 - Make sure no hardcoded secrets, keys, or credentials are added to the code or specifications.
+- Treat production deploys, data migrations, payment flows, credential changes, and external write actions as approval-gated work.
 
 ## Common Pitfalls
 


### PR DESCRIPTION
# Pull Request Description

Adds the `ai-loop` skill, which unifies the autonomous development cycle into a single, closed-loop workflow without manual intervention. It orchestrates three continuous phases:
1. **Spec**: Interviews the user to define clear requirements and edge cases.
2. **Build**: Implements exactly what the spec describes, avoiding scope creep.
3. **Review**: Self-assesses the implementation line-by-line against the spec, sending failures back to the Build phase until everything passes.

## Change Classification

- [x] Skill PR
- [ ] Docs PR
- [ ] Infra PR

## Issue Link (Optional)

## Quality Bar Checklist ✅

**All applicable items must be checked before merging.**

- [x] **Standards**: I have read `docs/contributors/quality-bar.md` and `docs/contributors/security-guardrails.md`.
- [x] **Metadata**: The `SKILL.md` frontmatter is valid (checked with `npm run validate`).
- [x] **Risk Label**: I have assigned the correct `risk:` tag (`none`, `safe`, `critical`, `offensive`, or `unknown` for legacy/unclassified content).
- [x] **Triggers**: The "When to use" section is clear and specific.
- [x] **Limitations**: The skill includes a `## Limitations` (or equivalent accepted constraints) section.
- [ ] **Security**: If this is an _offensive_ skill, I included the "Authorized Use Only" disclaimer.
- [ ] **Safety scan**: If this PR adds or modifies `SKILL.md` command guidance, remote/network examples, or token-like strings, I ran `npm run security:docs` (or equivalent hardening check) and addressed any findings.
- [x] **Automated Skill Review**: If this PR changes `SKILL.md`, I checked the `skill-review` GitHub Actions result and addressed any actionable feedback.
- [x] **Manual Logic Review**: If this PR changes `SKILL.md` or risky guidance, I manually reviewed the logic, safety, failure modes, and `risk:` label instead of relying on automated checks alone.
- [x] **Local Test**: I have verified the skill works locally.
- [ ] **Repo Checks**: I ran `npm run validate:references` if my change affected docs, workflows, or infrastructure.
- [x] **Source-Only PR**: I did not manually include generated registry artifacts (`CATALOG.md`, `skills_index.json`, `data/*.json`) in this PR.
- [ ] **Credits**: I have added the source credit in `README.md` (if applicable).
- [ ] **License provenance**: If this skill imports from an external `source_repo`, I have declared `license:` and `license_source:` in the frontmatter, or confirmed the upstream repo carries no restricting license.
- [x] **Maintainer Edits**: I enabled **Allow edits from maintainers** on the PR.

## Screenshots (if applicable)
