### PR TITLE
Add Vexilo · A field guide to Claude Code to Compare alternatives

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,6 +242,7 @@ Use the root repo as a landing page, then jump into the deeper surface that matc
 - **[Antigravity Awesome Skills vs Awesome Claude Skills](docs/users/antigravity-awesome-skills-vs-awesome-claude-skills.md)** for breadth vs curated-list tradeoffs.
 - **[Best Claude Code skills on GitHub](docs/users/best-claude-code-skills-github.md)** for a high-intent shortlist.
 - **[Best Cursor skills on GitHub](docs/users/best-cursor-skills-github.md)** for Cursor-compatible options and selection criteria.
+- **[Vexilo · A field guide to Claude Code](https://vexilo.app/?lang=en)** — different scope: a visual, searchable index of every Claude Code primitive (31 agents / 99 commands / 123 skills / 13 rules), organized around the 5-step workflow. Useful as a navigation layer *over* any skill library, not as a skill library itself. ([companion repo](https://github.com/lilhawk7077/claude-code-resources))
 
 ## Troubleshooting
 


### PR DESCRIPTION
## Adds Vexilo · A field guide to Claude Code to the Compare alternatives section

[Vexilo](https://vexilo.app/?lang=en) is a different kind of resource than the entries already here:

| Project | Type | What it gives you |
|---|---|---|
| Antigravity Awesome Skills | Skill library | 1,700+ installable skills |
| Awesome Claude Skills | Curated list | Curated shortlist of skills |
| **Vexilo** | **Visual index** | **Searchable, scenario-organized map of all agents / commands / skills / rules across the ecosystem** |

Vexilo is complementary rather than competitive: it sits *over* skill libraries as a navigation layer. The README explicitly says "Keep the root README short; use the dedicated docs for recovery and platform-specific guidance" — but for new users deciding *which* skill to invoke, the bottleneck isn't discovery (they have 1,700 here) but **decision support**. That's Vexilo's gap to fill.

### Entry details
- URL: https://vexilo.app/?lang=en
- Companion repo (MIT): https://github.com/lilhawk7077/claude-code-resources
- Active: v1.1.9, weekly updates
- Browser-based, zero install

### Checklist
- [x] Distinct scope from existing entries (visual index, not a skill library)
- [x] No duplicate of existing entry
- [x] Placed in the section most relevant to "how does this compare?"
- [x] Companion repo MIT-licensed and actively maintained