### PR TITLE
feat: add time-ledger for natural-language time tracking into your own Notion DB

### DIFF
--- a/README.md
+++ b/README.md
@@ -358,6 +358,7 @@ Key source families include:
 
 ### Community Contributors
 
+- **[cruisekkk/time-ledger](https://github.com/cruisekkk/time-ledger)**: Source for the `time-ledger` skill - natural-language time tracking parsed into the user's own Notion database with ask-instead-of-guessing reconciliation (MIT).
 - **[mattpocock/skills](https://github.com/mattpocock/skills)**: Source for 17 Matt Pocock workflow skills - codebase design, TDD, bug diagnosis, triage, PRDs, issues, prototyping, handoff, teaching, and skill-writing guidance (MIT).
 - **[emilkowalski/skills](https://github.com/emilkowalski/skills)**: Source for Emil Kowalski design engineering skills - UI polish, motion review, animation standards, component craft, and high-taste frontend guidance (MIT).
 - **[chaunsin/agent-skills](https://github.com/chaunsin/agent-skills)**: Source for the `pre-release-review` and `drizzle-migration-conflict` skills - deploy-readiness audits and Drizzle Kit migration-conflict workflows (Apache-2.0).

--- a/skills/time-ledger/SKILL.md
+++ b/skills/time-ledger/SKILL.md
@@ -37,7 +37,7 @@ The companion Notion template (free, linked in the source repo) ships this field
 - `Entry` (title) — the user's words or a clear title
 - `Activity` (select): Reading / Coding / Practice / Fitness / Investing / Meeting / Writing / Life / Other
 - `Minutes` (number)
-- `Date` (date) — expand to `"date:Date:start": "YYYY-MM-DD"` (a bare value 400s)
+- `Date` (date) — expand to `"date:Date:start": "YYYY-MM-DD"`; a bare `Date` value fails with HTTP 400
 - `Status` (select): To-sort / To-confirm / Done
 - `Compounding` (select): Compounding / Consuming / Neutral
 - `Notes` (text) — clue from the user's words / your question
@@ -106,6 +106,8 @@ Agent: 3 rows need confirmation — answering in one go works:
 
 - **Problem:** Notion API returns 400 on the date field.
   **Solution:** Expand to `"date:Date:start": "YYYY-MM-DD"` — a bare `Date` value fails.
+- **Problem:** `create-pages` succeeds but the Date column is empty (known Notion MCP issue: [notion-mcp-server#121](https://github.com/makenotion/notion-mcp-server/issues/121) — expanded date fields silently dropped).
+  **Solution:** After the session's first create, read the row back; if `Date` is empty, fill it with `update-page`.
 - **Problem:** Search returns example-row pages instead of the database.
   **Solution:** Filter for type `database` when resolving "time-ledger".
 - **Problem:** Model clock vs user timezone differ around midnight.

--- a/skills/time-ledger/SKILL.md
+++ b/skills/time-ledger/SKILL.md
@@ -1,0 +1,116 @@
+---
+name: time-ledger
+description: "Natural-language time tracking: parse what the user says they did into Activity/Minutes/Date rows in their own Notion database — asking instead of guessing when unsure."
+category: productivity
+risk: critical
+source: community
+source_repo: cruisekkk/time-ledger
+source_type: community
+date_added: "2026-07-04"
+author: cruisekkk
+tags: [time-tracking, notion, quantified-self, productivity, journaling]
+tools: [claude]
+license: "MIT"
+license_source: "https://github.com/cruisekkk/time-ledger/blob/main/LICENSE"
+---
+
+# Time Ledger
+
+## Overview
+
+Conversational time tracking. The user reports time in plain language — *"read papers 2h, gym 1h, did a leetcode"* — and the agent parses it into structured rows (activity, minutes, date, an optional compounding tag) and writes them to the user's own Notion database through the official Notion connector. The core design is an honesty contract: **anything uncertain becomes a `To-confirm` row and gets batch-asked — never fabricated.** A log that quietly invents durations is worse than no log.
+
+## When to Use This Skill
+
+- Use when the user reports time spent ("read papers for two hours", "hit the gym for an hour", "coded all morning")
+- Use when the user says "log it", "log my time", "time ledger", or "tidy up my time ledger"
+- Use when the user asks where their time went or for a time review
+
+## How It Works
+
+### Step 1: Find the database (zero-config)
+
+On the first write of a session, use Notion `search` to find the **database** (type `database`, not a page) whose title contains **"time-ledger"**. Read its `data_source_id` (the `collection://...` UUID) and use it as the parent for `create-pages` / `query` for the rest of the session. If more than one matches, ask the user which to use. Nothing is pasted or configured.
+
+The companion Notion template (free, linked in the source repo) ships this field schema — select values are a controlled enum, copy them exactly:
+
+- `Entry` (title) — the user's words or a clear title
+- `Activity` (select): Reading / Coding / Practice / Fitness / Investing / Meeting / Writing / Life / Other
+- `Minutes` (number)
+- `Date` (date) — expand to `"date:Date:start": "YYYY-MM-DD"` (a bare value 400s)
+- `Status` (select): To-sort / To-confirm / Done
+- `Compounding` (select): Compounding / Consuming / Neutral
+- `Notes` (text) — clue from the user's words / your question
+
+### Step 2: Direct report mode
+
+Parse the report → `create-pages` (parent = the data source id above). Set `Status=Done` for what is certain; for anything uncertain set `Status=To-confirm`, write the specific question in `Notes`, and ask it once in your reply.
+
+Parsing rules:
+
+- **Activity**: books/technical material → Reading; coding/building → Coding; leetcode → Practice; gym/running → Fitness; markets/research → Investing; meetings → Meeting; docs → Writing; meals/commute/chores → Life; otherwise → Other. Unsure → To-confirm.
+- **Duration cues**: "two hours"=120, "an hour"=60, "half an hour"=30, "a while"≈30 (mark To-confirm, note it is an estimate), "all morning"≈180. Use exact numbers when given.
+- **Date**: "today" = the user's local date; "yesterday" = prior day; unspecified = today. Unsure which day → ask.
+- **One report, multiple blocks**: "two hours on X, one hour on Y" → split into rows, but confirm whether the totals are additive (a frequent ambiguity) — default additive + one To-confirm row.
+- **Compounding tag**: only tag the obvious — Compounding = leaves a reusable asset (learning, building, writing); Consuming = forget-on-sight entertainment (only if the user volunteers it); leave ambiguous blank.
+
+### Step 3: Batch reconcile mode
+
+When the user says "tidy up my time ledger": query rows where `Status` ∈ {To-sort, To-confirm} or empty → parse each → `update-page` the certain ones to `Done`; batch **all** remaining questions into one message; fill answers in when the user replies.
+
+## Examples
+
+### Example 1: Direct report
+
+```text
+User:  log it: read ML system design 2h, gym 1h, did a leetcode
+Agent: Logged 3 entries ✅
+       · Reading · ML system design · 120min · Compounding
+       · Fitness · gym · 60min
+       · Practice · LeetCode · ~20min ❓ To-confirm: you didn't say how long — I guessed 20min, right?
+```
+
+### Example 2: Batch reconcile
+
+```text
+User:  tidy up my time ledger
+Agent: 3 rows need confirmation — answering in one go works:
+       1. Tue "LeetCode" — how many minutes?
+       2. Wed "reading" — book or papers (Reading), or course exercises (Practice)?
+       3. "all afternoon on the deck" — Wed or Thu?
+```
+
+## Best Practices
+
+- ✅ Batch all questions into one message; never interrogate item by item
+- ✅ Give a short receipt after logging (rows written, which are To-confirm, what the questions are)
+- ✅ Copy select values from the enum exactly
+- ❌ Don't fabricate a duration, category, or date when unsure — To-confirm + ask
+- ❌ Don't write a bare `Date` property; use the `date:Date:start` expansion
+- ❌ Don't judge the user's Consuming hours; the ledger is a mirror, not a critic
+
+## Limitations
+
+- Requires the user's own Notion workspace, the companion database (duplicate the template from the source repo), and the official Notion connector granted access to that database — connector/skill setups currently live on paid Claude tiers.
+- Self-report only, by design: it does not auto-track apps or screens (an auto-tracker knows what was open, not *why* the time was spent).
+- The Compounding/Consuming tags are hand rules, not a learned model.
+- Select enums must match the template; if the user renames fields, the instructions above must be mirrored to match.
+
+## Security & Safety Notes
+
+- **Mutation scope**: writes and updates rows only in the single user-granted Notion database, via the official Notion connector (MCP) — no shell commands, no network fetches, no credentials handled by the skill.
+- On claude.ai, Notion's write tools default to *needs approval* — the first write pops an approval prompt; this is expected, not a hang.
+- The honesty contract is also a safety property: when parsing confidence is low, the skill records `To-confirm` and asks, rather than writing invented data into the user's records.
+
+## Common Pitfalls
+
+- **Problem:** Notion API returns 400 on the date field.
+  **Solution:** Expand to `"date:Date:start": "YYYY-MM-DD"` — a bare `Date` value fails.
+- **Problem:** Search returns example-row pages instead of the database.
+  **Solution:** Filter for type `database` when resolving "time-ledger".
+- **Problem:** Model clock vs user timezone differ around midnight.
+  **Solution:** Treat "today" as the user's local date; ask when it could go either way.
+
+## Related Skills
+
+- `@trading-ledger` - The same "parse plain language → own Notion DB → ask instead of guessing" pattern applied to trading journals (entry thesis, plan, emotion).


### PR DESCRIPTION
Adds **time-ledger** — natural-language time tracking into the user's own Notion database via the official Notion connector. The user says *"read papers 2h, gym 1h"*; the skill parses activity/minutes/date and writes rows, with an explicit honesty contract: anything uncertain becomes a `To-confirm` row and is batch-asked, never fabricated.

Vendored from my repo [cruisekkk/time-ledger](https://github.com/cruisekkk/time-ledger) (MIT, bilingual EN/中文, companion free Notion template) and adapted to the canonical skill template. The upstream skill has been my daily driver since June 2026.

## Change Classification

- [x] Skill PR
- [ ] Docs PR
- [ ] Infra PR

## Issue Link (Optional)

N/A

## Quality Bar Checklist ✅

- [x] **Standards**: I have read `docs/contributors/quality-bar.md` and `docs/contributors/security-guardrails.md`.
- [x] **Metadata**: The `SKILL.md` frontmatter is valid (checked with `npm run validate` — all skills passed).
- [x] **Risk Label**: `risk: critical` — it mutates user state (appends/updates rows in the user-granted Notion database), matching the existing `notion-automation` precedent.
- [x] **Triggers**: "When to Use This Skill" lists concrete trigger phrases.
- [x] **Limitations**: Included (own Notion + connector required, paid-tier constraint, self-report by design).
- [x] **Security**: Not an offensive skill (N/A) — mutation scope documented under Security & Safety Notes; no shell/network/credential guidance.
- [x] **Safety scan**: Ran `npm run security:docs` — passed.
- [ ] **Automated Skill Review**: Will address any actionable findings from the `skill-review` workflow on this PR.
- [x] **Manual Logic Review**: Reviewed logic/failure modes manually — instructions are adapted from the upstream skill in daily production use, including the Notion date-property 400 gotcha and enum-copy rules.
- [x] **Local Test**: The upstream skill (identical operative instructions) runs daily against a real Notion database on Claude Code and claude.ai.
- [x] **Repo Checks**: Ran `npm run validate:references` — all references valid. `npm run check:readme-credits` — passes.
- [x] **Source-Only PR**: No generated registry artifacts included.
- [x] **Credits**: Added `cruisekkk/time-ledger` to `### Community Contributors` in `README.md`.
- [x] **License provenance**: `license: MIT` + `license_source` declared in frontmatter (I am the upstream author).
- [x] **Maintainer Edits**: Allow edits from maintainers is enabled.
