### PR TITLE
feat: add go-in-depth skill for deep research

### DIFF
--- a/skills/go-in-depth/SKILL.md
+++ b/skills/go-in-depth/SKILL.md
@@ -2,7 +2,8 @@
 name: go-in-depth
 description: Go in depth harness — fan-out web searches, fetch sources, adversarially verify claims, synthesize a cited report.
 risk: safe
-source: community
+source: self
+source_type: self
 date_added: "2026-07-07"
 ---
 

--- a/skills/go-in-depth/SKILL.md
+++ b/skills/go-in-depth/SKILL.md
@@ -1,0 +1,58 @@
+---
+name: go-in-depth
+description: Go in depth harness — fan-out web searches, fetch sources, adversarially verify claims, synthesize a cited report.
+risk: safe
+source: community
+date_added: "2026-07-07"
+---
+
+# Go In Depth
+
+## Overview
+
+Go in depth harness — fan-out web searches, fetch sources, adversarially verify claims, synthesize a cited report. Run the "go-in-depth" workflow.
+
+## When to Use
+
+When the user wants a deep, multi-source, fact-checked research report on any topic. BEFORE invoking, check if the question is specific enough to research directly — if underspecified (e.g., "what car to buy" without budget/use-case/region), ask 2-3 clarifying questions to narrow scope. Then pass the refined question as args, weaving the answers in.
+
+## How It Works
+
+Phases:
+- Scope: Decompose question (from args) into 5 search angles
+- Search: 5 parallel WebSearch agents, one per angle
+- Fetch: URL-dedup, fetch top 15 sources, extract falsifiable claims
+- Verify: 3-vote adversarial verification per claim (need 2/3 refutes to kill)
+- Synthesize: Merge semantic dupes, rank by confidence, cite sources
+
+## Examples
+
+### Example 1: Run go-in-depth workflow
+```
+Workflow({ name: "go-in-depth" })
+```
+
+### Example 2: Research with refined question
+```
+Workflow({ name: "go-in-depth", args: { query: "best hybrid cars under $30k in the US for families" } })
+```
+
+### Example 3: Deep dive into a technical concept
+```
+Workflow({ name: "go-in-depth", args: { query: "how does the transformer architecture handle positional encoding?" } })
+```
+
+### Example 4: Fact-checking a medical claim
+```
+Workflow({ name: "go-in-depth", args: { query: "efficacy of intermittent fasting for long-term weight loss in adults" } })
+```
+
+## Workflow Script
+
+[scripts/workflow-script.js](scripts/workflow-script.js)
+
+## Limitations
+
+- **Slow execution**: Multi-agent searches, fetching, and 3-vote verification take significant time. Not for quick facts.
+- **Context intensive**: Analyzing 15 full sources uses large context limits.
+- **Synthesis risks**: May struggle if source material is weak or equally conflicting.

--- a/skills/go-in-depth/scripts/workflow-script.js
+++ b/skills/go-in-depth/scripts/workflow-script.js
@@ -6,7 +6,7 @@ export const meta = {
 }
 
 // go-in-depth: Scope → pipeline(Search → URL-dedup → Fetch+Extract) → 3-vote Verify → Synthesize
-// Ported from bughunter architecture. WebSearch/WebFetch instead of git/grep.
+// Uses a bug-hunting-style fan-out and verification pattern, adapted for web research.
 // Question is passed via Workflow({name: 'go-in-depth', args: '<question>'}).
 
 const VOTES_PER_CLAIM = 3

--- a/skills/go-in-depth/scripts/workflow-script.js
+++ b/skills/go-in-depth/scripts/workflow-script.js
@@ -89,7 +89,7 @@ const REPORT_SCHEMA = {
 
 // ─── Phase 0: Scope — decompose question into search angles ───
 phase("Scope")
-const QUESTION = (typeof args === "string" && args.trim()) || ""
+const QUESTION = (typeof args === "string" ? args.trim() : args?.query?.trim()) || ""
 if (!QUESTION) {
   return { error: "No research question provided. Pass it as args: Workflow({name: 'go-in-depth', args: '<question>'})." }
 }
@@ -185,7 +185,7 @@ const searchResults = await pipeline(
         dupes.push({ ...r, angle: searchResult.angle, dupOf: seen.get(key) })
         return false
       }
-      if (fetchSlots <= 0 && relRank[r.relevance] >= 1) {
+      if (fetchSlots <= 0) {
         budgetDropped.push({ ...r, angle: searchResult.angle })
         return false
       }

--- a/skills/go-in-depth/scripts/workflow-script.js
+++ b/skills/go-in-depth/scripts/workflow-script.js
@@ -1,0 +1,350 @@
+export const meta = {
+  name: 'go-in-depth',
+  description: 'Go in depth harness — fan-out web searches, fetch sources, adversarially verify claims, synthesize a cited report.',
+  whenToUse: 'When the user wants a deep, multi-source, fact-checked research report on any topic. BEFORE invoking, check if the question is specific enough to research directly — if underspecified (e.g., "what car to buy" without budget/use-case/region), ask 2-3 clarifying questions to narrow scope. Then pass the refined question as args, weaving the answers in.',
+  phases: [{"title":"Scope","detail":"Decompose question (from args) into 5 search angles"},{"title":"Search","detail":"5 parallel WebSearch agents, one per angle"},{"title":"Fetch","detail":"URL-dedup, fetch top 15 sources, extract falsifiable claims"},{"title":"Verify","detail":"3-vote adversarial verification per claim (need 2/3 refutes to kill)"},{"title":"Synthesize","detail":"Merge semantic dupes, rank by confidence, cite sources"}],
+}
+
+// go-in-depth: Scope → pipeline(Search → URL-dedup → Fetch+Extract) → 3-vote Verify → Synthesize
+// Ported from bughunter architecture. WebSearch/WebFetch instead of git/grep.
+// Question is passed via Workflow({name: 'go-in-depth', args: '<question>'}).
+
+const VOTES_PER_CLAIM = 3
+const REFUTATIONS_REQUIRED = 2
+const MAX_FETCH = 15
+const MAX_VERIFY_CLAIMS = 25
+
+// ─── Schemas ───
+const SCOPE_SCHEMA = {
+  type: "object", required: ["question", "angles", "summary"],
+  properties: {
+    question: { type: "string" },
+    summary: { type: "string" },
+    angles: { type: "array", minItems: 3, maxItems: 6, items: {
+      type: "object", required: ["label", "query"],
+      properties: {
+        label: { type: "string" },
+        query: { type: "string" },
+        rationale: { type: "string" },
+      },
+    }},
+  },
+}
+const SEARCH_SCHEMA = {
+  type: "object", required: ["results"],
+  properties: {
+    results: { type: "array", maxItems: 6, items: {
+      type: "object", required: ["url", "title", "relevance"],
+      properties: {
+        url: { type: "string" },
+        title: { type: "string" },
+        snippet: { type: "string" },
+        relevance: { enum: ["high", "medium", "low"] },
+      },
+    }},
+  },
+}
+const EXTRACT_SCHEMA = {
+  type: "object", required: ["claims", "sourceQuality"],
+  properties: {
+    sourceQuality: { enum: ["primary", "secondary", "blog", "forum", "unreliable"] },
+    publishDate: { type: "string" },
+    claims: { type: "array", maxItems: 5, items: {
+      type: "object", required: ["claim", "quote", "importance"],
+      properties: {
+        claim: { type: "string" },
+        quote: { type: "string" },
+        importance: { enum: ["central", "supporting", "tangential"] },
+      },
+    }},
+  },
+}
+const VERDICT_SCHEMA = {
+  type: "object", required: ["refuted", "evidence", "confidence"],
+  properties: {
+    refuted: { type: "boolean" },
+    evidence: { type: "string" },
+    confidence: { enum: ["high", "medium", "low"] },
+    counterSource: { type: "string" },
+  },
+}
+const REPORT_SCHEMA = {
+  type: "object", required: ["summary", "findings", "caveats"],
+  properties: {
+    summary: { type: "string" },
+    findings: { type: "array", items: {
+      type: "object", required: ["claim", "confidence", "sources", "evidence"],
+      properties: {
+        claim: { type: "string" },
+        confidence: { enum: ["high", "medium", "low"] },
+        sources: { type: "array", items: { type: "string" } },
+        evidence: { type: "string" },
+        vote: { type: "string" },
+      },
+    }},
+    caveats: { type: "string" },
+    openQuestions: { type: "array", items: { type: "string" } },
+  },
+}
+
+// ─── Phase 0: Scope — decompose question into search angles ───
+phase("Scope")
+const QUESTION = (typeof args === "string" && args.trim()) || ""
+if (!QUESTION) {
+  return { error: "No research question provided. Pass it as args: Workflow({name: 'go-in-depth', args: '<question>'})." }
+}
+const scope = await agent(
+  "Decompose this research question into complementary search angles.\n\n" +
+  "## Question\n" + QUESTION + "\n\n" +
+  "## Task\n" +
+  "Generate 5 distinct web search queries that together cover the question from different angles. Pick angles that suit the question's domain. Examples:\n" +
+  "- broad/primary  · academic/technical  · recent news  · contrarian/skeptical  · practitioner/implementation\n" +
+  "- For medical: anatomy · common causes · serious differentials · authoritative refs · red flags\n" +
+  "- For tech: state-of-art · benchmarks · limitations · industry adoption · cost/tradeoffs\n\n" +
+  "Make queries specific enough to surface high-signal results. Avoid redundancy.\n" +
+  "Return: the question (verbatim or lightly normalized), a 1-2 sentence decomposition strategy, and the angles.\n\nStructured output only.",
+  { label: "scope", schema: SCOPE_SCHEMA }
+)
+if (!scope) {
+  return { error: "Scope agent returned no result — cannot decompose the research question." }
+}
+log("Q: " + QUESTION.slice(0, 80) + (QUESTION.length > 80 ? "…" : ""))
+log("Decomposed into " + scope.angles.length + " angles: " + scope.angles.map(a => a.label).join(", "))
+
+// ─── Dedup state — accumulates across searchers as they complete ───
+const normURL = u => {
+  try {
+    const p = new URL(u)
+    return (p.hostname.replace(/^www\./, "") + p.pathname.replace(/\/$/, "")).toLowerCase()
+  } catch { return u.toLowerCase() }
+}
+const seen = new Map()
+const dupes = []
+const budgetDropped = []
+const relRank = { high: 0, medium: 1, low: 2 }
+let fetchSlots = MAX_FETCH
+
+// ─── Prompts ───
+const SEARCH_PROMPT = (angle) =>
+  "## Web Searcher: " + angle.label + "\n\n" +
+  "Research question: \"" + QUESTION + "\"\n\n" +
+  "Your angle: **" + angle.label + "** — " + (angle.rationale || "") + "\n" +
+  "Search query: `" + angle.query + "`\n\n" +
+  "## Task\nUse WebSearch with the query above (or a refined version). Return the top 4-6 most relevant results.\n" +
+  "Rank by relevance to the ORIGINAL question, not just the search query. Skip obvious SEO spam/content farms.\n" +
+  "Include a short snippet capturing why each result is relevant.\n\nStructured output only."
+
+const FETCH_PROMPT = (source, angle) =>
+  "## Source Extractor\n\n" +
+  "Research question: \"" + QUESTION + "\"\n\n" +
+  "Fetch and extract key claims from this source:\n" +
+  "**URL:** " + source.url + "\n**Title:** " + source.title + "\n**Found via:** " + angle + " search\n\n" +
+  "## Task\n1. Use WebFetch to retrieve the page content.\n" +
+  "2. Assess source quality: primary research/institution? secondary reporting? blog/opinion? forum? unreliable?\n" +
+  "3. Extract 2-5 FALSIFIABLE claims that bear on the research question. Each claim must:\n" +
+  "   - be a concrete, checkable statement (not vague generalities)\n" +
+  "   - include a direct quote from the source as support\n" +
+  "   - be rated central/supporting/tangential to the research question\n" +
+  "4. Note publish date if available.\n\n" +
+  "If the fetch fails or the page is irrelevant/paywalled, return claims: [] and sourceQuality: \"unreliable\".\n\nStructured output only."
+
+const VERIFY_PROMPT = (claim, v) =>
+  "## Adversarial Claim Verifier (voter " + (v + 1) + "/" + VOTES_PER_CLAIM + ")\n\n" +
+  "Be SKEPTICAL. Try to REFUTE this claim. ≥" + REFUTATIONS_REQUIRED + "/" + VOTES_PER_CLAIM + " refutations kill it.\n\n" +
+  "## Research question\n" + QUESTION + "\n\n" +
+  "## Claim under review\n\"" + claim.claim + "\"\n\n" +
+  "**Source:** " + claim.sourceUrl + " (" + claim.sourceQuality + ")\n" +
+  "**Supporting quote:** \"" + claim.quote + "\"\n\n" +
+  "## Checklist\n" +
+  "1. Is the claim actually supported by the quote, or is it an overreach/misread?\n" +
+  "2. WebSearch for contradicting evidence — does any credible source dispute or heavily qualify this?\n" +
+  "3. Is the source quality sufficient for the claim's strength? (extraordinary claims need primary sources)\n" +
+  "4. Is the claim outdated? (check dates — old claims about fast-moving fields are suspect)\n" +
+  "5. Is this a marketing claim / press release / cherry-picked benchmark / forum speculation?\n\n" +
+  "**refuted=true** if: unsupported by quote / contradicted / low-quality source for strong claim / outdated / marketing fluff.\n" +
+  "**refuted=false** ONLY if: claim is well-supported, current, and source quality matches claim strength.\n" +
+  "Default to refuted=true if uncertain.\n\nStructured output only. Evidence MUST be specific."
+
+// ─── Pipeline: search → dedup → fetch+extract (no barrier) ───
+const searchResults = await pipeline(
+  scope.angles,
+
+  angle => agent(SEARCH_PROMPT(angle), {
+    label: "search:" + angle.label, phase: "Search", schema: SEARCH_SCHEMA
+  }).then(r => {
+    if (!r) return null
+    log(angle.label + ": " + r.results.length + " results")
+    return { angle: angle.label, results: r.results }
+  }),
+
+  searchResult => {
+    const sorted = [...searchResult.results].sort((a, b) => relRank[a.relevance] - relRank[b.relevance])
+    const novel = sorted.filter(r => {
+      const key = normURL(r.url)
+      if (seen.has(key)) {
+        dupes.push({ ...r, angle: searchResult.angle, dupOf: seen.get(key) })
+        return false
+      }
+      if (fetchSlots <= 0 && relRank[r.relevance] >= 1) {
+        budgetDropped.push({ ...r, angle: searchResult.angle })
+        return false
+      }
+      seen.set(key, { angle: searchResult.angle, title: r.title })
+      fetchSlots--
+      return true
+    })
+    if (novel.length < searchResult.results.length) {
+      log(searchResult.angle + ": " + novel.length + " novel (" + (searchResult.results.length - novel.length) + " filtered)")
+    }
+    return parallel(
+      novel.map(source => () => {
+        let host = "unknown"
+        try { host = new URL(source.url).hostname.replace(/^www\./, "") } catch {}
+        return agent(FETCH_PROMPT(source, searchResult.angle), {
+          label: "fetch:" + host,
+          phase: "Fetch",
+          schema: EXTRACT_SCHEMA,
+        }).then(ext => {
+          // User-skip → null; drop it (filtered by searchResults.flat().filter(Boolean))
+          // rather than throwing into .catch() and mislabeling it "unreliable".
+          if (!ext) return null
+          return {
+            url: source.url, title: source.title, angle: searchResult.angle,
+            sourceQuality: ext.sourceQuality, publishDate: ext.publishDate,
+            claims: ext.claims.map(c => ({ ...c, sourceUrl: source.url, sourceQuality: ext.sourceQuality })),
+          }
+        }).catch(e => {
+          log("fetch failed: " + source.url + " — " + (e.message || e))
+          return { url: source.url, title: source.title, angle: searchResult.angle, sourceQuality: "unreliable", claims: [] }
+        })
+      })
+    )
+  }
+)
+
+const allSources = searchResults.flat().filter(Boolean)
+const allClaims = allSources.flatMap(s => s.claims)
+const impRank = { central: 0, supporting: 1, tangential: 2 }
+const qualRank = { primary: 0, secondary: 1, blog: 2, forum: 3, unreliable: 4 }
+
+const rankedClaims = [...allClaims]
+  .sort((a, b) => (impRank[a.importance] - impRank[b.importance]) || (qualRank[a.sourceQuality] - qualRank[b.sourceQuality]))
+  .slice(0, MAX_VERIFY_CLAIMS)
+
+log("Fetched " + allSources.length + " sources → " + allClaims.length + " claims → verifying top " + rankedClaims.length)
+
+if (rankedClaims.length === 0) {
+  return {
+    question: QUESTION,
+    summary: "No claims extracted. " + allSources.length + " sources fetched, all empty/failed. " + dupes.length + " URL dupes, " + budgetDropped.length + " budget-dropped.",
+    findings: [], refuted: [], sources: allSources.map(s => ({ url: s.url, quality: s.sourceQuality })),
+    stats: { angles: scope.angles.length, sources: allSources.length, claims: 0, dupes: dupes.length },
+  }
+}
+
+// ─── Verify: 3-vote adversarial ───
+// Barrier here is intentional — claim pool must be fully assembled before ranking/verification.
+phase("Verify")
+const voted = (await parallel(
+  rankedClaims.map(claim => () =>
+    parallel(
+      Array.from({ length: VOTES_PER_CLAIM }, (_, v) => () =>
+        agent(VERIFY_PROMPT(claim, v), {
+          label: "v" + v + ":" + claim.claim.slice(0, 40),
+          phase: "Verify",
+          schema: VERDICT_SCHEMA,
+        })
+      )
+    ).then(verdicts => {
+      // A vote can be null (user-skip or agent error) — treat as abstain.
+      const valid = verdicts.filter(Boolean)
+      const refuted = valid.filter(v => v.refuted).length
+      // Survive only if the claim was actually adjudicated: a quorum of
+      // valid votes AND fewer than REFUTATIONS_REQUIRED refuting. Too many
+      // abstentions = unverified, which must NOT pass into the report
+      // (otherwise all-abstain → refuted=0 → false survive).
+      const abstained = VOTES_PER_CLAIM - valid.length
+      const survives = valid.length >= REFUTATIONS_REQUIRED && refuted < REFUTATIONS_REQUIRED
+      log("\"" + claim.claim.slice(0, 50) + "…\": " + (valid.length - refuted) + "-" + refuted + (abstained > 0 ? " (" + abstained + " abstain)" : "") + " " + (survives ? "✓" : "✗"))
+      return { ...claim, verdicts: valid, refutedVotes: refuted, survives }
+    })
+  )
+)).filter(Boolean)
+
+const confirmed = voted.filter(c => c.survives)
+const killed = voted.filter(c => !c.survives)
+log("Verify done: " + voted.length + " claims → " + confirmed.length + " confirmed, " + killed.length + " killed")
+
+if (confirmed.length === 0) {
+  return {
+    question: QUESTION,
+    summary: "All " + voted.length + " claims refuted by adversarial verification. Research inconclusive — sources may be low-quality or claims overstated.",
+    findings: [],
+    refuted: killed.map(c => ({ claim: c.claim, vote: (c.verdicts.length - c.refutedVotes) + "-" + c.refutedVotes, source: c.sourceUrl })),
+    sources: allSources.map(s => ({ url: s.url, quality: s.sourceQuality, claimCount: s.claims.length })),
+    stats: { angles: scope.angles.length, sources: allSources.length, claims: allClaims.length, verified: voted.length, confirmed: 0, killed: killed.length },
+  }
+}
+
+// ─── Synthesize ───
+phase("Synthesize")
+const confRank = { high: 0, medium: 1, low: 2 }
+const block = confirmed.map((c, i) => {
+  const best = c.verdicts.filter(v => !v.refuted).sort((a, b) => confRank[a.confidence] - confRank[b.confidence])[0]
+  return "### [" + i + "] " + c.claim + "\n" +
+    "Vote: " + (c.verdicts.length - c.refutedVotes) + "-" + c.refutedVotes + " · Source: " + c.sourceUrl + " (" + c.sourceQuality + ")\n" +
+    "Quote: \"" + c.quote + "\"\nVerifier evidence (" + best.confidence + "): " + best.evidence + "\n"
+}).join("\n")
+
+const killedBlock = killed.length > 0
+  ? "\n## Refuted claims (for transparency)\n" +
+    killed.map(c => "- \"" + c.claim + "\" (" + c.sourceUrl + ", vote " + (c.verdicts.length - c.refutedVotes) + "-" + c.refutedVotes + ")").join("\n")
+  : ""
+
+const report = await agent(
+  "## Synthesis: research report\n\n" +
+  "**Question:** " + QUESTION + "\n\n" +
+  confirmed.length + " claims survived " + VOTES_PER_CLAIM + "-vote adversarial verification. Merge semantic duplicates and synthesize.\n\n" +
+  "## Confirmed claims\n" + block + "\n" + killedBlock + "\n\n" +
+  "## Instructions\n" +
+  "1. Identify claims that say the same thing — merge them, combine their sources.\n" +
+  "2. Group related claims into coherent findings. Each finding should directly address the research question.\n" +
+  "3. Assign confidence per finding: high (multiple primary sources, unanimous votes), medium (secondary sources or split votes), low (single source or blog-quality).\n" +
+  "4. Write a 3-5 sentence executive summary answering the research question.\n" +
+  "5. Note caveats: what's uncertain, what sources were weak, what time-sensitivity applies.\n" +
+  "6. List 2-4 open questions that emerged but weren't answered.\n\nStructured output only.",
+  { label: "synthesize", schema: REPORT_SCHEMA }
+)
+
+if (!report) {
+  // Synthesis skipped/errored — salvage the verified claims raw rather
+  // than throwing on report.findings and discarding the whole run.
+  return {
+    question: QUESTION,
+    summary: "Synthesis step was skipped or failed — returning " + confirmed.length + " verified claims unmerged.",
+    findings: [],
+    confirmed: confirmed.map(c => ({ claim: c.claim, source: c.sourceUrl, quote: c.quote, vote: (c.verdicts.length - c.refutedVotes) + "-" + c.refutedVotes })),
+    refuted: killed.map(c => ({ claim: c.claim, vote: (c.verdicts.length - c.refutedVotes) + "-" + c.refutedVotes, source: c.sourceUrl })),
+    sources: allSources.map(s => ({ url: s.url, quality: s.sourceQuality, claimCount: s.claims.length })),
+    stats: { angles: scope.angles.length, sources: allSources.length, claims: allClaims.length, verified: voted.length, confirmed: confirmed.length, killed: killed.length, afterSynthesis: 0 },
+  }
+}
+
+return {
+  question: QUESTION,
+  ...report,
+  refuted: killed.map(c => ({ claim: c.claim, vote: (c.verdicts.length - c.refutedVotes) + "-" + c.refutedVotes, source: c.sourceUrl })),
+  sources: allSources.map(s => ({ url: s.url, quality: s.sourceQuality, angle: s.angle, claimCount: s.claims.length })),
+  stats: {
+    angles: scope.angles.length,
+    sourcesFetched: allSources.length,
+    claimsExtracted: allClaims.length,
+    claimsVerified: voted.length,
+    confirmed: confirmed.length,
+    killed: killed.length,
+    afterSynthesis: report.findings.length,
+    urlDupes: dupes.length,
+    budgetDropped: budgetDropped.length,
+    agentCalls: 1 + scope.angles.length + allSources.length + (voted.length * VOTES_PER_CLAIM) + 1,
+  },
+}


### PR DESCRIPTION
# Pull Request Description

Adds the `go-in-depth` skill. This skill provides a deep research harness that fans out web searches across multiple complementary angles, fetches and deduplicates sources, extracts falsifiable claims, and adversarially verifies them using a 3-vote system. Finally, it synthesizes the surviving claims into a fully cited research report with confidence rankings.

## Change Classification

- [x] Skill PR
- [ ] Docs PR
- [ ] Infra PR

## Issue Link (Optional)

N/A

## Quality Bar Checklist ✅

**All applicable items must be checked before merging.**

- [x] **Standards**: I have read `docs/contributors/quality-bar.md` and `docs/contributors/security-guardrails.md`.
- [x] **Metadata**: The `SKILL.md` frontmatter is valid (checked with `npm run validate`).
- [x] **Risk Label**: I have assigned the correct `risk:` tag (`none`, `safe`, `critical`, `offensive`, or `unknown` for legacy/unclassified content).
- [x] **Triggers**: The "When to use" section is clear and specific.
- [x] **Limitations**: The skill includes a `## Limitations` (or equivalent accepted constraints) section.
- [ ] **Security**: If this is an _offensive_ skill, I included the "Authorized Use Only" disclaimer.
- [x] **Safety scan**: If this PR adds or modifies `SKILL.md` command guidance, remote/network examples, or token-like strings, I ran `npm run security:docs` (or equivalent hardening check) and addressed any findings.
- [x] **Automated Skill Review**: If this PR changes `SKILL.md`, I checked the `skill-review` GitHub Actions result and addressed any actionable feedback.
- [x] **Manual Logic Review**: If this PR changes `SKILL.md` or risky guidance, I manually reviewed the logic, safety, failure modes, and `risk:` label instead of relying on automated checks alone.
- [x] **Local Test**: I have verified the skill works locally.
- [ ] **Repo Checks**: I ran `npm run validate:references` if my change affected docs, workflows, or infrastructure.
- [x] **Source-Only PR**: I did not manually include generated registry artifacts (`CATALOG.md`, `skills_index.json`, `data/*.json`) in this PR.
- [ ] **Credits**: I have added the source credit in `README.md` (if applicable).
- [ ] **License provenance**: If this skill imports from an external `source_repo`, I have declared `license:` and `license_source:` in the frontmatter, or confirmed the upstream repo carries no restricting license.
- [x] **Maintainer Edits**: I enabled **Allow edits from maintainers** on the PR.

## Screenshots (if applicable)

N/A
