### PR TITLE
feat: add ask-copilot skill

### DIFF
--- a/skills/ask-copilot/SKILL.md
+++ b/skills/ask-copilot/SKILL.md
@@ -1,0 +1,94 @@
+---
+name: ask-copilot
+description: "Use GitHub Copilot CLI in non-interactive mode to ask questions, review code, or generate snippets without manual interaction."
+category: development
+risk: safe
+source: self
+source_repo: cshara1/antigravity-awesome-skills
+source_type: self
+date_added: "2026-07-08"
+author: cshara1
+tags: [copilot, github, cli, review, prompt]
+tools: [claude, cursor, gemini]
+---
+
+# Ask Copilot
+
+## Overview
+
+This skill allows the agent to interact with GitHub Copilot CLI (`copilot`) in a non-interactive (headless) mode. Use this skill when you need secondary advice, code reviews, explanations, or code generation from GitHub Copilot's models.
+
+Use `source: self` and `source_type: self` when the skill is original to this repository and does not require README external-source credit.
+
+## When to Use This Skill
+
+- **User Request Only**: Use this skill **ONLY** when the user explicitly asks to "consult Copilot", "ask Copilot", "review with Copilot", or explicitly requests a second opinion using Copilot.
+- **Do NOT Invoke Automatically**: To comply with privacy policies, the agent must not invoke this skill automatically for its own second opinions or checks without explicit user consent.
+
+## How It Works
+
+### Step 1: Request User Consent for File Uploads
+
+Before executing any command that references local files and sends them to Copilot, you **MUST** obtain explicit user consent to upload their code to third-party servers.
+
+### Step 2: Execute with Minimal Permitted Flags
+
+To prevent TUI lockups, execute the `copilot` command with headless flags. Avoid using the blanket `--yolo` (or `--allow-all-tools`) bypass unless the task strictly requires mutation tools and is trusted by the user.
+
+- **For Read-Only / General Q&A**: Avoid `--yolo` and use `--allow-all-paths` instead. This allows Copilot CLI to directly access and read local files referenced in your prompt.
+- **For Trusted Mutation Tasks**: Only use `--yolo` if the user has explicitly authorized tool-execution / system mutations.
+
+### Step 3: Use Session Management (Optional)
+
+To maintain conversation context, use `--name` and `--resume` flags, or pass a `--session-id` on subsequent calls.
+
+## Examples
+
+### Example 1: General Question (Read-Only)
+
+Does not require `--yolo`. Use `--allow-all-paths` for path access.
+```bash
+copilot -p "Explain how to implement a debounce function in TypeScript" -s --allow-all-paths
+```
+
+### Example 2: Code Review (Direct File Reference)
+
+Always confirm with the user before executing. If consented, pass the file path directly in the prompt. Copilot CLI will read it using its path access permissions:
+```bash
+copilot -p "Review the file path/to/file.ts for potential memory leaks" -s --allow-all-paths
+```
+
+### Example 3: Named Session Management
+
+```bash
+copilot -p "My name is Taro. Remember this." -s --yolo --name "my-session-name"
+copilot -p "What is my name?" -s --yolo --resume "my-session-name"
+```
+
+## Best Practices
+
+- ✅ **Do:** Ask for user consent before uploading any project files to third-party endpoints.
+- ✅ **Do:** Pass file paths directly in the prompt text and let Copilot read them, instead of expanding them via shell `cat`.
+- ✅ **Do:** Use minimal permission flags like `--allow-all-paths` for read-only queries instead of `--yolo`.
+- ✅ **Do:** Use `-s` (silent) to suppress metadata and statistics, leaving only clean output.
+- ❌ **Don't:** Automatically trigger this skill for background second opinions without the user's explicit ask.
+- ❌ **Don't:** Run `copilot` without permission-bypass flags in background tasks, as it will hang waiting for interactive input.
+
+## Limitations
+
+- This skill does not replace environment-specific validation, testing, or expert review.
+- Stop and ask for clarification if required inputs, permissions, or safety boundaries are missing.
+
+## Security & Safety Notes
+
+- The `--yolo` flag bypasses all permission prompts and allows Copilot CLI to run arbitrary shell commands and mutate workspace files. It must be treated as a high-risk option and never used by default.
+- Always check that the code/files being sent do not contain sensitive credentials, API keys, or private environment variables.
+
+## Common Pitfalls
+
+- **Problem:** The terminal hangs or the command times out.
+  **Solution:** Ensure both `-p` (or `--prompt`) and a bypass flag (like `--allow-all-paths` or `--yolo`) are present in the command arguments. Without bypass flags, the CLI will prompt for confirmation which hangs headless processes.
+
+## Related Skills
+
+- `@cli-assistant` - How to interact with CLI tools in general.

--- a/skills/ask-copilot/SKILL.md
+++ b/skills/ask-copilot/SKILL.md
@@ -2,7 +2,7 @@
 name: ask-copilot
 description: "Use GitHub Copilot CLI in non-interactive mode to ask questions, review code, or generate snippets without manual interaction."
 category: development
-risk: safe
+risk: critical
 source: self
 source_repo: cshara1/antigravity-awesome-skills
 source_type: self
@@ -16,9 +16,11 @@ tools: [claude, cursor, gemini]
 
 ## Overview
 
-This skill allows the agent to interact with GitHub Copilot CLI (`copilot`) in a non-interactive (headless) mode. Use this skill when you need secondary advice, code reviews, explanations, or code generation from GitHub Copilot's models.
+This skill allows the agent to interact with GitHub Copilot CLI (`copilot`) in a non-interactive (headless) mode. Use this skill when the user explicitly wants secondary advice, code reviews, explanations, or code generation from GitHub Copilot's models.
 
 Use `source: self` and `source_type: self` when the skill is original to this repository and does not require README external-source credit.
+
+Copilot is an external service. Treat prompts, file paths, snippets, repository content, command output, and generated suggestions as data that may leave the local environment.
 
 ## When to Use This Skill
 
@@ -27,16 +29,18 @@ Use `source: self` and `source_type: self` when the skill is original to this re
 
 ## How It Works
 
-### Step 1: Request User Consent for File Uploads
+### Step 1: Request Explicit User Consent
 
-Before executing any command that references local files and sends them to Copilot, you **MUST** obtain explicit user consent to upload their code to third-party servers.
+Before executing any command that references local files, repository paths, snippets, command output, secrets-adjacent config, or private project context, you **MUST** obtain explicit user consent to send that material to GitHub Copilot.
+
+Ask for separate approval before allowing Copilot to run tools, execute shell commands, edit files, install packages, or mutate the workspace.
 
 ### Step 2: Execute with Minimal Permitted Flags
 
-To prevent TUI lockups, execute the `copilot` command with headless flags. Avoid using the blanket `--yolo` (or `--allow-all-tools`) bypass unless the task strictly requires mutation tools and is trusted by the user.
+To prevent TUI lockups, execute the `copilot` command with headless flags. Do not use blanket bypasses such as `--yolo` or `--allow-all-tools` for routine Q&A or review.
 
 - **For Read-Only / General Q&A**: Avoid `--yolo` and use `--allow-all-paths` instead. This allows Copilot CLI to directly access and read local files referenced in your prompt.
-- **For Trusted Mutation Tasks**: Only use `--yolo` if the user has explicitly authorized tool-execution / system mutations.
+- **For Trusted Mutation Tasks**: Prefer a scoped permission flag if the CLI supports one. Use blanket mutation bypasses only after the user explicitly authorizes Copilot to execute tools and mutate the workspace for the specific task.
 
 ### Step 3: Use Session Management (Optional)
 
@@ -46,9 +50,9 @@ To maintain conversation context, use `--name` and `--resume` flags, or pass a `
 
 ### Example 1: General Question (Read-Only)
 
-Does not require `--yolo`. Use `--allow-all-paths` for path access.
+Does not require repository path access or mutation permissions.
 ```bash
-copilot -p "Explain how to implement a debounce function in TypeScript" -s --allow-all-paths
+copilot -p "Explain how to implement a debounce function in TypeScript" -s
 ```
 
 ### Example 2: Code Review (Direct File Reference)
@@ -61,8 +65,8 @@ copilot -p "Review the file path/to/file.ts for potential memory leaks" -s --all
 ### Example 3: Named Session Management
 
 ```bash
-copilot -p "My name is Taro. Remember this." -s --yolo --name "my-session-name"
-copilot -p "What is my name?" -s --yolo --resume "my-session-name"
+copilot -p "Remember this session label for follow-up questions." -s --name "my-session-name"
+copilot -p "Summarize the prior advice in this session." -s --resume "my-session-name"
 ```
 
 ## Best Practices
@@ -72,22 +76,25 @@ copilot -p "What is my name?" -s --yolo --resume "my-session-name"
 - ✅ **Do:** Use minimal permission flags like `--allow-all-paths` for read-only queries instead of `--yolo`.
 - ✅ **Do:** Use `-s` (silent) to suppress metadata and statistics, leaving only clean output.
 - ❌ **Don't:** Automatically trigger this skill for background second opinions without the user's explicit ask.
+- ❌ **Don't:** Send files, logs, environment details, or private repository context to Copilot without explicit approval.
 - ❌ **Don't:** Run `copilot` without permission-bypass flags in background tasks, as it will hang waiting for interactive input.
 
 ## Limitations
 
 - This skill does not replace environment-specific validation, testing, or expert review.
 - Stop and ask for clarification if required inputs, permissions, or safety boundaries are missing.
+- Copilot responses may be incomplete, outdated, or wrong; verify any proposed code locally before using it.
 
 ## Security & Safety Notes
 
 - The `--yolo` flag bypasses all permission prompts and allows Copilot CLI to run arbitrary shell commands and mutate workspace files. It must be treated as a high-risk option and never used by default.
 - Always check that the code/files being sent do not contain sensitive credentials, API keys, or private environment variables.
+- Prefer redacted snippets over whole files when only a small context sample is needed.
 
 ## Common Pitfalls
 
 - **Problem:** The terminal hangs or the command times out.
-  **Solution:** Ensure both `-p` (or `--prompt`) and a bypass flag (like `--allow-all-paths` or `--yolo`) are present in the command arguments. Without bypass flags, the CLI will prompt for confirmation which hangs headless processes.
+  **Solution:** Ensure both `-p` (or `--prompt`) and the narrowest required non-interactive permission flag are present in the command arguments. Without required permission flags, the CLI may prompt for confirmation and hang headless processes.
 
 ## Related Skills
 


### PR DESCRIPTION
# Pull Request Description

Added the `ask-copilot` skill to allow agents to interact with the GitHub Copilot CLI in non-interactive (headless) mode. This avoids terminal freeze/lockups when executing copilot from secondary agents.

## Change Classification

- [x] Skill PR
- [ ] Docs PR
- [ ] Infra PR

## Issue Link (Optional)



## Quality Bar Checklist ✅

**All applicable items must be checked before merging.**

- [x] **Standards**: I have read `docs/contributors/quality-bar.md` and `docs/contributors/security-guardrails.md`.
- [x] **Metadata**: The `SKILL.md` frontmatter is valid (checked with `npm run validate`).
- [x] **Risk Label**: I have assigned the correct `risk:` tag (`none`, `safe`, `critical`, `offensive`, or `unknown` for legacy/unclassified content).
- [x] **Triggers**: The "When to use" section is clear and specific.
- [x] **Limitations**: The skill includes a `## Limitations` (or equivalent accepted constraints) section.
- [ ] **Security**: If this is an _offensive_ skill, I included the "Authorized Use Only" disclaimer.
- [x] **Safety scan**: If this PR adds or modifies `SKILL.md` command guidance, remote/network examples, or token-like strings, I ran `npm run security:docs` (or equivalent hardening check) and addressed any findings.
- [x] **Automated Skill Review**: If this PR changes `SKILL.md`, I checked the `skill-review` GitHub Actions result and addressed any actionable feedback.
- [x] **Manual Logic Review**: If this PR changes `SKILL.md` or risky guidance, I manually reviewed the logic, safety, failure modes, and `risk:` label instead of relying on automated checks alone.
- [x] **Local Test**: I have verified the skill works locally.
- [ ] **Repo Checks**: I ran `npm run validate:references` if my change affected docs, workflows, or infrastructure.
- [x] **Source-Only PR**: I did not manually include generated registry artifacts (`CATALOG.md`, `skills_index.json`, `data/*.json`) in this PR.
- [ ] **Credits**: I have added the source credit in `README.md` (if applicable).
- [ ] **License provenance**: If this skill imports from an external `source_repo`, I have declared `license:` and `license_source:` in the frontmatter, or confirmed the upstream repo carries no restricting license.
- [x] **Maintainer Edits**: I enabled **Allow edits from maintainers** on the PR.

## Screenshots (if applicable)
