### PR TITLE
docs: refresh x-twitter-scraper skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -354,6 +354,7 @@ Key source families include:
 - **[dair-ai/dair-academy-plugins](https://github.com/dair-ai/dair-academy-plugins)**: Official DAIR Academy plugin skills imported as standalone skills - image generation, adaptive learning, lesson artifacts, LLM council deliberation, survey papers, wiki building, and YouTube study notes (MIT).
 - **[weaviate/agent-skills](https://github.com/weaviate/agent-skills)**: Official Weaviate skills - vector database operations, semantic and hybrid search, data imports, RAG cookbooks, agentic RAG, multimodal PDF search, and async client patterns (BSD-3-Clause).
 - **[pilot-protocol/pilotprotocol](https://github.com/pilot-protocol/pilotprotocol)**: Official Pilot Protocol overlay network - agent addressing, encrypted P2P messaging, NAT traversal, and an installable agent app store (AGPL-3.0).
+- **[Xquik-dev/x-twitter-scraper](https://github.com/Xquik-dev/x-twitter-scraper)**: Official Xquik skill for X data workflows - tweet search, user lookup, follower export, media downloads, MCP, webhooks, OpenAPI, and SDK setup (MIT).
 
 </details>
 
@@ -467,7 +468,6 @@ Key source families include:
 - **[mishanefedov/skill-issue](https://github.com/mishanefedov/skill-issue)**: Source for the `skill-issue` activation-audit skill for grading SKILL.md trigger metadata, prompt matching, and collision clusters (MIT).
 - **[wede-wx/atlas](https://github.com/wede-wx/atlas)**: Source for the `atlas-contract` and `atlas-ledger` goal-integrity skills - contract, phase-check, final-audit, and project-ledger guardrails for long-running agent work (MIT).
 - **[yehudalevy-collab/polis-protocol](https://github.com/yehudalevy-collab/polis-protocol)**: Source for the `polis-protocol` multi-agent coordination skill with capability cards, routing history, and protocol amendments (MIT).
-- **[Xquik-dev/x-twitter-scraper](https://github.com/Xquik-dev/x-twitter-scraper)**: Xquik skill for X/Twitter data workflows: tweet search, user lookup, follower export, media downloads, MCP, webhooks, and 23 extraction tools.
 - **[connerlambden/helium-mcp](https://github.com/connerlambden/helium-mcp)**: Source for the `helium-mcp` skill — MCP server for news intelligence, media bias analysis, market data, options pricing, and semantic meme search.
 - **[shmlkv/dna-claude-analysis](https://github.com/shmlkv/dna-claude-analysis)**: Personal genome analysis toolkit — Python scripts analyzing raw DNA data across 17 categories (health risks, ancestry, pharmacogenomics, nutrition, psychology, etc.) with terminal-style single-page HTML visualization.
 - **[AlmogBaku/debug-skill](https://github.com/AlmogBaku/debug-skill)**: Interactive debugger skill for AI agents — breakpoints, stepping, variable inspection, and stack traces via the `dap` CLI. Supports Python, Go, Node.js/TypeScript, Rust, and C/C++.

--- a/skills/x-twitter-scraper/SKILL.md
+++ b/skills/x-twitter-scraper/SKILL.md
@@ -1,11 +1,16 @@
 ---
 name: x-twitter-scraper
-description: "X/Twitter automation skill for tweet search, follower export, posting, DMs, webhooks, MCP, SDKs, Hermes Tweet, and TweetClaw."
+description: "Use Xquik for X data workflows: tweet search, user lookup, follower export, media downloads, monitors, webhooks, REST API, MCP, SDK setup, and approval-gated account actions."
 category: data
 risk: critical
 source: community
-tags: "[twitter, x-api, tweet-search, twitter-api, twitter-scraper, follower-export, automation, mcp, sdk, webhooks, hermes-agent, hermes-tweet, openclaw, tweetclaw]"
+source_repo: Xquik-dev/x-twitter-scraper
+source_type: official
+author: Xquik
+tags: [twitter, x, social-media, x-api, tweet-search, follower-export, automation, mcp, sdk, webhooks]
 date_added: "2026-02-28"
+license: MIT
+license_source: https://github.com/Xquik-dev/x-twitter-scraper/blob/master/LICENSE
 plugin:
   targets:
     codex: blocked
@@ -16,9 +21,9 @@ plugin:
 
 ## Overview
 
-Gives AI agents X (Twitter) data and automation workflows through the Xquik platform. Covers tweet search, advanced Twitter search, profile tweets, user lookup, follower export, media download, posting, replies, DMs, giveaway draws, account monitoring, webhooks, 23 bulk extraction tools, MCP, official SDKs, the Hermes Tweet Hermes Agent plugin, and the TweetClaw OpenClaw plugin.
+Gives AI agents X (Twitter) data and automation workflows through the Xquik platform. Covers tweet search, profile tweets, user lookup, follower export, media download, replies, DMs, giveaway draws, account monitoring, webhooks, bulk extraction tools, remote MCP, OpenAPI, and official SDKs.
 
-This repository entry is documentation-only: it does not include an executable scraper, binary, package, or vendored runtime code. The external Xquik, Hermes Tweet, and TweetClaw tools referenced below must be reviewed and installed separately before use.
+This repository entry is documentation-only: it does not include an executable scraper, binary, package, or vendored runtime code. Review the Xquik service, public docs, and SDK package before use.
 
 Because this workflow can automate authenticated X/Twitter account actions, treat it as critical-risk guidance. Only use it with accounts and targets you are authorized to operate, and require explicit user approval before posting, replying, liking, reposting, following, unfollowing, sending DMs, creating monitors, registering webhooks, or starting bulk extraction.
 
@@ -35,8 +40,6 @@ Because this workflow can automate authenticated X/Twitter account actions, trea
 - User wants to run a giveaway draw from tweet replies
 - User needs real-time monitoring of an X account (new tweets, follower changes)
 - User wants webhook delivery of monitored events
-- User wants the Hermes Tweet Hermes Agent plugin with `tweet_explore`, `tweet_read`, and approval-gated `tweet_action`
-- User wants the TweetClaw OpenClaw plugin instead of direct REST or MCP setup
 - User asks about trending topics on X
 
 ## Setup
@@ -57,25 +60,15 @@ git clone https://github.com/Xquik-dev/x-twitter-scraper.git .claude/skills/x-tw
 git clone https://github.com/Xquik-dev/x-twitter-scraper.git .agents/skills/x-twitter-scraper
 ```
 
-### Use the Hermes Agent Plugin
+### Use the TypeScript SDK
 
-For Hermes Agent runtime tools, install Hermes Tweet. It wraps the same Xquik API with `tweet_explore` for endpoint discovery, `tweet_read` for read-only calls, and approval-gated `tweet_action` for writes and private actions.
-
-```bash
-hermes plugins install Xquik-dev/hermes-tweet --enable
-```
-
-Use Hermes Tweet when a Hermes Agent should search Twitter/X, read tweet replies, look up users, export followers, monitor tweets, post tweets, post replies, send DMs, or automate X actions with explicit approval gates.
-
-### Use the OpenClaw Plugin
-
-For OpenClaw runtime tools, install TweetClaw. It wraps the same Xquik API with `explore` for endpoint discovery and `tweetclaw` for approved calls.
+For JavaScript or TypeScript integrations, install the validated SDK package:
 
 ```bash
-openclaw plugins install @xquik/tweetclaw
+npm install x-developer@2.4.16
 ```
 
-Use TweetClaw when the agent should search tweets, post tweets, post replies, send DMs, export followers, download media, create monitors, deliver webhooks, or run giveaway draws from OpenClaw.
+Use REST, the SDK, or MCP depending on the host environment. Verify unfamiliar endpoint parameters against the current docs or OpenAPI spec before constructing calls.
 
 ### Get an API Key
 
@@ -101,12 +94,10 @@ export XQUIK_API_KEY
 | Account Monitoring | Track new tweets, replies, retweets, quotes, follower changes |
 | Webhooks | HMAC-signed real-time event delivery to your endpoint |
 | Giveaway Draws | Random winner selection from tweet replies with filters |
-| 23 Extraction Tools | Followers, following, verified followers, mentions, posts, replies, reposts, quotes, threads, articles, communities, lists, Spaces, people search, media, likes, and more |
+| Bulk Extraction Tools | Followers, following, verified followers, mentions, posts, replies, reposts, quotes, threads, articles, communities, lists, Spaces, people search, media, likes, and more |
 | Write Actions | Send tweets, post replies, like, repost, follow, unfollow, and send DMs after explicit approval |
 | SDKs | Official TypeScript, Python, Ruby, Go, Kotlin, Java, PHP, C#, CLI, and Terraform clients |
 | MCP Server | StreamableHTTP endpoint for AI-native integrations |
-| Hermes Tweet Hermes Agent Plugin | Installable `hermes-tweet` runtime with `tweet_explore`, `tweet_read`, and approval-gated `tweet_action` tools |
-| TweetClaw OpenClaw Plugin | Installable `@xquik/tweetclaw` runtime with `explore` and `tweetclaw` tools |
 
 ## Examples
 
@@ -133,11 +124,6 @@ export XQUIK_API_KEY
 **Monitor an account:**
 ```
 "Monitor @openai for new tweets and notify me via webhook"
-```
-
-**Use Hermes Agent:**
-```
-"Use Hermes Tweet to search Twitter/X for this launch, read the tweet replies, and prepare a draft reply for approval"
 ```
 
 **Bulk extraction:**
@@ -176,10 +162,6 @@ export XQUIK_API_KEY
 ## Repository
 
 https://github.com/Xquik-dev/x-twitter-scraper
-
-Hermes Tweet Hermes Agent plugin: https://github.com/Xquik-dev/hermes-tweet
-
-TweetClaw OpenClaw plugin: https://github.com/Xquik-dev/tweetclaw
 
 **Maintained By:** [Xquik](https://xquik.com)
 


### PR DESCRIPTION
## Change Summary

- Refreshes the `x-twitter-scraper` skill copy with current Xquik source metadata, license provenance, and SDK setup.
- Moves the Xquik source credit into the official source section required by CI.
- Removes outdated plugin-specific install paths so the skill points users to the maintained REST, MCP, OpenAPI, and SDK surfaces.
- Keeps generated registry artifacts untouched.

## Validation

- `npm run validate` passed with existing unrelated warnings.
- `npm run security:docs` passed.
- `npm run check:readme-credits -- --base origin/main --head HEAD` passed.
- `git diff --check` passed.
- Verified `x-developer@2.4.16` on npm and checked the referenced Xquik docs and OpenAPI URLs.

## Change Classification

- [x] Skill PR
- [ ] Docs PR
- [ ] Infra PR

## Quality Bar Checklist

- [x] Metadata: `SKILL.md` frontmatter validates.
- [x] Risk Label: existing `risk: critical` remains in place.
- [x] Triggers: the existing "When to Use" section remains specific.
- [x] Safety scan: ran `npm run security:docs`.
- [x] Manual Logic Review: checked the command guidance and approval gates.
- [x] Source-Only PR: no generated registry artifacts are included.
- [x] License provenance: added source repository and MIT license source.
