### PR TITLE
Improve MiniMax image generation guidance

### DIFF
--- a/skills/mmx-cli/SKILL.md
+++ b/skills/mmx-cli/SKILL.md
@@ -80,16 +80,29 @@ cat conversation.json | mmx text chat --messages-file - --output json
 
 ### image generate
 
-Generate images. Model: `image-01`.
+Generate images through MiniMax. Use this command for text-to-image tasks, thumbnails, concept art, social visuals, and quick prompt iteration. Model: `image-01`.
 
 ```bash
 mmx image generate --prompt <text> [flags]
 ```
 
 ```bash
+# Machine-readable response for agents
 mmx image generate --prompt "A cat in a spacesuit" --output json --quiet
+
+# Save multiple generated images to a directory
 mmx image generate --prompt "Logo" --n 3 --out-dir ./gen/ --quiet
+
+# Select region explicitly when a workflow must stay on one MiniMax endpoint family
+mmx image generate --prompt "Product hero image" --region global --output json --quiet
+mmx image generate --prompt "Product hero image" --region cn --output json --quiet
 ```
+
+Agent notes:
+
+- Prefer `--output json --quiet --non-interactive` when another tool will parse the result.
+- Use `--dry-run` before API-backed calls when validating arguments or CI examples.
+- Keep generated media in a task-local output directory and validate returned file paths or URLs before reusing them.
 
 ---
 


### PR DESCRIPTION
Reason: add target image capability using existing tool/provider pattern

## Summary
- Expands the existing MiniMax CLI skill's image generation section with text-to-image usage guidance.
- Adds explicit agent-safe JSON output, dry-run, task-local output, and global/CN region examples.

## Quality Bar Checklist
- [x] Source-only change: updates canonical skill content only.
- [x] Validation run by contributor: `npm run validate`.
- [x] Plugin compatibility checked by contributor: `npm run plugin-compat:check`.
- [x] No secrets or credentials added.
- [x] Maintainer will run repository validation before merge.

## Checks
- `git add -A -N && git diff HEAD | grep -E "$SECRET_RE"` (no matches)
- `python3 -m venv .venv && .venv/bin/pip install -r tools/requirements.txt`
- `PATH=".venv/bin:$PATH" npm run validate`
- `PATH=".venv/bin:$PATH" npm run plugin-compat:check`


