### PR TITLE
feat: add idea-autopsy — business-idea validation skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -364,6 +364,7 @@ Key source families include:
 ### Community Contributors
 
 - **[atdy/maoxuan-product-agent](https://github.com/atdy/maoxuan-product-agent)**: Source for the `product-decision-agent` skill - Chinese-first product judgment across prioritization, growth, operations, data, delivery, and cross-functional collaboration, with 36 tested scenarios (MIT).
+- **[hafiz-actyte/idea-autopsy](https://github.com/hafiz-actyte/idea-autopsy)**: Source for the `idea-autopsy` skill - business-idea validation that hunts the one sentence that kills an idea before you build: kill-list check, five hard filters, free-AI one-prompt test, and live ad-market verification (MIT).
 - **[cruisekkk/trading-ledger](https://github.com/cruisekkk/trading-ledger)**: Source for the `trading-ledger` skill - decision-quality trade journaling that captures entry thesis, plan, and emotion into the user's own Notion database (MIT).
 - **[cruisekkk/time-ledger](https://github.com/cruisekkk/time-ledger)**: Source for the `time-ledger` skill - natural-language time tracking parsed into the user's own Notion database with ask-instead-of-guessing reconciliation (MIT).
 - **[mattpocock/skills](https://github.com/mattpocock/skills)**: Source for 17 Matt Pocock workflow skills - codebase design, TDD, bug diagnosis, triage, PRDs, issues, prototyping, handoff, teaching, and skill-writing guidance (MIT).

--- a/skills/idea-autopsy/SKILL.md
+++ b/skills/idea-autopsy/SKILL.md
@@ -1,0 +1,125 @@
+---
+name: idea-autopsy
+description: "Autopsy a business idea before you build it: kill-list check, five hard filters, a free-AI one-prompt test, live ad-market verification, and a verdict with a named kill-pattern."
+category: product
+risk: safe
+source: community
+source_repo: hafiz-actyte/idea-autopsy
+source_type: community
+date_added: "2026-07-10"
+author: hafiz-actyte
+tags: [business-ideas, idea-validation, market-research, startup, founders]
+tools: [claude, cursor, gemini]
+license: "MIT"
+license_source: "https://github.com/hafiz-actyte/idea-autopsy/blob/main/LICENSE"
+---
+
+# Idea Autopsy
+
+## Overview
+
+Turns the agent into a ruthless business-idea pathologist: instead of encouraging
+the user, it hunts for the one sentence that kills an idea — before any money or
+weeks are spent building it. Built from a real founder kill-list of 42 dead ideas
+(including a 9/10-scored idea and one that turned out to be federally illegal to
+charge for). Every autopsy ends in a hard verdict: DEAD with a named kill-pattern,
+or SURVIVED with the one cheapest test that could still kill it.
+
+## When to Use This Skill
+
+- Use when the user proposes a new business, product, or side-project idea
+- Use when the user asks "should I build X?" or "validate this idea"
+- Use when the user says "autopsy my idea"
+- Use before any market-research or build-planning task for a new venture
+
+## How It Works
+
+### Step 1: Kill-list check
+
+If the project contains a `REJECTION.md` (the user's personal kill-list), read it
+first and match the idea by niche OR by kill-pattern. A match = verdict DEAD, cite
+the row, stop. If no kill-list exists, create one from the template — this autopsy
+writes its first row.
+
+### Step 2: The five filters
+
+Demand evidence, not optimism. One hard NO = dead.
+
+1. **Real pain?** 2am-problem, or a nice-to-have "vitamin"?
+2. **Buyer has money?** Right now — not after the product helps them.
+3. **Proven demand?** Can the user name a single live competitor ad?
+4. **Legal to charge for?** Regulated, licensed, or illegal in the target market? Name the law if suspicion exists.
+5. **A moat?** What stops the 50th copycat next month?
+
+### Step 3: The free-AI test
+
+Try to produce the idea's core deliverable with one prompt to a frontier model.
+If one prompt produces the whole deliverable free, the verdict is DEAD with
+kill-pattern `free-AI`: the user doesn't have a product, they have a prompt.
+
+### Step 4: Live-market verification (own eyes)
+
+Desk research lies. Walk the user through the Meta Ad Library (or equivalent) with
+an explicit checklist: number of ACTIVE advertisers, age of the oldest running ad
+(90+ days = someone is paying because it works), and the three traps — zero ads
+(`wrong-channel`), a few giants (`incumbent-owned`), or hundreds of ads
+(`crowded` commodity knife-fight: demand ≠ room for you).
+
+### Step 5: Verdict
+
+```
+VERDICT: DEAD | SURVIVED
+KILL-PATTERN: <name>            (if dead)
+THE ONE SENTENCE: <the single finding that decided it>
+EVIDENCE: <2-4 hard facts with sources/numbers>
+NEXT: <if survived: the ONE cheapest test that could still kill it>
+```
+
+Then append a one-line row to the user's `REJECTION.md`. The kill-list is the
+compounding asset — every autopsy makes the next one faster.
+
+## Examples
+
+### Example 1: Idea that dies on the free-AI test
+
+```
+User: Should I build a chargeback-response kit for Shopify sellers? Ready-to-send
+      evidence packets, $29 one-time.
+Agent: Running the autopsy... Step 3 kills it: one prompt to a frontier model
+      produces a complete, usable evidence packet for free.
+      VERDICT: DEAD. KILL-PATTERN: free-AI.
+      THE ONE SENTENCE: If AI ships your whole deliverable in one prompt, you
+      don't have a product — you have a prompt.
+```
+
+### Example 2: Proven demand that still dies
+
+```
+User: An app that identifies plants from a photo — there are over a thousand
+      active ads for these, demand is proven!
+Agent: Step 4 confirms ~1,100 active advertisers — and that's the trap. The AI is
+      free, the datasets are public, everyone could build it, so everyone did.
+      VERDICT: DEAD. KILL-PATTERN: no-moat.
+      THE ONE SENTENCE: Demand tells you a market exists; it doesn't tell you
+      there's room for you.
+```
+
+## Best Practices
+
+- ✅ Demand a number, a law, a live ad, or a quote for every claim
+- ✅ Treat a fast honest kill as a WIN — it saves weeks and dollars
+- ✅ Make the user verify ad-library findings with their own eyes
+- ❌ Don't soften verdicts to be encouraging — "it depends" is a failed autopsy
+- ❌ Don't let buildability excitement skip the buyer questions; building was never the problem
+
+## Limitations
+
+- This skill does not replace legal advice, financial advice, or professional market research.
+- Kill-patterns are priors, not verdicts — a new niche matching an old pattern still deserves a fresh check that the pattern applies.
+- Ad-library checks reflect one acquisition channel; some categories legitimately sell through search or app stores.
+- Stop and ask for clarification if the idea's target market, buyer, or deliverable is unclear.
+
+## Security & Safety Notes
+
+- This skill performs no shell commands, network mutations, or credential handling; it produces analysis and writes only to the project's own `REJECTION.md`.
+- Web checks (ad libraries) are performed by the USER in their own browser; the skill only provides the checklist.

--- a/skills/idea-autopsy/SKILL.md
+++ b/skills/idea-autopsy/SKILL.md
@@ -2,7 +2,7 @@
 name: idea-autopsy
 description: "Autopsy a business idea before you build it: kill-list check, five hard filters, a free-AI one-prompt test, live ad-market verification, and a verdict with a named kill-pattern."
 category: product
-risk: safe
+risk: critical
 source: community
 source_repo: hafiz-actyte/idea-autopsy
 source_type: community
@@ -38,8 +38,22 @@ or SURVIVED with the one cheapest test that could still kill it.
 
 If the project contains a `REJECTION.md` (the user's personal kill-list), read it
 first and match the idea by niche OR by kill-pattern. A match = verdict DEAD, cite
-the row, stop. If no kill-list exists, create one from the template — this autopsy
-writes its first row.
+the row, stop. If no kill-list exists, ask the user for permission to create one
+with exactly this schema — this autopsy writes its first row:
+
+```markdown
+# REJECTION.md — my kill-list
+
+## Killed ideas
+
+| # | Idea/Niche | Killed (date) | Hard reason (one line) | Pattern |
+|---|-----------|---------------|------------------------|---------|
+
+## Survivors under test
+
+| Idea | Passed filters (date) | Pending test | Deadline |
+|------|----------------------|--------------|----------|
+```
 
 ### Step 2: The five filters
 
@@ -121,5 +135,6 @@ Agent: Step 4 confirms ~1,100 active advertisers — and that's the trap. The AI
 
 ## Security & Safety Notes
 
-- This skill performs no shell commands, network mutations, or credential handling; it produces analysis and writes only to the project's own `REJECTION.md`.
+- This skill performs no shell commands, network calls, or credential handling.
+- It modifies project state in exactly one place: creating or appending rows to the project's own `REJECTION.md` (hence `risk: critical`). It never edits other files; ask permission before creating the file on first run.
 - Web checks (ad libraries) are performed by the USER in their own browser; the skill only provides the checklist.

--- a/skills/idea-autopsy/SKILL.md
+++ b/skills/idea-autopsy/SKILL.md
@@ -89,8 +89,12 @@ EVIDENCE: <2-4 hard facts with sources/numbers>
 NEXT: <if survived: the ONE cheapest test that could still kill it>
 ```
 
-Then append a one-line row to the user's `REJECTION.md`. The kill-list is the
-compounding asset — every autopsy makes the next one faster.
+Then record the result — gated on consent: if `REJECTION.md` exists, or the user
+approved creating it in Step 1, append a one-line row (dead) or note the survivor
+with the date and pending test. If the user declined the kill-list, do NOT create
+or write the file — print the proposed row as text so they can save it wherever
+they prefer. The kill-list is the compounding asset — every autopsy makes the
+next one faster, but only with the user's consent.
 
 ## Examples
 

--- a/skills/idea-autopsy/SKILL.md
+++ b/skills/idea-autopsy/SKILL.md
@@ -37,8 +37,11 @@ or SURVIVED with the one cheapest test that could still kill it.
 ### Step 1: Kill-list check
 
 If the project contains a `REJECTION.md` (the user's personal kill-list), read it
-first and match the idea by niche OR by kill-pattern. A match = verdict DEAD, cite
-the row, stop. If no kill-list exists, ask the user for permission to create one
+first. A NICHE match (same niche as a killed row) = verdict DEAD, cite the row,
+stop. A KILL-PATTERN match alone (new niche, previously-seen pattern) is a strong
+prior, NOT a verdict: name the matching pattern, then run the specific check for
+that pattern (the relevant filter or test below) to confirm it actually applies
+before declaring death. If no kill-list exists, ask the user for permission to create one
 with exactly this schema — this autopsy writes its first row:
 
 ```markdown


### PR DESCRIPTION
## Change Classification

- [ ] Skill PR
- [ ] Docs PR
- [ ] Infra PR

## Issue Link (Optional)

Use this only when the PR should auto-close an issue:

`Closes #N` or `Fixes #N`

## Quality Bar Checklist ✅

**All applicable items must be checked before merging.**

- [ ] **Standards**: I have read `docs/contributors/quality-bar.md` and `docs/contributors/security-guardrails.md`.
- [ ] **Metadata**: The `SKILL.md` frontmatter is valid (checked with `npm run validate`).
- [ ] **Risk Label**: I have assigned the correct `risk:` tag (`none`, `safe`, `critical`, `offensive`, or `unknown` for legacy/unclassified content).
- [ ] **Triggers**: The "When to use" section is clear and specific.
- [ ] **Limitations**: The skill includes a `## Limitations` (or equivalent accepted constraints) section.
- [ ] **Security**: If this is an _offensive_ skill, I included the "Authorized Use Only" disclaimer.
- [ ] **Safety scan**: If this PR adds or modifies `SKILL.md` command guidance, remote/network examples, or token-like strings, I ran `npm run security:docs` (or equivalent hardening check) and addressed any findings.
- [ ] **Automated Skill Review**: If this PR changes `SKILL.md`, I checked the `skill-review` GitHub Actions result and addressed any actionable feedback.
- [ ] **Manual Logic Review**: If this PR changes `SKILL.md` or risky guidance, I manually reviewed the logic, safety, failure modes, and `risk:` label instead of relying on automated checks alone.
- [ ] **Local Test**: I have verified the skill works locally.
- [ ] **Repo Checks**: I ran `npm run validate:references` if my change affected docs, workflows, or infrastructure.
- [ ] **Source-Only PR**: I did not manually include generated registry artifacts (`CATALOG.md`, `skills_index.json`, `data/*.json`) in this PR.
- [ ] **Credits**: I have added the source credit in `README.md` (if applicable).
- [ ] **License provenance**: If this skill imports from an external `source_repo`, I have declared `license:` and `license_source:` in the frontmatter, or confirmed the upstream repo carries no restricting license.
- [ ] **Maintainer Edits**: I enabled **Allow edits from maintainers** on the PR.

## Screenshots (if applicable)