### PR TITLE
feat: add exact installer selection and dry-run

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,41 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [14.3.0] - 2026-07-13 - "Exact Selection, Safe Preview, and Community Memory"
+
+> Version-pinned exact skill sets for active users and teams, plus two reviewed community skills with maintainer safety and correctness hardening.
+
+## Added
+
+- Added `--skills <csv>` for exact canonical skill names, IDs, and nested paths, with unknown or ambiguous selectors rejected before target writes.
+- Added `--dry-run` to show the pinned ref, exact selected skills, per-target installs or updates, stale managed removals, repository-clone migration, and ignored unsafe manifest entries without mutating targets.
+- Added **lore**, a project-local Markdown memory workflow with five stdlib Python helpers, explicit mirror boundaries, and project-input trust controls (PR #810).
+- Added **quit-sponsor**, an opt-in smoking-cessation support workflow aligned to current CDC, WHO, and NICE guidance with local-data and emergency-escalation boundaries (PR #809).
+
+## Changed
+
+- Preserved recorded top-level and nested metadata tags in the canonical generated skill index for downstream expert discovery.
+- Preflight every selected target before the first multi-target mutation and treat `--skills` as explicit desired state for installer-managed entries.
+- Corrected the documented `Wolfe-Jam/faf-skills` inventory from 17 skills to the seven currently published upstream (PR #811).
+
+## Fixed
+
+- Ignore unsafe managed paths from a local installer manifest instead of resolving or pruning outside the install root.
+- Fixed `lore` candidate duplicate detection, clean helper failures, audit mutation wording, and higher-priority instruction boundaries before merge.
+- Removed categorical cessation guidance from `quit-sponsor`; quit dates, abrupt cessation, gradual reduction, and medications now remain individualized and clinically bounded.
+
+## Validation
+
+- Added exact-selection, ambiguity, filter-intersection, stale-removal preview, unsafe-manifest, no-write, and multi-target atomicity coverage.
+- Required fresh policy, source-validation, artifact-preview, and skill-review checks for PRs #809–#811, then regenerated canonical catalog and plugin surfaces.
+- Ran strict repository validation, documentation security checks, the full root and web-app test suites, TypeScript, ESLint, production build, prerender, sitemap, and SEO verification.
+
+## Credits
+
+- **[@metrox-eth](https://github.com/metrox-eth)** for `quit-sponsor` (PR #809).
+- **[@TheaDust](https://github.com/TheaDust)** for `lore` (PR #810).
+- **[@Wolfe-Jam](https://github.com/Wolfe-Jam)** for correcting the `faf-skills` source inventory (PR #811).
+
 ## [14.2.0] - 2026-07-12 - "Workflow Reliability and UI Research"
 
 > Three reviewed community skills for idea validation, deterministic AI workflows, and source-grounded UI research, with maintainer hardening and synchronized distributions.

--- a/README.md
+++ b/README.md
@@ -236,6 +236,14 @@ If Antigravity starts hitting context limits with too many active skills, the ac
 
 If you use OpenCode or another `.agents/skills` host, prefer a reduced install up front instead of copying the full library into a context-sensitive runtime. The installer now supports `--risk`, `--category`, and `--tags` so you can keep the installed set narrow.
 
+For a reproducible exact set, pin the package and catalog release and preview the full per-target plan before writing:
+
+```bash
+npx agentic-awesome-skills@14.3.0 --codex --release 14.3.0 --skills frontend-design,game-development/2d-games --dry-run
+```
+
+Remove `--dry-run` only after reviewing the install, update, and removal plan. Unknown or ambiguous skill identifiers fail closed, and metadata filters combine with `--skills` using AND.
+
 ## Browse 1,948+ Skills
 
 Use the root repo as a landing page, then jump into the deeper surface that matches your intent.

--- a/docs/users/faq.md
+++ b/docs/users/faq.md
@@ -246,11 +246,21 @@ You can narrow further with `--tags` or exclude values with a trailing `-`:
 npx agentic-awesome-skills --path .agents/skills --tags debugging,typescript-
 ```
 
+To manage a reproducible exact set and inspect every install, update, or removal without writing:
+
+```bash
+npx agentic-awesome-skills@14.3.0 --path .agents/skills --release 14.3.0 --skills frontend-design,backend-dev-guidelines --dry-run
+```
+
+Remove `--dry-run` only after reviewing the plan.
+
 The filter rules are:
 
 - comma-separated values are ORed within one flag
 - exclusions use a trailing `-`, for example `legal-`
 - `--risk`, `--category`, and `--tags` combine with AND
+- `--skills` accepts exact names, ids, or nested paths; unknown or ambiguous values fail closed
+- exact selection and metadata filters combine with AND
 
 This keeps the installed skill set smaller and reduces the chance of context overload in OpenCode-style runtimes.
 

--- a/docs/users/getting-started.md
+++ b/docs/users/getting-started.md
@@ -169,7 +169,7 @@ A: Use the activation flow in [agent-overload-recovery.md](agent-overload-recove
 A: The Antigravity CLI reads skill directories from `~/.gemini/antigravity-cli/skills/<skill>/SKILL.md`. Run `npx agentic-awesome-skills --agy`, restart `agy`, then open `/skills` or type a specific slash command such as `/brainstorming`.
 
 **Q: What if OpenCode or another `.agents/skills` host becomes unstable with a full install?**
-A: Start with a reduced install instead of copying the whole library. For example: `npx agentic-awesome-skills --path .agents/skills --category development,backend --risk safe,none`. You can narrow further with `--tags` and use a trailing `-` to exclude values such as `typescript-`.
+A: Start with a reduced install instead of copying the whole library. For example: `npx agentic-awesome-skills --path .agents/skills --category development,backend --risk safe,none`. You can narrow further with `--tags` and use a trailing `-` to exclude values such as `typescript-`. To manage a reproducible exact set, first preview it with `npx agentic-awesome-skills@14.3.0 --path .agents/skills --release 14.3.0 --skills frontend-design,backend-dev-guidelines --dry-run`, then remove `--dry-run` only after reviewing the plan.
 
 **Q: Is this free?**
 A: Yes. Original code and tooling are MIT-licensed, and original documentation/non-code written content is CC BY 4.0. See [../../LICENSE](../../LICENSE) and [../../LICENSE-CONTENT](../../LICENSE-CONTENT).

--- a/tools/bin/install.js
+++ b/tools/bin/install.js
@@ -41,7 +41,9 @@ function parseArgs(argv = process.argv.slice(2)) {
   let riskArg = null;
   let categoryArg = null;
   let tagsArg = null;
+  let skillsArg = null;
   let versionInfo = false;
+  let dryRun = false;
   let cursor = false,
     claude = false,
     gemini = false,
@@ -56,7 +58,7 @@ function parseArgs(argv = process.argv.slice(2)) {
       versionInfo = true;
       continue;
     }
-    if (["--path", "--release", "--tag", "--risk", "--category", "--tags"].includes(a[i])) {
+    if (["--path", "--release", "--tag", "--risk", "--category", "--tags", "--skills"].includes(a[i])) {
       const value = a[i + 1];
       if (!value || value.startsWith("--")) {
         throw new Error(`Option ${a[i]} requires a value.`);
@@ -67,7 +69,12 @@ function parseArgs(argv = process.argv.slice(2)) {
       if (a[i] === "--risk") riskArg = value;
       if (a[i] === "--category") categoryArg = value;
       if (a[i] === "--tags") tagsArg = value;
+      if (a[i] === "--skills") skillsArg = value;
       i += 1;
+      continue;
+    }
+    if (a[i] === "--dry-run") {
+      dryRun = true;
       continue;
     }
     if (a[i] === "--cursor") {
@@ -109,7 +116,9 @@ function parseArgs(argv = process.argv.slice(2)) {
     riskArg,
     categoryArg,
     tagsArg,
+    skillsArg,
     versionInfo,
+    dryRun,
     cursor,
     claude,
     gemini,
@@ -179,6 +188,8 @@ Options:
   --risk <csv>     Install only skills matching these risk labels
   --category <csv> Install only skills matching these categories
   --tags <csv>     Install only skills matching these tags
+  --skills <csv>   Set exact managed skill names, ids, or nested skill paths
+  --dry-run        Preview installs/updates/removals for every target without writing
   --version        Print the installer version
   --release <ver>  Clone tag v<ver> (e.g. 4.6.0 -> v4.6.0)
   --tag <tag>      Clone this tag or branch (e.g. v4.6.0, main)
@@ -191,6 +202,7 @@ Examples:
   npx agentic-awesome-skills --agy
   npx agentic-awesome-skills --path .agents/skills --category development,backend --risk safe,none
   npx agentic-awesome-skills --path .agents/skills --tags debugging,typescript-legacy-
+  npx agentic-awesome-skills --codex --skills frontend-design,game-development/2d-games --dry-run
   npx agentic-awesome-skills --release 4.6.0
   npx agentic-awesome-skills --path ./my-skills
   npx agentic-awesome-skills --claude --codex    Install to multiple targets
@@ -228,6 +240,19 @@ function parseSelectorArg(raw) {
     include: uniqueValues(include).filter((value) => !excludeValues.includes(value)),
     exclude: excludeValues,
   };
+}
+
+function parseExactSkillArg(raw) {
+  if (typeof raw !== "string" || !raw.trim()) {
+    return [];
+  }
+
+  const values = raw.split(",").map((value) => value.trim());
+  if (values.some((value) => !value)) {
+    throw new Error("--skills must be a comma-separated list of non-empty exact skill names, ids, or paths.");
+  }
+
+  return uniqueValues(values);
 }
 
 function hasActiveSelector(selector) {
@@ -422,21 +447,51 @@ function replaceManagedEntry(
 }
 
 /** Copy contents of repo's skills/ into target so each skill is target/skill-name/ (for Claude Code etc.). */
-function getInstallEntries(tempDir, selectors = buildInstallSelectors({})) {
+function resolveExactSkillSelections(repoSkills, skillEntries, requestedSkills = []) {
+  if (requestedSkills.length === 0) {
+    return null;
+  }
+
+  const skills = skillEntries.map((skillId) => readSkill(repoSkills, skillId));
+  const resolvedEntries = new Set();
+
+  for (const requestedSkill of requestedSkills) {
+    const matches = skills.filter((skill) => (
+      skill.name === requestedSkill ||
+      skill.id === requestedSkill ||
+      path.basename(skill.id) === requestedSkill
+    ));
+
+    if (matches.length === 0) {
+      throw new Error(`Unknown skill requested by --skills: ${requestedSkill}`);
+    }
+    if (matches.length > 1) {
+      throw new Error(
+        `Ambiguous skill requested by --skills: ${requestedSkill}. Use one exact nested skill path: ${matches.map((skill) => skill.id).join(", ")}`,
+      );
+    }
+
+    resolvedEntries.add(matches[0].id);
+  }
+
+  return resolvedEntries;
+}
+
+function getInstallEntries(tempDir, selectors = buildInstallSelectors({}), requestedSkills = []) {
   const repoSkills = path.join(tempDir, "skills");
   if (!fs.existsSync(repoSkills)) {
-    console.error("Cloned repo has no skills/ directory.");
-    process.exit(1);
+    throw new Error("Cloned repo has no skills/ directory.");
   }
 
   const skillEntries = listSkillIdsRecursive(repoSkills);
-  const filteredEntries = hasInstallSelectors(selectors)
-    ? skillEntries.filter((skillId) => matchesInstallSelectors(readSkill(repoSkills, skillId), selectors))
-    : skillEntries;
+  const selectedEntries = resolveExactSkillSelections(repoSkills, skillEntries, requestedSkills);
+  const filteredEntries = skillEntries.filter((skillId) => (
+    (!selectedEntries || selectedEntries.has(skillId)) &&
+    (!hasInstallSelectors(selectors) || matchesInstallSelectors(readSkill(repoSkills, skillId), selectors))
+  ));
 
-  if (hasInstallSelectors(selectors) && filteredEntries.length === 0) {
-    console.error("No skills matched the requested --risk/--category/--tags filters.");
-    process.exit(1);
+  if ((selectedEntries || hasInstallSelectors(selectors)) && filteredEntries.length === 0) {
+    throw new Error("No skills matched the requested --skills/--risk/--category/--tags selection.");
   }
 
   const entries = [...filteredEntries];
@@ -550,6 +605,22 @@ function readInstallManifest(targetPath) {
   }
 }
 
+function normalizeManifestEntries(entries) {
+  const normalized = [];
+  const invalid = [];
+  for (const entry of entries) {
+    try {
+      normalized.push(normalizeInstallEntry(entry));
+    } catch (error) {
+      invalid.push(entry);
+    }
+  }
+  return {
+    entries: uniqueValues(normalized).sort(),
+    invalid: uniqueValues(invalid).sort(),
+  };
+}
+
 function writeInstallManifest(targetPath, installEntries) {
   const manifestPath = resolveInstallManifestPath(targetPath);
   const normalizedEntries = [...new Set(installEntries.map(normalizeInstallEntry).filter(Boolean))].sort();
@@ -572,14 +643,17 @@ function writeInstallManifest(targetPath, installEntries) {
 
 function pruneRemovedEntries(targetPath, previousEntries, installEntries) {
   const next = new Set(installEntries.map(normalizeInstallEntry));
-  for (const entry of previousEntries) {
-    const normalizedEntry = normalizeInstallEntry(entry);
+  const normalizedPrevious = normalizeManifestEntries(previousEntries);
+  for (const entry of normalizedPrevious.invalid) {
+    console.warn(`  Skipping unsafe managed entry path from manifest: ${entry}`);
+  }
+  for (const normalizedEntry of normalizedPrevious.entries) {
     if (next.has(normalizedEntry)) {
       continue;
     }
-    const candidate = resolveManagedPath(targetPath, entry);
+    const candidate = resolveManagedPath(targetPath, normalizedEntry);
     if (!candidate) {
-      console.warn(`  Skipping unsafe managed entry path from manifest: ${entry}`);
+      console.warn(`  Skipping unsafe managed entry path from manifest: ${normalizedEntry}`);
       continue;
     }
     assertSafeDestinationPath(candidate, targetPath);
@@ -658,7 +732,16 @@ function resolveInstallRef(opts) {
   return DEFAULT_RELEASE_REF;
 }
 
-function installForTarget(tempDir, target, selectors = buildInstallSelectors({})) {
+function installForTarget(
+  tempDir,
+  target,
+  selectors = buildInstallSelectors({}),
+  installEntries = null,
+  requestedSkills = [],
+) {
+  // Resolve all selection errors before creating or changing the target.
+  const resolvedInstallEntries = installEntries || getInstallEntries(tempDir, selectors, requestedSkills);
+
   if (fs.existsSync(target.path)) {
     ensureTargetIsDirectory(target.path);
     const targetStats = fs.lstatSync(target.path);
@@ -698,10 +781,9 @@ function installForTarget(tempDir, target, selectors = buildInstallSelectors({})
     fs.mkdirSync(target.path, { recursive: true });
   }
 
-  const installEntries = getInstallEntries(tempDir, selectors);
-  const managedEntries = getManagedEntries(installEntries, target);
+  const managedEntries = getManagedEntries(resolvedInstallEntries, target);
   const previousEntries = readInstallManifest(target.path);
-  installSkillsIntoTarget(tempDir, target.path, installEntries);
+  installSkillsIntoTarget(tempDir, target.path, resolvedInstallEntries);
   pruneRemovedEntries(target.path, previousEntries, managedEntries);
   writeInstallManifest(target.path, managedEntries);
   console.log(`  ✓ Installed to ${target.path}`);
@@ -737,7 +819,7 @@ function getPostInstallMessages(targets, selectors = buildInstallSelectors({})) 
 
   if (targets.some((target) => isOpenCodeStylePath(target.path))) {
     const baseMessage =
-      "For Antigravity 2.0, OpenCode, or other .agents/skills installs, prefer a reduced install with --risk, --category, or --tags to avoid context overload.";
+      "For Antigravity 2.0, OpenCode, or other .agents/skills installs, prefer a reduced install with --skills, --risk, --category, or --tags to avoid context overload.";
     messages.push(baseMessage);
     if (!hasInstallSelectors(selectors)) {
       messages.push(
@@ -747,6 +829,82 @@ function getPostInstallMessages(targets, selectors = buildInstallSelectors({})) 
   }
 
   return messages;
+}
+
+function buildDryRunTargetPlan(target, installEntries) {
+  const desiredEntries = uniqueValues(getManagedEntries(installEntries, target)).sort();
+  const targetExists = fs.existsSync(target.path);
+
+  if (targetExists) {
+    const stats = fs.lstatSync(target.path);
+    if (stats.isSymbolicLink()) {
+      throw new Error(`Refusing to preview through symlinked target: ${target.path}`);
+    }
+    if (!stats.isDirectory()) {
+      throw new Error(`Install path exists but is not a directory: ${target.path}`);
+    }
+  }
+
+  const previous = normalizeManifestEntries(readInstallManifest(target.path));
+  const desiredSet = new Set(desiredEntries);
+  const remove = previous.entries.filter((entry) => !desiredSet.has(entry));
+
+  // Match the apply-time destination checks without creating any path. This
+  // makes the preview fail before a later install could encounter a symlinked
+  // managed destination or an unsafe stale manifest entry.
+  for (const entry of [...desiredEntries, ...remove]) {
+    const candidate = resolveManagedPath(target.path, entry);
+    if (!candidate) {
+      throw new Error(`Refusing unsafe managed entry in dry-run plan: ${entry}`);
+    }
+    assertSafeDestinationPath(candidate, target.path);
+  }
+
+  return {
+    name: target.name,
+    path: target.path,
+    targetExists,
+    replacesRepositoryClone: targetExists && fs.existsSync(path.join(target.path, ".git")),
+    installOrUpdate: desiredEntries,
+    remove,
+    ignoredUnsafeManifestEntries: previous.invalid,
+  };
+}
+
+function buildDryRunPlan(ref, targets, installEntries) {
+  return {
+    ref: ref || "default release",
+    targets: targets.map((target) => buildDryRunTargetPlan(target, installEntries)),
+    skills: installEntries.filter((entry) => entry !== "docs").sort(),
+  };
+}
+
+function printDryRunPlan(plan) {
+  console.log("\nDry run: no target files or directories will be created, changed, or removed.");
+  console.log(`Ref: ${plan.ref}`);
+  console.log(`Exact skill set (${plan.skills.length}):`);
+  for (const skill of plan.skills) {
+    console.log(`  ${skill}`);
+  }
+  console.log("Target mutation plans:");
+  for (const target of plan.targets) {
+    console.log(`  ${target.name}: ${target.path}`);
+    console.log(`    target: ${target.targetExists ? "existing directory" : "will be created"}`);
+    if (target.replacesRepositoryClone) {
+      console.log("    migration: existing repository clone will be backed up and replaced");
+    }
+    console.log(`    install/update managed entries (${target.installOrUpdate.length}):`);
+    for (const entry of target.installOrUpdate) {
+      console.log(`      ${entry}`);
+    }
+    console.log(`    remove stale managed entries (${target.remove.length}):`);
+    for (const entry of target.remove) {
+      console.log(`      ${entry}`);
+    }
+    for (const entry of target.ignoredUnsafeManifestEntries) {
+      console.log(`    ignored unsafe manifest entry: ${entry}`);
+    }
+  }
 }
 
 function main() {
@@ -759,6 +917,14 @@ function main() {
     return;
   }
   const selectors = buildInstallSelectors(opts);
+  let requestedSkills;
+  try {
+    requestedSkills = parseExactSkillArg(opts.skillsArg);
+  } catch (error) {
+    console.error(`Error: ${error.message}`);
+    process.exitCode = 1;
+    return;
+  }
   const ref = resolveInstallRef(opts);
 
   if (opts.help) {
@@ -788,10 +954,38 @@ function main() {
     }
     run("git", buildCloneArgs(REPO, tempDir, ref));
 
+    // Resolve the exact set once before touching any target. This keeps an
+    // unknown/ambiguous --skills value or an empty filter intersection atomic
+    // across multi-target installs.
+    let installEntries;
+    try {
+      installEntries = getInstallEntries(tempDir, selectors, requestedSkills);
+    } catch (error) {
+      console.error(`Error: ${error.message}`);
+      process.exitCode = 1;
+      return;
+    }
+
+    // Preflight every target before mutating the first one. The same plan is
+    // printed for --dry-run and acts as the multi-target safety gate for apply.
+    let dryRunPlan;
+    try {
+      dryRunPlan = buildDryRunPlan(ref, targets, installEntries);
+    } catch (error) {
+      console.error(`Error: ${error.message}`);
+      process.exitCode = 1;
+      return;
+    }
+
+    if (opts.dryRun) {
+      printDryRunPlan(dryRunPlan);
+      return;
+    }
+
     console.log(`\nInstalling for ${targets.length} target(s):`);
     for (const target of targets) {
       console.log(`\n${target.name}:`);
-      installForTarget(tempDir, target, selectors);
+      installForTarget(tempDir, target, selectors, installEntries);
     }
 
     for (const message of getPostInstallMessages(targets, selectors)) {
@@ -821,6 +1015,8 @@ module.exports = {
   replaceManagedEntry,
   getPostInstallMessages,
   buildCloneArgs,
+  buildDryRunPlan,
+  buildDryRunTargetPlan,
   buildInstallSelectors,
   getInstallEntries,
   getManagedEntries,
@@ -831,10 +1027,14 @@ module.exports = {
   main,
   matchesInstallSelectors,
   normalizeInstallEntry,
+  normalizeManifestEntries,
+  parseExactSkillArg,
   parseSelectorArg,
+  printDryRunPlan,
   parseArgs,
   pruneRemovedEntries,
   readInstallManifest,
+  resolveExactSkillSelections,
   resolveInstallRef,
   writeInstallManifest,
 };

--- a/tools/scripts/generate_index.py
+++ b/tools/scripts/generate_index.py
@@ -831,6 +831,18 @@ def coerce_metadata_text(value):
         return value
     return str(value)
 
+
+def coerce_metadata_list(value):
+    if isinstance(value, set):
+        values = [coerce_metadata_text(item) for item in sorted(value, key=str)]
+    elif isinstance(value, (list, tuple)):
+        values = [coerce_metadata_text(item) for item in value]
+    elif isinstance(value, str):
+        values = value.split(",") if "," in value else value.split()
+    else:
+        return []
+    return list(dict.fromkeys(item.strip() for item in values if item and item.strip()))
+
 def parse_frontmatter(content):
     """
     Parses YAML frontmatter, sanitizing unquoted values containing @.
@@ -936,6 +948,11 @@ def generate_index(skills_dir, output_file, compatibility_report=None):
             license_source = coerce_metadata_text(metadata.get("license_source"))
             date_added = coerce_metadata_text(metadata.get("date_added"))
             category = coerce_metadata_text(metadata.get("category"))
+            tags_value = metadata.get("tags")
+            nested_metadata = metadata.get("metadata")
+            if tags_value is None and isinstance(nested_metadata, Mapping):
+                tags_value = nested_metadata.get("tags")
+            tags = coerce_metadata_list(tags_value)
 
             if name is not None:
                 skill_info["name"] = name
@@ -955,6 +972,8 @@ def generate_index(skills_dir, output_file, compatibility_report=None):
                 skill_info["license_source"] = license_source
             if date_added is not None:
                 skill_info["date_added"] = date_added
+            if tags:
+                skill_info["tags"] = tags
             
             # Category: prefer frontmatter, then folder structure, then conservative inference
             if category is not None:

--- a/tools/scripts/tests/installer_cli_args.test.js
+++ b/tools/scripts/tests/installer_cli_args.test.js
@@ -15,6 +15,23 @@ const release = installer.parseArgs(['--release', '14.0.0']);
 assert.strictEqual(release.versionArg, '14.0.0');
 assert.strictEqual(release.versionInfo, false);
 
+const exactPreview = installer.parseArgs([
+  '--codex',
+  '--skills',
+  'frontend-design,game-development/2d-games',
+  '--dry-run',
+]);
+assert.strictEqual(exactPreview.skillsArg, 'frontend-design,game-development/2d-games');
+assert.strictEqual(exactPreview.dryRun, true);
+assert.deepStrictEqual(
+  installer.parseExactSkillArg(exactPreview.skillsArg),
+  ['frontend-design', 'game-development/2d-games'],
+);
+assert.throws(
+  () => installer.parseExactSkillArg('frontend-design,,backend-dev-guidelines'),
+  /non-empty exact skill/i,
+);
+
 const version = spawnSync(process.execPath, [installerPath, '--version'], { encoding: 'utf8' });
 assert.strictEqual(version.status, 0, version.stderr);
 assert.strictEqual(version.stdout.trim(), packageVersion);

--- a/tools/scripts/tests/installer_exact_selection.test.js
+++ b/tools/scripts/tests/installer_exact_selection.test.js
@@ -1,0 +1,263 @@
+const assert = require("assert");
+const fs = require("fs");
+const os = require("os");
+const path = require("path");
+const { spawnSync } = require("child_process");
+
+const installer = require(path.resolve(__dirname, "..", "..", "bin", "install.js"));
+const packageVersion = require(path.resolve(__dirname, "..", "..", "..", "package.json")).version;
+const pinnedRef = `v${packageVersion}`;
+
+function writeSkill(repoRoot, skillPath, frontmatter) {
+  const skillDir = path.join(repoRoot, "skills", skillPath);
+  fs.mkdirSync(skillDir, { recursive: true });
+  fs.writeFileSync(
+    path.join(skillDir, "SKILL.md"),
+    `---\n${frontmatter}\n---\n\n# ${skillPath}\n`,
+    "utf8",
+  );
+}
+
+const tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), "installer-exact-selection-"));
+
+try {
+  const repoRoot = path.join(tmpRoot, "repo");
+  fs.mkdirSync(path.join(repoRoot, "skills"), { recursive: true });
+  fs.mkdirSync(path.join(repoRoot, "docs"), { recursive: true });
+  fs.writeFileSync(path.join(repoRoot, "docs", "README.md"), "# Docs\n", "utf8");
+
+  writeSkill(
+    repoRoot,
+    "frontend-design",
+    "name: frontend-design\ncategory: development\nrisk: safe\ntags: [frontend]",
+  );
+  writeSkill(
+    repoRoot,
+    path.join("game-development", "2d-games"),
+    "name: 2D Games\ncategory: games\nrisk: safe\ntags: [game]",
+  );
+  writeSkill(
+    repoRoot,
+    path.join("legacy-games", "2d-games"),
+    "name: Legacy 2D Games\ncategory: games\nrisk: safe\ntags: [game]",
+  );
+  writeSkill(
+    repoRoot,
+    "shared-one",
+    "name: Shared Skill\ncategory: development\nrisk: safe\ntags: [shared]",
+  );
+  writeSkill(
+    repoRoot,
+    "shared-two",
+    "name: Shared Skill\ncategory: development\nrisk: safe\ntags: [shared]",
+  );
+
+  const requested = installer.parseExactSkillArg("frontend-design,game-development/2d-games");
+  assert.deepStrictEqual(
+    installer.getInstallEntries(repoRoot, installer.buildInstallSelectors({}), requested),
+    ["frontend-design", "game-development/2d-games", "docs"],
+    "--skills should resolve exact root ids and full nested paths",
+  );
+
+  assert.deepStrictEqual(
+    installer.getInstallEntries(
+      repoRoot,
+      installer.buildInstallSelectors({ categoryArg: "development" }),
+      requested,
+    ),
+    ["frontend-design", "docs"],
+    "--skills must combine with metadata filters using AND",
+  );
+
+  assert.throws(
+    () => installer.getInstallEntries(
+      repoRoot,
+      installer.buildInstallSelectors({ categoryArg: "games" }),
+      installer.parseExactSkillArg("frontend-design"),
+    ),
+    /No skills matched/i,
+    "an empty exact-selection/filter intersection must fail instead of installing docs or a broad fallback",
+  );
+
+  assert.throws(
+    () => installer.getInstallEntries(
+      repoRoot,
+      installer.buildInstallSelectors({}),
+      installer.parseExactSkillArg("does-not-exist"),
+    ),
+    /unknown skill requested/i,
+    "unknown exact skill selections must fail",
+  );
+  assert.throws(
+    () => installer.getInstallEntries(
+      repoRoot,
+      installer.buildInstallSelectors({}),
+      installer.parseExactSkillArg("2d-games"),
+    ),
+    /ambiguous skill requested/i,
+    "ambiguous basename selections must require a full nested path",
+  );
+  assert.throws(
+    () => installer.getInstallEntries(
+      repoRoot,
+      installer.buildInstallSelectors({}),
+      installer.parseExactSkillArg("Shared Skill"),
+    ),
+    /ambiguous skill requested/i,
+    "ambiguous canonical names must fail",
+  );
+
+  const absentTarget = path.join(tmpRoot, "absent-target");
+  assert.throws(
+    () => installer.installForTarget(
+      repoRoot,
+      { name: "Absent", path: absentTarget },
+      installer.buildInstallSelectors({}),
+      null,
+      installer.parseExactSkillArg("does-not-exist"),
+    ),
+    /unknown skill requested/i,
+  );
+  assert.strictEqual(
+    fs.existsSync(absentTarget),
+    false,
+    "invalid --skills selection must fail before an absent target is created",
+  );
+
+  const existingTarget = path.join(tmpRoot, "existing-target");
+  fs.mkdirSync(existingTarget, { recursive: true });
+  const sentinelPath = path.join(existingTarget, "sentinel.txt");
+  fs.writeFileSync(sentinelPath, "keep", "utf8");
+  const manifestPath = path.join(existingTarget, ".antigravity-install-manifest.json");
+  fs.writeFileSync(
+    manifestPath,
+    JSON.stringify({
+      schemaVersion: 1,
+      entries: ["frontend-design", "legacy-skill", "docs", "../outside"],
+    }),
+    "utf8",
+  );
+  const plan = installer.buildDryRunPlan(
+    pinnedRef,
+    [
+      { name: "Existing", path: existingTarget },
+      { name: "Absent", path: absentTarget },
+    ],
+    ["game-development/2d-games", "frontend-design", "docs"],
+  );
+  assert.deepStrictEqual(plan.targets[0].remove, ["legacy-skill"]);
+  assert.deepStrictEqual(plan.targets[0].ignoredUnsafeManifestEntries, ["../outside"]);
+  assert.strictEqual(plan.targets[1].targetExists, false);
+  const output = [];
+  const originalLog = console.log;
+  console.log = (message) => output.push(String(message));
+  try {
+    installer.printDryRunPlan(plan);
+  } finally {
+    console.log = originalLog;
+  }
+  assert.strictEqual(fs.readFileSync(sentinelPath, "utf8"), "keep");
+  assert.strictEqual(fs.existsSync(absentTarget), false);
+  assert.match(output.join("\n"), new RegExp(`Ref: ${pinnedRef.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}`));
+  assert.match(output.join("\n"), new RegExp(existingTarget.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")));
+  assert.match(output.join("\n"), /Exact skill set \(2\):/);
+  assert.match(output.join("\n"), /frontend-design/);
+  assert.match(output.join("\n"), /remove stale managed entries \(1\)/i);
+  assert.match(output.join("\n"), /legacy-skill/);
+  assert.match(output.join("\n"), /ignored unsafe manifest entry: \.\.\/outside/i);
+
+  // Exercise the real CLI boundary with a deterministic fake git clone. This
+  // proves --dry-run returns before installForTarget can mutate either an
+  // existing target or a missing one.
+  const fakeBin = path.join(tmpRoot, "fake-bin");
+  fs.mkdirSync(fakeBin, { recursive: true });
+  const fakeGit = path.join(fakeBin, "git");
+  fs.writeFileSync(
+    fakeGit,
+    `#!/usr/bin/env node
+const fs = require("fs");
+const destination = process.argv[process.argv.length - 1];
+fs.appendFileSync(process.env.FAKE_GIT_LOG, JSON.stringify(process.argv.slice(2)) + "\\n");
+fs.cpSync(process.env.FAKE_GIT_SOURCE, destination, { recursive: true, force: true });
+`,
+    "utf8",
+  );
+  fs.chmodSync(fakeGit, 0o755);
+
+  const fakeGitLog = path.join(tmpRoot, "fake-git-log.jsonl");
+  const cliEnv = {
+    ...process.env,
+    FAKE_GIT_SOURCE: repoRoot,
+    FAKE_GIT_LOG: fakeGitLog,
+    PATH: `${fakeBin}${path.delimiter}${process.env.PATH || ""}`,
+  };
+  const installerPath = path.resolve(__dirname, "..", "..", "bin", "install.js");
+  const beforeDryRunEntries = fs.readdirSync(existingTarget).sort();
+  const dryRun = spawnSync(
+    process.execPath,
+    [installerPath, "--path", existingTarget, "--release", packageVersion, "--skills", "frontend-design", "--dry-run"],
+    { encoding: "utf8", env: cliEnv },
+  );
+  assert.strictEqual(dryRun.status, 0, dryRun.stderr);
+  assert.match(dryRun.stdout, new RegExp(`Ref: ${pinnedRef.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}`));
+  assert.match(dryRun.stdout, /Exact skill set \(1\):/);
+  assert.match(dryRun.stdout, /remove stale managed entries \(1\)/i);
+  assert.match(dryRun.stdout, /legacy-skill/);
+  assert.deepStrictEqual(fs.readdirSync(existingTarget).sort(), beforeDryRunEntries);
+  assert.strictEqual(fs.readFileSync(sentinelPath, "utf8"), "keep");
+  const cloneArgs = JSON.parse(fs.readFileSync(fakeGitLog, "utf8").trim().split("\n")[0]);
+  assert.deepStrictEqual(
+    cloneArgs.slice(0, 5),
+    ["clone", "--depth", "1", "--branch", pinnedRef],
+    "the real CLI dry run must clone the explicitly pinned release",
+  );
+
+  const outsideSentinel = path.join(tmpRoot, "outside");
+  fs.writeFileSync(outsideSentinel, "outside stays", "utf8");
+  assert.doesNotThrow(() => installer.pruneRemovedEntries(existingTarget, ["../outside"], []));
+  assert.strictEqual(fs.readFileSync(outsideSentinel, "utf8"), "outside stays");
+
+  const unknownTarget = path.join(tmpRoot, "unknown-target");
+  const unknown = spawnSync(
+    process.execPath,
+    [installerPath, "--path", unknownTarget, "--skills", "does-not-exist", "--dry-run"],
+    { encoding: "utf8", env: cliEnv },
+  );
+  assert.strictEqual(unknown.status, 1);
+  assert.match(unknown.stderr, /Unknown skill requested/);
+  assert.strictEqual(fs.existsSync(unknownTarget), false);
+
+  const multiHome = path.join(tmpRoot, "multi-home");
+  const firstTarget = path.join(multiHome, ".claude", "skills");
+  const codexHome = path.join(tmpRoot, "codex-home");
+  const unsafeTarget = path.join(codexHome, "skills");
+  const unsafeRealTarget = path.join(tmpRoot, "unsafe-real-target");
+  fs.mkdirSync(firstTarget, { recursive: true });
+  fs.mkdirSync(codexHome, { recursive: true });
+  fs.mkdirSync(unsafeRealTarget, { recursive: true });
+  const firstSentinel = path.join(firstTarget, "first-sentinel.txt");
+  fs.writeFileSync(firstSentinel, "first stays", "utf8");
+  let createdUnsafeSymlink = false;
+  try {
+    fs.symlinkSync(unsafeRealTarget, unsafeTarget, "dir");
+    createdUnsafeSymlink = true;
+  } catch (error) {
+    // Some platforms disallow unprivileged directory symlinks.
+  }
+  if (createdUnsafeSymlink) {
+    const multiTarget = spawnSync(
+      process.execPath,
+      [installerPath, "--claude", "--codex", "--skills", "frontend-design"],
+      {
+        encoding: "utf8",
+        env: { ...cliEnv, HOME: multiHome, CODEX_HOME: codexHome },
+      },
+    );
+    assert.strictEqual(multiTarget.status, 1);
+    assert.match(multiTarget.stderr, /symlinked target/i);
+    assert.deepStrictEqual(fs.readdirSync(firstTarget), ["first-sentinel.txt"]);
+    assert.strictEqual(fs.readFileSync(firstSentinel, "utf8"), "first stays");
+  }
+} finally {
+  fs.rmSync(tmpRoot, { recursive: true, force: true });
+}

--- a/tools/scripts/tests/test_generate_index_categories.py
+++ b/tools/scripts/tests/test_generate_index_categories.py
@@ -100,6 +100,38 @@ class GenerateIndexCategoryTests(unittest.TestCase):
             self.assertEqual(categories["nested-skill"], "bundles")
             self.assertEqual(categories["playwright-skill"], "test-automation")
 
+    def test_generate_index_preserves_top_level_and_nested_tags(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            base = pathlib.Path(temp_dir)
+            skills_dir = base / "skills"
+            output_file = base / "skills_index.json"
+
+            top_level = skills_dir / "top-level"
+            top_level.mkdir(parents=True)
+            (top_level / "SKILL.md").write_text(
+                "---\nname: top-level\ndescription: Top level tags\ntags: [api, typescript, api]\n---\nbody\n",
+                encoding="utf-8",
+            )
+
+            nested_tags = skills_dir / "nested-tags"
+            nested_tags.mkdir(parents=True)
+            (nested_tags / "SKILL.md").write_text(
+                "---\nname: nested-tags\ndescription: Nested tags\nmetadata:\n  tags: data, python\n---\nbody\n",
+                encoding="utf-8",
+            )
+
+            skills = generate_index.generate_index(str(skills_dir), str(output_file))
+            by_id = {skill["id"]: skill for skill in skills}
+
+            self.assertEqual(by_id["top-level"]["tags"], ["api", "typescript"])
+            self.assertEqual(by_id["nested-tags"]["tags"], ["data", "python"])
+
+    def test_tag_coercion_is_deterministic_for_yaml_sets(self):
+        self.assertEqual(
+            generate_index.coerce_metadata_list({"typescript", "api"}),
+            ["api", "typescript"],
+        )
+
     def test_generate_index_rejects_duplicate_route_ids(self):
         with tempfile.TemporaryDirectory() as temp_dir:
             base = pathlib.Path(temp_dir)


### PR DESCRIPTION
# Pull Request Description

Adds a safe exact-set workflow to the npm installer so experienced users and the upcoming catalog Workbench can turn a deliberate skill selection into a reproducible install command.

The installer now supports `--skills <csv>` and `--dry-run`, resolves names/ids/nested paths deterministically, fails closed on unknown or ambiguous selectors, previews installs/updates/removals for every target, and performs all preflight checks before any write. Exact selection combines with risk/category/tag filters using AND.

This also preserves generated category/tag metadata for all catalog entries and documents the pinned preview-first workflow across the installation docs trinity.

## Change Classification

- [ ] Skill PR
- [x] Docs PR
- [x] Infra PR

## Issue Link (Optional)

N/A

## Quality Bar Checklist ✅

- [x] **Standards**: Read the quality bar and security guardrails.
- [x] **Metadata**: N/A — no `SKILL.md` changes; strict validation passes.
- [x] **Risk Label**: N/A — no skill risk metadata changes.
- [x] **Triggers**: N/A — no skill content changes.
- [x] **Limitations**: N/A — no skill content changes.
- [x] **Security**: N/A — no offensive skill changes.
- [x] **Safety scan**: `npm run security:docs` and strict repository security scans pass.
- [x] **Automated Skill Review**: N/A — no `SKILL.md` changes.
- [x] **Manual Logic Review**: Exact selection, atomic preflight, managed-path safety, and dry-run no-write behavior were reviewed manually and covered by tests.
- [x] **Local Test**: Targeted installer/generator tests, the full repository suite, web-app tests, app build/prerender, and npm pack smoke tests pass.
- [x] **Repo Checks**: `npm run validate:references`, strict validation, warning budget, consistency audit, and source-only diff checks pass.
- [x] **Source-Only PR**: No generated registry artifacts are included.
- [x] **Credits**: N/A — no external skill source added by this PR.
- [x] **License provenance**: N/A — no external content imported.
- [x] **Maintainer Edits**: Enabled by repository ownership.

## Verification

- exact root id and nested-path selection
- exact selection plus metadata-filter intersection
- unknown/ambiguous/empty selections fail before target creation
- dry-run leaves absent and existing targets unchanged
- multi-target preflight fails atomically before writes
- unsafe managed manifest paths are ignored/refused
- current package version and pinned release are exercised dynamically
- generated catalog preserves 1,948 unique ids and category/tag metadata

## Screenshots (if applicable)

N/A — CLI and metadata foundation only; the user-facing Workbench follows as a separate PR after the 14.3.0 package is public.
