### PR TITLE
Add claude-skills to Community Contributors

### DIFF
--- a/README.md
+++ b/README.md
@@ -448,6 +448,7 @@ Key source families include:
 - **[alirezarezvani/claude-skills](https://github.com/alirezarezvani/claude-skills)**: Senior Engineering and PM toolkit.
 - **[karanb192/awesome-claude-skills](https://github.com/karanb192/awesome-claude-skills)**: A massive list of verified skills for Claude Code.
 - **[VoltAgent/awesome-agent-skills](https://github.com/VoltAgent/awesome-agent-skills)**: Curated collection of 1000+ official and community agent skills from leading development teams (MIT).
+- **[redamancy231-create/claude-skills](https://github.com/redamancy231-create/claude-skills)**: Claude Code 技能集合，含会话交接、项目文档生成、事前否决三个实战验证 Skill，提炼自50+轮跨模型独立审查。
 - **[zircote/.claude](https://github.com/zircote/.claude)**: Archived Claude Code dotfiles/config repo with a Shopify development skill reference.
 - **[vibeforge1111/vibeship-spawner-skills](https://github.com/vibeforge1111/vibeship-spawner-skills)**: AI agents, integrations, maker tools, and other production-grade skill packs.
 - **[coreyhaines31/marketingskills](https://github.com/coreyhaines31/marketingskills)**: Marketing skills for CRO, copywriting, SEO, paid ads, and growth (23 skills, MIT).


### PR DESCRIPTION
Add [claude-skills](https://github.com/redamancy231-create/claude-skills) — a curated collection of 3 Claude Code skills (session-end, write-claude-md, kill-test-first), each independently verified through multi-model review across 50+ rounds. Added to Community Contributors section alongside existing skill collections.