### PR TITLE
docs: clarify protected branch commit flow

### DIFF
--- a/docs/maintainers/pr-autonomy.md
+++ b/docs/maintainers/pr-autonomy.md
@@ -71,7 +71,7 @@ Deletions, copies, ambiguous moves, and all canonical skill-content changes rema
 
 Generated artifacts and contributor credits no longer write directly to `main`. Push and scheduled maintenance workflows regenerate the repository state without persisted checkout credentials, reject any unmanaged drift, and maintain one bot PR from `automation/canonical-repo-state`.
 
-Because GitHub suppresses ordinary workflow recursion for PRs created with `GITHUB_TOKEN`, the trusted writer explicitly dispatches the four required checks on the bot branch. That dispatch is accepted only on the exact branch, only for files declared by the generated-files contract, and only when rerunning `sync:repo-state` produces the exact full Git tree. A trusted waiter binds the open PR to its immutable head, verifies all four exact GitHub Actions checks, proves effective `main` protection, performs an immediate squash merge, and explicitly dispatches main CI, Pages, and CodeQL. It has no bypass around `main` protection.
+Because GitHub suppresses ordinary workflow recursion for PRs created with `GITHUB_TOKEN`, the trusted writer explicitly dispatches the four required checks on the bot branch. That dispatch is accepted only on the exact branch, only for files declared by the generated-files contract, and only when rerunning `sync:repo-state` produces the exact full Git tree. A trusted waiter binds the open PR to its immutable head, verifies all four exact GitHub Actions checks, confirms that `main` remains protected and unchanged, performs an immediate exact-head squash merge, and explicitly dispatches main CI, Pages, and CodeQL. The detailed protection policy is configured and audited with maintainer credentials; the workflow token has no bypass around it.
 
 ## Later Phases
 

--- a/skills/commit/SKILL.md
+++ b/skills/commit/SKILL.md
@@ -22,7 +22,7 @@ Before committing, always check the current branch:
 git branch --show-current
 ```
 
-**If you're on `main` or `master`, you MUST create a feature branch first** — unless the user explicitly asked to commit to main. Do not ask the user whether to create a branch; just proceed with branch creation. The `create-branch` skill will still propose a branch name for the user to confirm.
+**If you're on `main` or `master`, you MUST create a feature branch first** — unless the user explicitly asked to commit to main and the server permits direct pushes. A user request does not bypass protected-branch rules; when the remote rejects direct updates, use the repository's required pull-request path. Do not ask the user whether to create a branch; just proceed with branch creation. The `create-branch` skill will still propose a branch name for the user to confirm.
 
 Use the `create-branch` skill to create the branch. After `create-branch` completes, verify the current branch has changed before proceeding:
 
@@ -168,5 +168,6 @@ Reason: Caused performance regression in production.
 
 ## Limitations
 - Use this skill only when the task clearly matches the scope described above.
+- Direct-to-main instructions remain subordinate to server-side branch protection and required checks.
 - Do not treat the output as a substitute for environment-specific validation, testing, or expert review.
 - Stop and ask for clarification if required inputs, permissions, safety boundaries, or success criteria are missing.


### PR DESCRIPTION
Clarifies that direct-to-main instructions remain subordinate to server-side branch protection, and aligns the autonomy documentation with the live enforcement boundary. This PR intentionally changes one canonical skill so the protected merge and canonical artifact PR lane are exercised end to end.

## Change Classification
- [x] Skill improvement
- [x] Maintainer documentation

## Quality Bar Checklist
- [x] The skill remains focused and actionable.
- [x] No generated artifacts are committed in this source PR.
- [x] Validation and documentation security checks pass.
- [x] The exact head SHA will be reviewed before merge.

## Testing
- `npm run validate`
- `npm run security:docs`