### PR TITLE
fix(ci): bind canonical checks to pull request

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,9 @@ on:
 permissions:
   contents: read
 
+env:
+  IS_TRUSTED_CANONICAL_SYNC_PR: ${{ inputs.canonical_sync_pr == true || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository && github.head_ref == 'automation/canonical-repo-state' && github.event.pull_request.user.login == 'github-actions[bot]') }}
+
 jobs:
   pr-policy:
     if: github.event_name == 'pull_request' || inputs.canonical_sync_pr == true
@@ -39,7 +42,7 @@ jobs:
           node-version: "lts/*"
 
       - name: Install PR policy dependencies
-        if: github.event_name == 'pull_request'
+        if: github.event_name == 'pull_request' && env.IS_TRUSTED_CANONICAL_SYNC_PR != 'true'
         run: npm ci --ignore-scripts
 
       - name: Fetch base branch
@@ -47,7 +50,7 @@ jobs:
 
       - name: Intake PR change
         id: intake
-        if: github.event_name == 'pull_request'
+        if: github.event_name == 'pull_request' && env.IS_TRUSTED_CANONICAL_SYNC_PR != 'true'
         run: |
           node tools/scripts/pr_preflight.cjs \
             --base "origin/${{ github.base_ref }}" \
@@ -58,9 +61,9 @@ jobs:
             --write-step-summary
 
       - name: Validate canonical-sync path boundary
-        if: inputs.canonical_sync_pr == true
+        if: env.IS_TRUSTED_CANONICAL_SYNC_PR == 'true'
         run: |
-          test "$GITHUB_REF_NAME" = "automation/canonical-repo-state"
+          test "${GITHUB_HEAD_REF:-$GITHUB_REF_NAME}" = "automation/canonical-repo-state"
           node tools/scripts/validate_canonical_sync_pr.cjs --base origin/main --head HEAD
 
       - name: Validate protected release path boundary
@@ -74,13 +77,13 @@ jobs:
             --include-release-managed
 
       - name: Set up Python for canonical reproduction
-        if: inputs.canonical_sync_pr == true
+        if: env.IS_TRUSTED_CANONICAL_SYNC_PR == 'true'
         uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
         with:
           python-version: "3.10"
 
       - name: Reproduce canonical-sync tree from trusted main
-        if: inputs.canonical_sync_pr == true
+        if: env.IS_TRUSTED_CANONICAL_SYNC_PR == 'true'
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
@@ -105,11 +108,11 @@ jobs:
           test "$expected_tree" = "$actual_tree"
 
       - name: Install npm dependencies
-        if: inputs.canonical_sync_pr == true
+        if: env.IS_TRUSTED_CANONICAL_SYNC_PR == 'true'
         run: npm ci --ignore-scripts
 
       - name: Enforce PR source-only contract
-        if: github.event_name == 'pull_request'
+        if: github.event_name == 'pull_request' && env.IS_TRUSTED_CANONICAL_SYNC_PR != 'true'
         env:
           IS_TRUSTED_RELEASE_PR: ${{ github.event.pull_request.head.repo.full_name == github.repository && startsWith(github.head_ref, 'release/v') && github.event.pull_request.user.login == github.repository_owner }}
         run: |
@@ -176,7 +179,7 @@ jobs:
         run: npm run check:warning-budget
 
       - name: Verify README source credits for changed skills
-        if: github.event_name == 'pull_request'
+        if: github.event_name == 'pull_request' && env.IS_TRUSTED_CANONICAL_SYNC_PR != 'true'
         run: npm run check:readme-credits -- --base "origin/${{ github.base_ref }}" --head HEAD
 
       - name: Validate references
@@ -227,7 +230,7 @@ jobs:
         run: git fetch origin "${{ github.base_ref || 'main' }}"
 
       - name: Generate PR intake JSON
-        if: github.event_name == 'pull_request'
+        if: github.event_name == 'pull_request' && env.IS_TRUSTED_CANONICAL_SYNC_PR != 'true'
         run: |
           mkdir -p .tmp/pr-evidence
           node tools/scripts/pr_preflight.cjs \
@@ -239,7 +242,7 @@ jobs:
 
       - name: Generate changed-skill evidence
         id: changed_skill_evidence
-        if: github.event_name == 'pull_request'
+        if: github.event_name == 'pull_request' && env.IS_TRUSTED_CANONICAL_SYNC_PR != 'true'
         continue-on-error: true
         run: |
           node tools/scripts/run-python.js tools/scripts/changed_skill_evidence.py \
@@ -249,7 +252,7 @@ jobs:
 
       - name: Resolve advisory semantic-review state
         id: semantic_review
-        if: github.event_name == 'pull_request'
+        if: github.event_name == 'pull_request' && env.IS_TRUSTED_CANONICAL_SYNC_PR != 'true'
         env:
           HEAD_REPOSITORY: ${{ github.event.pull_request.head.repo.full_name }}
           BASE_REPOSITORY: ${{ github.repository }}
@@ -273,7 +276,7 @@ jobs:
             --write-step-summary
 
       - name: Upload advisory evidence
-        if: always() && github.event_name == 'pull_request'
+        if: always() && github.event_name == 'pull_request' && env.IS_TRUSTED_CANONICAL_SYNC_PR != 'true'
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: pr-evidence-${{ github.event.pull_request.number }}
@@ -282,13 +285,13 @@ jobs:
           retention-days: 14
 
       - name: Enforce deterministic changed-skill gate
-        if: github.event_name == 'pull_request' && steps.changed_skill_evidence.outcome == 'failure'
+        if: github.event_name == 'pull_request' && env.IS_TRUSTED_CANONICAL_SYNC_PR != 'true' && steps.changed_skill_evidence.outcome == 'failure'
         run: |
           echo "Changed-skill evidence reported a blocking regression or operational failure."
           exit 1
 
       - name: Record canonical-sync evidence boundary
-        if: inputs.canonical_sync_pr == true
+        if: env.IS_TRUSTED_CANONICAL_SYNC_PR == 'true'
         run: echo "Canonical-sync content is verified by managed-path and reproducibility gates."
 
   artifact-preview:
@@ -315,14 +318,14 @@ jobs:
         run: npm ci
 
       - name: Generate canonical artifacts preview
-        if: inputs.canonical_sync_pr != true
+        if: env.IS_TRUSTED_CANONICAL_SYNC_PR != 'true'
         run: |
           npm run chain
           npm run catalog
           npm run sync:web-assets
 
       - name: Reproduce canonical-sync PR from main
-        if: inputs.canonical_sync_pr == true
+        if: env.IS_TRUSTED_CANONICAL_SYNC_PR == 'true'
         env:
           GH_TOKEN: ${{ github.token }}
         run: npm run sync:repo-state
@@ -351,7 +354,7 @@ jobs:
             exit 0
           fi
 
-          if [ "${{ inputs.canonical_sync_pr }}" = "true" ]; then
+          if [ "$IS_TRUSTED_CANONICAL_SYNC_PR" = "true" ]; then
             echo "::error::Canonical-sync PR is not byte-for-byte reproducible from main."
             printf '%s\n' "$drift_files"
             exit 1
@@ -485,13 +488,6 @@ jobs:
             - [x] Contains only files declared by the generated-files contract.
             - [x] Reproducibility is verified byte-for-byte by required CI.
             - [x] No source or workflow changes are included.
-
-      - name: Dispatch required checks for canonical-sync PR
-        if: steps.canonical_pr.outputs.pull-request-number != ''
-        env:
-          GH_TOKEN: ${{ github.token }}
-          PR_BRANCH: ${{ steps.canonical_pr.outputs.pull-request-branch }}
-        run: gh workflow run ci.yml --ref "$PR_BRANCH" -f canonical_sync_pr=true
 
       - name: Merge canonical-sync PR after exact required checks
         if: steps.canonical_pr.outputs.pull-request-number != ''

--- a/.github/workflows/repo-hygiene.yml
+++ b/.github/workflows/repo-hygiene.yml
@@ -103,13 +103,6 @@ jobs:
             - [x] Reproducibility is verified byte-for-byte by required CI.
             - [x] No source or workflow changes are included.
 
-      - name: Dispatch required checks for canonical-sync PR
-        if: steps.canonical_pr.outputs.pull-request-number != ''
-        env:
-          GH_TOKEN: ${{ github.token }}
-          PR_BRANCH: ${{ steps.canonical_pr.outputs.pull-request-branch }}
-        run: gh workflow run ci.yml --ref "$PR_BRANCH" -f canonical_sync_pr=true
-
       - name: Merge canonical-sync PR after exact required checks
         if: steps.canonical_pr.outputs.pull-request-number != ''
         env:

--- a/tools/scripts/merge_canonical_sync_pr.cjs
+++ b/tools/scripts/merge_canonical_sync_pr.cjs
@@ -5,6 +5,7 @@ const { spawnSync } = require("child_process");
 const REQUIRED_CHECKS = ["pr-policy", "pr-evidence", "source-validation", "artifact-preview"];
 const GITHUB_ACTIONS_APP_ID = 15368;
 const BOT_BRANCH = "automation/canonical-repo-state";
+const CI_WORKFLOW_PATH = ".github/workflows/ci.yml";
 
 function parseArgs(argv) {
   const options = { pollSeconds: 10, maxAttempts: 180 };
@@ -39,10 +40,14 @@ function runGh(args, options = {}) {
   return result.stdout.trim();
 }
 
-function latestRequiredChecks(checkRuns) {
+function latestRequiredChecks(checkRuns, expectedCheckSuiteId) {
   const result = new Map();
   for (const run of checkRuns || []) {
-    if (Number(run?.app?.id) !== GITHUB_ACTIONS_APP_ID || !REQUIRED_CHECKS.includes(String(run?.name || ""))) {
+    if (
+      Number(run?.app?.id) !== GITHUB_ACTIONS_APP_ID ||
+      Number(run?.check_suite?.id) !== Number(expectedCheckSuiteId) ||
+      !REQUIRED_CHECKS.includes(String(run?.name || ""))
+    ) {
       continue;
     }
     const prior = result.get(run.name);
@@ -55,8 +60,8 @@ function latestRequiredChecks(checkRuns) {
   return result;
 }
 
-function summarizeChecks(checkRuns) {
-  const latest = latestRequiredChecks(checkRuns);
+function summarizeChecks(checkRuns, expectedCheckSuiteId) {
+  const latest = latestRequiredChecks(checkRuns, expectedCheckSuiteId);
   return REQUIRED_CHECKS.map((name) => {
     const run = latest.get(name);
     if (!run) return { name, state: "pending", conclusion: "missing" };
@@ -89,11 +94,40 @@ function validateProtectedMain(branch) {
   return true;
 }
 
+function selectCanonicalPullRequestRun(runs, options, expectedBaseSha) {
+  const matches = (runs || []).filter((run) => (
+    run?.path === CI_WORKFLOW_PATH &&
+    run?.event === "pull_request" &&
+    run?.head_branch === BOT_BRANCH &&
+    run?.head_sha === options.head &&
+    run?.head_repository?.full_name === options.repo &&
+    run?.actor?.login === "github-actions[bot]" &&
+    Number.isInteger(Number(run?.check_suite_id)) &&
+    Number(run.check_suite_id) > 0 &&
+    Array.isArray(run?.pull_requests) &&
+    run.pull_requests.length === 1 &&
+    Number(run.pull_requests[0]?.number) === Number(options.pr) &&
+    run.pull_requests[0]?.base?.ref === "main" &&
+    run.pull_requests[0]?.base?.sha === expectedBaseSha &&
+    run.pull_requests[0]?.head?.ref === BOT_BRANCH &&
+    run.pull_requests[0]?.head?.sha === options.head &&
+    Number(run.pull_requests[0]?.base?.repo?.id) === Number(run.head_repository?.id) &&
+    Number(run.pull_requests[0]?.head?.repo?.id) === Number(run.head_repository?.id)
+  ));
+  if (matches.length > 1) {
+    throw new Error("Multiple canonical-sync pull-request CI runs matched the exact trusted identity.");
+  }
+  return matches[0] || null;
+}
+
 function wait(milliseconds) {
   return new Promise((resolve) => setTimeout(resolve, milliseconds));
 }
 
-async function waitForChecks(options, dependencies = {}) {
+async function waitForChecks(options, expectedCheckSuiteId, dependencies = {}) {
+  if (!Number.isInteger(Number(expectedCheckSuiteId)) || Number(expectedCheckSuiteId) <= 0) {
+    throw new Error("Canonical-sync PR CI did not expose a valid check-suite ID.");
+  }
   const load = dependencies.loadCheckRuns || (() => {
     const payload = JSON.parse(runGh([
       "api",
@@ -104,7 +138,7 @@ async function waitForChecks(options, dependencies = {}) {
   const pause = dependencies.wait || wait;
 
   for (let attempt = 1; attempt <= options.maxAttempts; attempt += 1) {
-    const summaries = summarizeChecks(load());
+    const summaries = summarizeChecks(load(), expectedCheckSuiteId);
     process.stdout.write(`[canonical-sync] ${summaries.map((item) => `${item.name}:${item.conclusion}`).join(" ")}\n`);
     const failed = summaries.filter((item) => item.state === "failed");
     if (failed.length) throw new Error(`Canonical-sync required checks failed: ${failed.map((item) => item.name).join(", ")}`);
@@ -112,6 +146,42 @@ async function waitForChecks(options, dependencies = {}) {
     await pause(options.pollSeconds * 1000);
   }
   throw new Error("Timed out waiting for canonical-sync required checks.");
+}
+
+async function ensurePullRequestChecksStarted(options, expectedBaseSha, dependencies = {}) {
+  const load = dependencies.loadWorkflowRuns || (() => {
+    const payload = JSON.parse(runGh([
+      "api",
+      `repos/${options.repo}/actions/runs?head_sha=${options.head}&per_page=100`,
+    ]) || "{}");
+    return payload.workflow_runs || [];
+  });
+  const rerun = dependencies.rerunWorkflow || ((run) => runGh([
+    "api",
+    `repos/${options.repo}/actions/runs/${run.id}/rerun`,
+    "-X",
+    "POST",
+  ]));
+  const pause = dependencies.wait || wait;
+
+  for (let attempt = 1; attempt <= options.maxAttempts; attempt += 1) {
+    const run = selectCanonicalPullRequestRun(load(), options, expectedBaseSha);
+    if (!run) {
+      await pause(options.pollSeconds * 1000);
+      continue;
+    }
+    const status = String(run.status || "").toLowerCase();
+    const conclusion = String(run.conclusion || "").toLowerCase();
+    if (status === "completed" && conclusion === "action_required") {
+      rerun(run);
+      process.stdout.write(`[canonical-sync] restarted PR-associated CI run ${run.id}.\n`);
+      return run;
+    }
+    if (["queued", "in_progress", "waiting", "requested", "pending"].includes(status)) return run;
+    if (status === "completed" && conclusion === "success") return run;
+    throw new Error(`Canonical-sync PR CI cannot start from ${status || "unknown"}/${conclusion || "none"}.`);
+  }
+  throw new Error("Timed out waiting for the canonical-sync pull-request CI run.");
 }
 
 async function main() {
@@ -122,7 +192,8 @@ async function main() {
   if (!/^[0-9a-f]{40}$/u.test(initialBaseSha)) throw new Error("Protected main did not expose a full base SHA.");
   const initialPr = JSON.parse(runGh(["api", `repos/${options.repo}/pulls/${options.pr}`]));
   validatePullRequest(initialPr, options, initialBaseSha);
-  await waitForChecks(options);
+  const pullRequestRun = await ensurePullRequestChecksStarted(options, initialBaseSha);
+  await waitForChecks(options, pullRequestRun.check_suite_id);
   const pr = JSON.parse(runGh(["api", `repos/${options.repo}/pulls/${options.pr}`]));
   const finalBranch = JSON.parse(runGh(["api", `repos/${options.repo}/branches/main`]));
   validateProtectedMain(finalBranch);
@@ -163,8 +234,10 @@ if (require.main === module) {
 }
 
 module.exports = {
+  ensurePullRequestChecksStarted,
   latestRequiredChecks,
   parseArgs,
+  selectCanonicalPullRequestRun,
   summarizeChecks,
   validateProtectedMain,
   validatePullRequest,

--- a/tools/scripts/tests/automation_workflows.test.js
+++ b/tools/scripts/tests/automation_workflows.test.js
@@ -11,6 +11,7 @@ function readText(relativePath) {
 const packageJson = JSON.parse(readText("package.json"));
 const generatedFiles = JSON.parse(readText("tools/config/generated-files.json"));
 const ciWorkflow = readText(".github/workflows/ci.yml");
+const canonicalMergeScript = readText("tools/scripts/merge_canonical_sync_pr.cjs");
 const publishWorkflow = readText(".github/workflows/publish-npm.yml");
 const releaseWorkflowScript = readText("tools/scripts/release_workflow.js");
 const hygieneWorkflowPath = path.join(repoRoot, ".github", "workflows", "repo-hygiene.yml");
@@ -200,10 +201,15 @@ assert.match(
   /branch: automation\/canonical-repo-state/,
   "main CI should maintain one fixed canonical-sync branch",
 );
-assert.match(
+assert.doesNotMatch(
   ciWorkflow,
   /gh workflow run ci\.yml --ref "\$PR_BRANCH" -f canonical_sync_pr=true/,
-  "main CI should explicitly dispatch required checks for GITHUB_TOKEN-created PRs",
+  "canonical checks must remain associated with the pull request",
+);
+assert.match(
+  canonicalMergeScript,
+  /actions\/runs\/\$\{run\.id\}\/rerun/,
+  "main CI should restart the PR-associated workflow suppressed for a GITHUB_TOKEN-created PR",
 );
 assert.match(
   ciWorkflow,
@@ -265,10 +271,10 @@ assert.match(
   /uses: peter-evans\/create-pull-request@[a-f0-9]{40}/,
   "repo hygiene should publish canonical drift through a pinned pull-request action",
 );
-assert.match(
+assert.doesNotMatch(
   hygieneWorkflow,
   /gh workflow run ci\.yml --ref "\$PR_BRANCH" -f canonical_sync_pr=true/,
-  "repo hygiene should explicitly dispatch required checks for GITHUB_TOKEN-created PRs",
+  "repo hygiene should use the exact PR-associated workflow instead of a redundant dispatch",
 );
 assert.doesNotMatch(
   hygieneWorkflow,

--- a/tools/scripts/tests/merge_canonical_sync_pr.test.js
+++ b/tools/scripts/tests/merge_canonical_sync_pr.test.js
@@ -7,7 +7,9 @@ const options = canonicalMerge.parseArgs(["--repo", "owner/repo", "--pr", "42", 
 assert.strictEqual(options.pollSeconds, 10);
 assert.throws(() => canonicalMerge.parseArgs(["--repo", "owner/repo", "--pr", "42", "--head", "short"]), /full SHA-1/);
 
-function run(name, conclusion = "success", id = 1, appId = 15368) {
+const CHECK_SUITE_ID = 777;
+
+function run(name, conclusion = "success", id = 1, appId = 15368, checkSuiteId = CHECK_SUITE_ID) {
   return {
     id,
     name,
@@ -15,14 +17,21 @@ function run(name, conclusion = "success", id = 1, appId = 15368) {
     conclusion,
     completed_at: `2026-07-13T20:00:0${id}Z`,
     app: { id: appId },
+    check_suite: { id: checkSuiteId },
   };
 }
 
 const passing = ["pr-policy", "pr-evidence", "source-validation", "artifact-preview"].map((name, index) => run(name, "success", index + 1));
-assert.ok(canonicalMerge.summarizeChecks(passing).every((item) => item.state === "success"));
-assert.strictEqual(canonicalMerge.summarizeChecks([...passing, run("pr-policy", "success", 9, 999)])[0].state, "success");
-assert.strictEqual(canonicalMerge.summarizeChecks(passing.filter((item) => item.name !== "pr-evidence"))[1].state, "pending");
-assert.strictEqual(canonicalMerge.summarizeChecks([...passing, run("artifact-preview", "failure", 9)])[3].state, "failed");
+assert.ok(canonicalMerge.summarizeChecks(passing, CHECK_SUITE_ID).every((item) => item.state === "success"));
+assert.strictEqual(canonicalMerge.summarizeChecks([...passing, run("pr-policy", "success", 9, 999)], CHECK_SUITE_ID)[0].state, "success");
+assert.strictEqual(canonicalMerge.summarizeChecks(passing.filter((item) => item.name !== "pr-evidence"), CHECK_SUITE_ID)[1].state, "pending");
+assert.strictEqual(canonicalMerge.summarizeChecks([...passing, run("artifact-preview", "failure", 9)], CHECK_SUITE_ID)[3].state, "failed");
+const spoofSuitePassing = ["pr-policy", "pr-evidence", "source-validation", "artifact-preview"]
+  .map((name, index) => run(name, "success", index + 20, 15368, 888));
+assert.strictEqual(
+  canonicalMerge.summarizeChecks([...spoofSuitePassing, run("artifact-preview", "failure", 9)], CHECK_SUITE_ID)[3].state,
+  "failed",
+);
 
 assert.strictEqual(canonicalMerge.validatePullRequest({
   number: 42,
@@ -40,9 +49,75 @@ assert.throws(() => canonicalMerge.validatePullRequest({
   head: { ref: "other", sha: HEAD, repo: { full_name: "owner/repo" } },
 }, options, "b".repeat(40)), /identity/);
 
+const canonicalRun = {
+  id: 123,
+  check_suite_id: CHECK_SUITE_ID,
+  path: ".github/workflows/ci.yml",
+  event: "pull_request",
+  status: "completed",
+  conclusion: "action_required",
+  head_branch: "automation/canonical-repo-state",
+  head_sha: HEAD,
+  head_repository: { id: 999, full_name: "owner/repo" },
+  actor: { login: "github-actions[bot]" },
+  pull_requests: [{
+    number: 42,
+    base: { ref: "main", sha: "b".repeat(40), repo: { id: 999 } },
+    head: { ref: "automation/canonical-repo-state", sha: HEAD, repo: { id: 999 } },
+  }],
+};
+assert.strictEqual(canonicalMerge.selectCanonicalPullRequestRun([canonicalRun], options, "b".repeat(40)), canonicalRun);
+assert.strictEqual(canonicalMerge.selectCanonicalPullRequestRun([
+  { ...canonicalRun, actor: { login: "attacker" } },
+], options, "b".repeat(40)), null);
+assert.strictEqual(canonicalMerge.selectCanonicalPullRequestRun([
+  { ...canonicalRun, pull_requests: [{ ...canonicalRun.pull_requests[0], number: 41 }] },
+], options, "b".repeat(40)), null);
+assert.strictEqual(canonicalMerge.selectCanonicalPullRequestRun([
+  {
+    ...canonicalRun,
+    pull_requests: [{
+      ...canonicalRun.pull_requests[0],
+      base: { ...canonicalRun.pull_requests[0].base, sha: "c".repeat(40) },
+    }],
+  },
+], options, "b".repeat(40)), null);
+assert.throws(
+  () => canonicalMerge.selectCanonicalPullRequestRun(
+    [canonicalRun, { ...canonicalRun, id: 124 }],
+    options,
+    "b".repeat(40),
+  ),
+  /Multiple canonical-sync/,
+);
+
 (async () => {
+  let reruns = 0;
+  await canonicalMerge.ensurePullRequestChecksStarted({ ...options, pollSeconds: 1, maxAttempts: 2 }, "b".repeat(40), {
+    loadWorkflowRuns: () => [canonicalRun],
+    rerunWorkflow(run) {
+      assert.strictEqual(run.id, 123);
+      reruns += 1;
+    },
+    wait: async () => {},
+  });
+  assert.strictEqual(reruns, 1);
+
+  let loads = 0;
+  await canonicalMerge.ensurePullRequestChecksStarted({ ...options, pollSeconds: 1, maxAttempts: 2 }, "b".repeat(40), {
+    loadWorkflowRuns() {
+      loads += 1;
+      return loads === 1 ? [] : [{ ...canonicalRun, status: "in_progress", conclusion: null }];
+    },
+    rerunWorkflow() {
+      throw new Error("in-progress CI must not be rerun");
+    },
+    wait: async () => {},
+  });
+  assert.strictEqual(loads, 2);
+
   let calls = 0;
-  await canonicalMerge.waitForChecks({ ...options, pollSeconds: 1, maxAttempts: 2 }, {
+  await canonicalMerge.waitForChecks({ ...options, pollSeconds: 1, maxAttempts: 2 }, CHECK_SUITE_ID, {
     loadCheckRuns() {
       calls += 1;
       return calls === 1 ? passing.slice(0, 3) : passing;


### PR DESCRIPTION
Fix the live canonical-sync E2E failure by restarting and validating the exact pull-request workflow run instead of relying on detached workflow-dispatch checks.

The coordinator now binds the run to the exact PR, base/head SHAs, repository IDs, bot actor, and check-suite ID before merging. The trusted canonical PR is recognized on pull_request events and redundant dispatches are removed.

## Quality Bar Checklist

- [x] Full repository test suite passes.
- [x] Workflow lint passes.
- [x] Canonical PR identity and check-suite confusion cases are tested.
- [x] Two independent correctness/security audits passed.
- [x] No generated registry artifacts are included.