### PR TITLE
fix: bind protected fork workflow runs

### DIFF
--- a/tools/scripts/merge_batch.cjs
+++ b/tools/scripts/merge_batch.cjs
@@ -1030,8 +1030,17 @@ function validateActionRequiredRuns(
       reasons.push("head SHA does not match the captured pull request head");
     }
     if (!prNumbers.includes(prNumber)) {
-      const canBindEmptyMetadata = prNumbers.length === 0
-        && prIdentity
+      const identityValues = [
+        run?.head_branch,
+        run?.head_repository?.full_name,
+        run?.repository?.full_name,
+        prIdentity?.headRefName,
+        prIdentity?.headRepository,
+        prIdentity?.baseRepository,
+      ];
+      const canBindEmptyMetadata = Array.isArray(run?.pull_requests)
+        && run.pull_requests.length === 0
+        && identityValues.every((value) => typeof value === "string" && value.length > 0)
         && run?.head_branch === prIdentity.headRefName
         && run?.head_repository?.full_name === prIdentity.headRepository
         && run?.repository?.full_name === prIdentity.baseRepository;

--- a/tools/scripts/merge_batch.cjs
+++ b/tools/scripts/merge_batch.cjs
@@ -619,6 +619,8 @@ function loadPullRequestDetails(projectRoot, repoSlug, prNumber) {
       "number",
       "title",
       "headRefOid",
+      "headRefName",
+      "headRepository",
       "url",
     ].join(","),
   });
@@ -987,6 +989,7 @@ function validateActionRequiredRuns(
   prNumber,
   headSha,
   allowedWorkflowPaths = APPROVAL_WORKFLOW_PATHS,
+  prIdentity = null,
 ) {
   const workflowById = new Map(
     workflows
@@ -1027,7 +1030,14 @@ function validateActionRequiredRuns(
       reasons.push("head SHA does not match the captured pull request head");
     }
     if (!prNumbers.includes(prNumber)) {
-      reasons.push(`pull request metadata does not contain #${prNumber}`);
+      const canBindEmptyMetadata = prNumbers.length === 0
+        && prIdentity
+        && run?.head_branch === prIdentity.headRefName
+        && run?.head_repository?.full_name === prIdentity.headRepository
+        && run?.repository?.full_name === prIdentity.baseRepository;
+      if (!canBindEmptyMetadata) {
+        reasons.push(`pull request metadata does not contain #${prNumber} and the exact fork identity does not match`);
+      }
     }
     if (reasons.length) {
       throw new Error(`Refusing workflow run ${runId || "<unknown>"}: ${reasons.join("; ")}.`);
@@ -1114,6 +1124,11 @@ function approveActionRequiredRuns(projectRoot, repoSlug, prDetails, options = {
     prNumber,
     headOid,
     options.allowedWorkflowPaths || APPROVAL_WORKFLOW_PATHS,
+    {
+      headRefName: prDetails.headRefName,
+      headRepository: prDetails.headRepository?.nameWithOwner,
+      baseRepository: repoSlug,
+    },
   );
 
   assertUnchangedTuple(

--- a/tools/scripts/tests/merge_batch.test.js
+++ b/tools/scripts/tests/merge_batch.test.js
@@ -248,6 +248,9 @@ function runFixture(overrides = {}) {
     path: ".github/workflows/ci.yml",
     event: "pull_request",
     head_sha: HEAD_SHA,
+    head_branch: "feature/example",
+    head_repository: { full_name: "contributor/repo" },
+    repository: { full_name: "owner/repo" },
     pull_requests: [{ number: 450 }],
     ...overrides,
   };
@@ -261,6 +264,39 @@ function runFixture(overrides = {}) {
     HEAD_SHA,
   );
   assert.strictEqual(valid.length, 1);
+
+  const emptyMetadataIdentity = {
+    headRefName: "feature/example",
+    headRepository: "contributor/repo",
+    baseRepository: "owner/repo",
+  };
+  const emptyMetadata = mergeBatch.validateActionRequiredRuns(
+    [runFixture({ pull_requests: [] })],
+    [workflowFixture()],
+    450,
+    HEAD_SHA,
+    undefined,
+    emptyMetadataIdentity,
+  );
+  assert.strictEqual(emptyMetadata.length, 1);
+  for (const [label, identity] of [
+    ["wrong branch", { ...emptyMetadataIdentity, headRefName: "feature/other" }],
+    ["wrong fork", { ...emptyMetadataIdentity, headRepository: "attacker/repo" }],
+    ["wrong base repository", { ...emptyMetadataIdentity, baseRepository: "attacker/base" }],
+  ]) {
+    assert.throws(
+      () => mergeBatch.validateActionRequiredRuns(
+        [runFixture({ pull_requests: [] })],
+        [workflowFixture()],
+        450,
+        HEAD_SHA,
+        undefined,
+        identity,
+      ),
+      /exact fork identity does not match/,
+      label,
+    );
+  }
 
   for (const [label, run, workflows, pattern] of [
     ["unrelated PR", runFixture({ pull_requests: [{ number: 451 }] }), [workflowFixture()], /does not contain #450/],

--- a/tools/scripts/tests/merge_batch.test.js
+++ b/tools/scripts/tests/merge_batch.test.js
@@ -297,6 +297,30 @@ function runFixture(overrides = {}) {
       label,
     );
   }
+  for (const [label, run, identity = emptyMetadataIdentity] of [
+    ["missing pull request metadata", runFixture({ pull_requests: undefined })],
+    ["non-array pull request metadata", runFixture({ pull_requests: {} })],
+    ["nonempty malformed pull request metadata", runFixture({ pull_requests: [{}] })],
+    ["missing run branch", runFixture({ pull_requests: [], head_branch: undefined })],
+    ["missing run fork", runFixture({ pull_requests: [], head_repository: undefined })],
+    ["missing run base repository", runFixture({ pull_requests: [], repository: undefined })],
+    ["missing captured branch", runFixture({ pull_requests: [] }), { ...emptyMetadataIdentity, headRefName: undefined }],
+    ["missing captured fork", runFixture({ pull_requests: [] }), { ...emptyMetadataIdentity, headRepository: undefined }],
+    ["missing captured base repository", runFixture({ pull_requests: [] }), { ...emptyMetadataIdentity, baseRepository: undefined }],
+  ]) {
+    assert.throws(
+      () => mergeBatch.validateActionRequiredRuns(
+        [run],
+        [workflowFixture()],
+        450,
+        HEAD_SHA,
+        undefined,
+        identity,
+      ),
+      /exact fork identity does not match/,
+      label,
+    );
+  }
 
   for (const [label, run, workflows, pattern] of [
     ["unrelated PR", runFixture({ pull_requests: [{ number: 451 }] }), [workflowFixture()], /does not contain #450/],


### PR DESCRIPTION
## Summary

- allow the guarded merge helper to approve `action_required` fork runs when GitHub returns an empty `pull_requests` array
- require an exact match on event, head SHA, head branch, head repository, base repository, active workflow ID, and allowlisted workflow path
- retain the existing PR tuple checks immediately before and after approval

## Validation

- `node tools/scripts/tests/merge_batch.test.js`
- `npm run lint:workflows`
- `git diff --check`

## Quality Bar Checklist

- [x] Trust boundary reviewed
- [x] Exact fork identity is fail-closed
- [x] Negative mismatch tests added
- [x] Maintainer edits enabled