### PR TITLE
fix: restore protected fork approval flow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -190,7 +190,7 @@ jobs:
         run: npm audit --audit-level=high
 
       - name: Refresh ephemeral derived sources for tests
-        run: npm run plugin-compat:sync && npm run bundles:sync && npm run index
+        run: npm run plugin-compat:sync && npm run index && npm run bundles:sync
 
       - name: Run tests
         run: npm run test

--- a/tools/scripts/merge_batch.cjs
+++ b/tools/scripts/merge_batch.cjs
@@ -959,12 +959,10 @@ function formatCheckSummary(summaries) {
 function listActionRequiredRuns(projectRoot, repoSlug, headSha) {
   const payload = runGhApiJson(projectRoot, [
     `repos/${repoSlug}/actions/runs?head_sha=${headSha}&status=action_required&per_page=100`,
-  ], {
-    paginate: true,
-    slurp: true,
-  });
+  ]);
 
-  const runs = flattenGhSlurpPayload(payload).filter((run) => Number.isInteger(Number(run?.id)));
+  const runs = (Array.isArray(payload?.workflow_runs) ? payload.workflow_runs : [])
+    .filter((run) => Number.isInteger(Number(run?.id)));
   const seen = new Set();
   return runs.filter((run) => {
     const id = Number(run.id);

--- a/tools/scripts/tests/workflow_contracts.test.js
+++ b/tools/scripts/tests/workflow_contracts.test.js
@@ -103,7 +103,7 @@ assert.doesNotMatch(
 assert.match(ciWorkflow, /^permissions:\n  contents: read$/m);
 assert.match(
   ciWorkflow,
-  /source-validation:[\s\S]*?- name: Refresh ephemeral derived sources for tests\n\s+run: npm run plugin-compat:sync && npm run bundles:sync && npm run index\n[\s\S]*?- name: Run tests\n\s+run: npm run test/,
+  /source-validation:[\s\S]*?- name: Refresh ephemeral derived sources for tests\n\s+run: npm run plugin-compat:sync && npm run index && npm run bundles:sync\n[\s\S]*?- name: Run tests\n\s+run: npm run test/,
   "source-only skill PRs must refresh uncommitted mirrors and indexes before tests read them",
 );
 assert.match(ciWorkflow, /name: pr-evidence-/);


### PR DESCRIPTION
## Summary

- parse the GitHub workflow-runs response from its real `workflow_runs` envelope so validated fork approvals are actually discovered
- generate the ephemeral skill index before rendering bundle docs in source validation

## Validation

- merge batch tests
- workflow contract tests
- live read-only probe found four action-required runs for the exact #818 head
- diff check

## Quality Bar Checklist

- [x] Exact workflow-run binding remains fail-closed
- [x] Live API shape verified
- [x] Regression contracts pass
- [x] Maintainer edits enabled