### PR TITLE
feat(web): Redesign catalog experience

### DIFF
--- a/apps/web-app/src/App.tsx
+++ b/apps/web-app/src/App.tsx
@@ -1,5 +1,5 @@
 import { Suspense, lazy } from 'react';
-import { BrowserRouter as Router, Link, Route, Routes } from 'react-router-dom';
+import { BrowserRouter as Router, Link, NavLink, Route, Routes } from 'react-router-dom';
 import { Icon } from './components/ui/Icon';
 
 const Home = lazy(() => import('./pages/Home'));
@@ -15,65 +15,92 @@ function App(): React.ReactElement {
   return (
     <Router basename={import.meta.env.BASE_URL.replace(/\/$/, '') || '/'}>
       <div className="app-shell min-h-screen bg-[var(--surface-canvas)] text-[var(--text-primary)]">
-        <header className="sticky top-0 z-50 border-b border-[var(--stroke-subtle)] bg-[var(--surface-card)]">
-          <div className="mx-auto flex h-16 w-full max-w-screen-2xl items-center justify-between px-4 lg:px-6">
-            <Link to="/" className="group inline-flex items-center gap-3 rounded-[var(--radius-sm)] px-1 py-1">
+        <header className="app-header">
+          <div className="app-header__inner">
+            <Link to="/" className="brand-link" aria-label="Agentic Skills home">
               <img
                 src={logoSrc}
                 alt="Agentic Skills logo"
-                className="h-9 w-auto object-contain transition-transform duration-[var(--motion-fast)] ease-[var(--motion-ease)] group-hover:scale-[1.015]"
+                className="brand-link__logo"
               />
-              <span className="hidden text-sm font-semibold tracking-[0.01em] text-[var(--text-primary)] sm:inline-block">
+              <span className="brand-link__name">
                 Agentic Skills
               </span>
             </Link>
 
-            <nav className="flex items-center gap-2">
-              <Link
+            <nav className="app-nav" aria-label="Primary navigation">
+              <NavLink
+                to="/"
+                end
+                className={({ isActive }) => `app-nav__link ${isActive ? 'is-active' : ''}`}
+              >
+                Explore
+              </NavLink>
+              <NavLink
                 to="/workbench"
-                className="rounded-[var(--radius-sm)] px-3 py-2 text-sm font-semibold text-[var(--text-secondary)] transition-colors hover:text-[var(--text-primary)]"
+                className={({ isActive }) => `app-nav__link ${isActive ? 'is-active' : ''}`}
               >
                 Workbench
-              </Link>
-              <Link
+              </NavLink>
+              <NavLink
                 to="/plugins"
-                className="hidden rounded-[var(--radius-sm)] px-3 py-2 text-sm font-medium text-[var(--text-secondary)] transition-colors hover:text-[var(--text-primary)] sm:inline-flex"
+                className={({ isActive }) => `app-nav__link ${isActive ? 'is-active' : ''}`}
               >
                 Plugins
-              </Link>
+              </NavLink>
+            </nav>
+
+            <div className="app-header__actions">
               <a
                 href="https://github.com/sickn33/agentic-awesome-skills"
                 target="_blank"
                 rel="noreferrer"
-                className="inline-flex items-center gap-2 rounded-[var(--radius-sm)] border border-[var(--stroke-subtle)] bg-[var(--surface-elevated)] px-3 py-2 text-sm font-medium text-[var(--text-secondary)] shadow-[var(--shadow-soft)] transition-all duration-[var(--motion-fast)] ease-[var(--motion-ease)] hover:border-[var(--accent-border)] hover:text-[var(--text-primary)] hover:shadow-[var(--shadow-medium)]"
+                className="github-link"
               >
-                <Icon name="github" size={18} weight="duotone" className="opacity-85" />
-                GitHub Repository
+                <Icon name="github" size={19} weight="fill" />
+                <span>View on GitHub</span>
               </a>
-            </nav>
+
+              <details className="mobile-nav">
+                <summary aria-label="Open navigation">Menu</summary>
+                <nav aria-label="Mobile navigation">
+                  <Link to="/">Explore</Link>
+                  <Link to="/workbench">Workbench</Link>
+                  <Link to="/plugins">Plugins</Link>
+                  <a href="https://github.com/sickn33/agentic-awesome-skills" target="_blank" rel="noreferrer">View on GitHub</a>
+                </nav>
+              </details>
+            </div>
           </div>
         </header>
 
-        <main className="mx-auto w-full max-w-screen-2xl px-4 py-6 md:py-8 lg:px-6">
-          <div className="overflow-hidden rounded-[var(--radius-xl)] border border-[var(--stroke-subtle)] bg-[var(--surface-card)] shadow-[var(--shadow-soft)]">
-            <Suspense
-              fallback={
-                <div className="flex min-h-[40vh] items-center justify-center text-sm text-[var(--text-muted)]">
-                  Loading...
-                </div>
-              }
-            >
-              <Routes>
-                <Route path="/" element={<Home />} />
-                <Route path="/plugins" element={<Plugins />} />
-                <Route path="/workbench" element={<Workbench />} />
-                <Route path="/topics/:slug" element={<TopicLanding />} />
-                <Route path="/skill/:id" element={<SkillDetail />} />
-                <Route path="*" element={<NotFound />} />
-              </Routes>
-            </Suspense>
-          </div>
+        <main className="app-main">
+          <Suspense
+            fallback={
+              <div className="flex min-h-[40vh] items-center justify-center text-sm text-[var(--text-muted)]">
+                Loading...
+              </div>
+            }
+          >
+            <Routes>
+              <Route path="/" element={<Home />} />
+              <Route path="/plugins" element={<Plugins />} />
+              <Route path="/workbench" element={<Workbench />} />
+              <Route path="/topics/:slug" element={<TopicLanding />} />
+              <Route path="/skill/:id" element={<SkillDetail />} />
+              <Route path="*" element={<NotFound />} />
+            </Routes>
+          </Suspense>
         </main>
+
+        <footer className="app-footer">
+          <p>Independent, community-curated project. Review skills before use.</p>
+          <nav aria-label="Footer navigation">
+            <a href="https://github.com/sickn33/agentic-awesome-skills#contributing" target="_blank" rel="noreferrer">Contributing</a>
+            <a href="https://github.com/sickn33/agentic-awesome-skills/blob/main/LICENSE" target="_blank" rel="noreferrer">License</a>
+            <a href="https://github.com/sickn33/agentic-awesome-skills/blob/main/CODE_OF_CONDUCT.md" target="_blank" rel="noreferrer">Code of Conduct</a>
+          </nav>
+        </footer>
       </div>
     </Router>
   );

--- a/apps/web-app/src/components/SkillCard.tsx
+++ b/apps/web-app/src/components/SkillCard.tsx
@@ -11,55 +11,39 @@ interface SkillCardProps {
 
 export const SkillCard = React.memo(({ skill, starCount }: SkillCardProps) => {
   return (
-    <div className="group relative h-full">
+    <article className="skill-row group">
       <Link
         to={`/skill/${skill.id}`}
-        className="relative flex h-full flex-col overflow-hidden rounded-2xl border border-slate-200/90 bg-white p-6 shadow-[0_20px_40px_-34px_rgba(15,23,42,0.85)] transition-all hover:-translate-y-1 hover:border-slate-300 hover:shadow-[0_28px_56px_-34px_rgba(15,23,42,0.7)] dark:border-slate-800 dark:bg-slate-900 dark:hover:border-slate-700"
+        className="skill-row__link"
+        aria-label={`Read skill ${skill.name}`}
       >
-        <div className="pointer-events-none absolute inset-x-0 top-0 h-24 bg-gradient-to-r from-slate-100/70 via-transparent to-teal-100/50 opacity-0 transition-opacity duration-300 group-hover:opacity-100 dark:from-slate-800/60 dark:to-teal-900/20" />
-
-        <div className="relative mb-5 flex items-start gap-3">
-          <div className="flex min-w-0 items-center gap-2.5">
-            <div className="rounded-lg border border-slate-200 bg-slate-100 p-2 text-slate-700 dark:border-slate-700 dark:bg-slate-800 dark:text-slate-300">
-              <Icon name="book" size={20} className="h-5 w-5" />
-            </div>
-            <span className="truncate rounded-full border border-slate-200 bg-slate-100 px-2.5 py-1 text-xs font-medium text-slate-700 dark:border-slate-700 dark:bg-slate-800 dark:text-slate-300">
-              {skill.category || 'Uncategorized'}
-            </span>
+        <div className="skill-row__mark" aria-hidden="true">
+          <Icon name="book" size={22} />
+        </div>
+        <div className="skill-row__content">
+          <div className="skill-row__titleline">
+            <h3>@{skill.name}</h3>
+            <span>{skill.category || 'Uncategorized'}</span>
+          </div>
+          <p>{skill.description}</p>
+          <div className="skill-row__meta">
+            <span>Risk: <strong>{skill.risk || 'unknown'}</strong></span>
+            {skill.date_added && <span>Added {skill.date_added}</span>}
           </div>
         </div>
-
-        <h3 className="mb-2 line-clamp-1 text-lg font-semibold text-slate-900 dark:text-slate-100">
-          @{skill.name}
-        </h3>
-
-        <p className="mb-5 line-clamp-3 flex-grow text-sm leading-relaxed text-slate-600 dark:text-slate-400">
-          {skill.description}
-        </p>
-
-        <div className="mb-4 flex items-center justify-between border-y border-slate-200/80 py-3 text-xs text-slate-500 dark:border-slate-800 dark:text-slate-400">
-          <span>
-            Risk:{' '}
-            <span className="font-semibold text-slate-700 dark:text-slate-200">{skill.risk || 'unknown'}</span>
-          </span>
-          {skill.date_added && (
-            <span className="ml-2 truncate">Added {skill.date_added}</span>
-          )}
-        </div>
-
-        <div className="mt-auto flex items-center text-sm font-medium text-slate-800 transition-transform group-hover:translate-x-1 dark:text-slate-200">
-          Read skill
+        <span className="skill-row__open">
+          Open skill
           <Icon name="arrowRight" size={16} className="ml-1 h-4 w-4" />
-        </div>
+        </span>
       </Link>
-      <div className="absolute right-6 top-6 z-10">
+      <div className="skill-row__save">
         <SkillStarButton
           skillId={skill.id}
           communityCount={starCount}
           variant="default"
         />
       </div>
-    </div>
+    </article>
   );
 });
 

--- a/apps/web-app/src/index.css
+++ b/apps/web-app/src/index.css
@@ -8,26 +8,27 @@
   --font-sans: 'Outfit', 'Avenir Next', 'Segoe UI', 'Helvetica Neue', sans-serif;
   --font-mono: 'JetBrains Mono', 'SFMono-Regular', Menlo, Monaco, Consolas, 'Liberation Mono', monospace;
 
-  --surface-canvas: #f3f5f8;
-  --surface-card: #fcfdff;
-  --surface-elevated: #f8fafc;
-  --stroke-subtle: #d8dee8;
+  --surface-canvas: #fbfcfd;
+  --surface-card: #ffffff;
+  --surface-elevated: #f5f8fa;
+  --stroke-subtle: #d9dee3;
+  --stroke-strong: #aeb7c0;
 
-  --text-primary: #0f172a;
-  --text-secondary: #334155;
-  --text-muted: #546178;
+  --text-primary: #080b0e;
+  --text-secondary: #343b43;
+  --text-muted: #65707b;
 
-  --accent-solid: #0f766e;
-  --accent-border: #0d9488;
-  --accent-soft: #ccfbf1;
-  --accent-ring: #14b8a6;
+  --accent-solid: #079ee8;
+  --accent-border: #00aef0;
+  --accent-soft: #e9f8ff;
+  --accent-ring: #079ee8;
 
-  --radius-sm: 0.6rem;
-  --radius-lg: 1rem;
-  --radius-xl: 1.35rem;
+  --radius-sm: 0.35rem;
+  --radius-lg: 0.55rem;
+  --radius-xl: 0.75rem;
 
-  --shadow-soft: 0 8px 22px rgba(15, 23, 42, 0.08);
-  --shadow-medium: 0 14px 34px rgba(15, 23, 42, 0.12);
+  --shadow-soft: 0 1px 2px rgba(8, 11, 14, 0.04);
+  --shadow-medium: 0 10px 30px rgba(8, 11, 14, 0.1);
 
   --motion-fast: 180ms;
   --motion-base: 260ms;
@@ -40,26 +41,30 @@
 
 @media (prefers-color-scheme: dark) {
   :root {
-    --surface-canvas: #070b12;
-    --surface-card: #0b1220;
-    --surface-elevated: #131c2d;
-    --stroke-subtle: #1f2a3d;
+    --surface-canvas: #0b0d10;
+    --surface-card: #101317;
+    --surface-elevated: #171b20;
+    --stroke-subtle: #30363d;
+    --stroke-strong: #58616c;
 
     --text-primary: #e2e8f0;
     --text-secondary: #c5d0dd;
     --text-muted: #9ba9be;
 
-    --accent-solid: #2dd4bf;
-    --accent-border: #14b8a6;
-    --accent-soft: rgba(20, 184, 166, 0.14);
-    --accent-ring: #2dd4bf;
+    --accent-solid: #38bdf8;
+    --accent-border: #0ea5e9;
+    --accent-soft: rgba(14, 165, 233, 0.14);
+    --accent-ring: #38bdf8;
 
     --shadow-soft: 0 10px 32px rgba(0, 0, 0, 0.45);
     --shadow-medium: 0 16px 46px rgba(0, 0, 0, 0.5);
   }
 }
 
-* {
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
   border-color: var(--stroke-subtle);
 }
 
@@ -92,6 +97,1889 @@ body {
   font-family: var(--font-sans);
   line-height: 1.5;
   overflow-x: hidden;
+}
+
+button,
+input,
+select,
+textarea {
+  font: inherit;
+}
+
+.app-header {
+  position: sticky;
+  top: 0;
+  z-index: 60;
+  border-bottom: 1px solid var(--stroke-subtle);
+  background: color-mix(in oklab, var(--surface-card) 94%, transparent);
+  backdrop-filter: blur(18px);
+}
+
+.app-header__inner {
+  display: grid;
+  grid-template-columns: 1fr auto 1fr;
+  align-items: center;
+  width: min(100%, 1600px);
+  height: 72px;
+  margin: 0 auto;
+  padding: 0 28px;
+}
+
+.brand-link {
+  display: inline-flex;
+  align-items: center;
+  gap: 11px;
+  width: fit-content;
+  color: var(--text-primary);
+  text-decoration: none;
+}
+
+.brand-link__logo {
+  width: 36px;
+  height: 36px;
+  object-fit: contain;
+}
+
+.brand-link__name {
+  font-size: 1.08rem;
+  font-weight: 750;
+  letter-spacing: -0.025em;
+}
+
+.app-nav {
+  display: flex;
+  align-self: stretch;
+  align-items: stretch;
+  gap: 30px;
+}
+
+.app-nav__link {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  color: var(--text-secondary);
+  font-size: 0.92rem;
+  font-weight: 560;
+  text-decoration: none;
+}
+
+.app-nav__link::after {
+  position: absolute;
+  right: 0;
+  bottom: -1px;
+  left: 0;
+  height: 3px;
+  background: var(--accent-solid);
+  content: '';
+  opacity: 0;
+  transform: scaleX(0.45);
+  transition: opacity var(--motion-fast), transform var(--motion-fast);
+}
+
+.app-nav__link:hover,
+.app-nav__link.is-active {
+  color: var(--text-primary);
+}
+
+.app-nav__link.is-active::after {
+  opacity: 1;
+  transform: scaleX(1);
+}
+
+.app-header__actions {
+  display: flex;
+  justify-content: flex-end;
+}
+
+.github-link {
+  display: inline-flex;
+  align-items: center;
+  gap: 9px;
+  min-height: 42px;
+  padding: 0 15px;
+  border: 1px solid var(--stroke-subtle);
+  border-radius: var(--radius-sm);
+  color: var(--text-primary);
+  background: var(--surface-card);
+  font-size: 0.88rem;
+  font-weight: 620;
+  text-decoration: none;
+  transition: border-color var(--motion-fast), background var(--motion-fast);
+}
+
+.github-link:hover {
+  border-color: var(--stroke-strong);
+  background: var(--surface-elevated);
+}
+
+.mobile-nav {
+  display: none;
+  position: relative;
+}
+
+.mobile-nav summary {
+  display: grid;
+  width: 44px;
+  height: 44px;
+  place-items: center;
+  overflow: hidden;
+  border: 1px solid var(--stroke-subtle);
+  border-radius: var(--radius-sm);
+  cursor: pointer;
+  font-size: 0;
+  list-style: none;
+}
+
+.mobile-nav summary::before {
+  color: var(--text-primary);
+  content: '☰';
+  font-size: 1.35rem;
+}
+
+.mobile-nav nav {
+  position: absolute;
+  top: 50px;
+  right: 0;
+  display: grid;
+  min-width: 210px;
+  border: 1px solid var(--stroke-subtle);
+  background: var(--surface-card);
+  box-shadow: var(--shadow-medium);
+}
+
+.mobile-nav nav a {
+  min-height: 48px;
+  padding: 13px 16px;
+  border-bottom: 1px solid var(--stroke-subtle);
+  color: var(--text-primary);
+  text-decoration: none;
+}
+
+.app-main {
+  width: min(100%, 1600px);
+  min-height: calc(100vh - 144px);
+  margin: 0 auto;
+  overflow: hidden;
+}
+
+.app-footer {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 24px;
+  min-height: 72px;
+  padding: 18px 28px;
+  border-top: 1px solid var(--stroke-subtle);
+  color: var(--text-muted);
+  background: var(--surface-card);
+  font-size: 0.78rem;
+}
+
+.app-footer nav {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 24px;
+}
+
+.app-footer a {
+  color: var(--text-secondary);
+  text-decoration: none;
+}
+
+.skill-row {
+  position: relative;
+  min-width: 0;
+  overflow: hidden;
+  border-bottom: 1px solid var(--stroke-subtle);
+  background: var(--surface-card);
+  transition: background var(--motion-fast);
+}
+
+.skill-row:first-child {
+  border-top: 1px solid var(--stroke-subtle);
+}
+
+.skill-row:hover {
+  background: color-mix(in oklab, var(--accent-soft) 38%, var(--surface-card));
+}
+
+.skill-row__link {
+  display: grid;
+  grid-template-columns: 58px minmax(0, 1fr) 112px;
+  align-items: center;
+  gap: 18px;
+  min-height: 142px;
+  padding: 22px 160px 22px 6px;
+  color: inherit;
+  text-decoration: none;
+}
+
+.skill-row__mark {
+  display: grid;
+  width: 54px;
+  height: 54px;
+  place-items: center;
+  border: 1px solid #151a20;
+  border-radius: var(--radius-sm);
+  color: #dff8ff;
+  background: #0c1116;
+}
+
+.skill-row__titleline {
+  display: flex;
+  align-items: baseline;
+  gap: 12px;
+}
+
+.skill-row__titleline h3 {
+  min-width: 0;
+  margin: 0;
+  overflow: hidden;
+  color: var(--text-primary);
+  font-size: 1.05rem;
+  font-weight: 720;
+  letter-spacing: -0.018em;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.skill-row__titleline > span {
+  color: var(--accent-solid);
+  font-size: 0.76rem;
+  font-weight: 620;
+}
+
+.skill-row__content > p {
+  display: -webkit-box;
+  max-width: 60rem;
+  margin: 6px 0 0;
+  overflow: hidden;
+  color: var(--text-secondary);
+  font-size: 0.86rem;
+  line-height: 1.55;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 2;
+}
+
+.skill-row__content {
+  min-width: 0;
+}
+
+.skill-row__meta {
+  display: flex;
+  gap: 20px;
+  margin-top: 10px;
+  color: var(--text-muted);
+  font-family: var(--font-mono);
+  font-size: 0.68rem;
+}
+
+.skill-row__meta strong {
+  color: var(--text-secondary);
+  font-weight: 650;
+}
+
+.skill-row__open {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 42px;
+  border: 1px solid var(--stroke-subtle);
+  border-radius: var(--radius-sm);
+  color: var(--text-primary);
+  background: var(--surface-card);
+  font-size: 0.82rem;
+  font-weight: 650;
+}
+
+.skill-row__save {
+  position: absolute;
+  top: 20px;
+  right: 22px;
+  z-index: 2;
+}
+
+.catalog-layout {
+  display: grid;
+  grid-template-columns: 278px minmax(0, 1fr);
+  align-items: start;
+  min-height: calc(100vh - 72px);
+}
+
+.catalog-rail {
+  position: sticky;
+  top: 72px;
+  height: calc(100vh - 72px);
+  overflow: auto;
+  border-right: 1px solid var(--stroke-subtle);
+  background: var(--surface-card);
+}
+
+.catalog-rail__label {
+  margin: 0;
+  padding: 28px 22px 10px;
+  color: var(--text-muted);
+  font-family: var(--font-mono);
+  font-size: 0.66rem;
+  font-weight: 650;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+}
+
+.catalog-rail nav {
+  padding: 0 14px 22px;
+}
+
+.catalog-rail nav button {
+  position: relative;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  width: 100%;
+  min-height: 43px;
+  padding: 0 12px 0 16px;
+  border: 0;
+  color: var(--text-secondary);
+  background: transparent;
+  cursor: pointer;
+  font-size: 0.84rem;
+  text-align: left;
+}
+
+.catalog-rail nav button::before {
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  left: 0;
+  width: 3px;
+  background: var(--accent-solid);
+  content: '';
+  opacity: 0;
+}
+
+.catalog-rail nav button:hover,
+.catalog-rail nav button.is-active {
+  color: var(--text-primary);
+  background: var(--accent-soft);
+}
+
+.catalog-rail nav button.is-active::before {
+  opacity: 1;
+}
+
+.catalog-rail nav button span:last-child {
+  color: var(--text-muted);
+  font-family: var(--font-mono);
+  font-size: 0.63rem;
+}
+
+.catalog-rail__workbench {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  margin: 0 22px;
+  padding: 16px 0;
+  border-top: 1px solid var(--stroke-subtle);
+  color: var(--text-primary);
+  font-size: 0.8rem;
+  font-weight: 620;
+  text-decoration: none;
+}
+
+.catalog-content {
+  min-width: 0;
+  padding: 0 46px 72px;
+}
+
+.catalog-hero {
+  padding: 60px 0 24px;
+}
+
+.catalog-hero h1 {
+  max-width: 19ch;
+  margin: 0;
+  color: var(--text-primary);
+  font-size: clamp(3rem, 5vw, 5.25rem);
+  font-weight: 780;
+  letter-spacing: -0.065em;
+  line-height: 0.96;
+}
+
+.catalog-hero > p {
+  max-width: 760px;
+  margin: 22px 0 0;
+  color: var(--text-secondary);
+  font-size: clamp(1rem, 1.45vw, 1.25rem);
+  line-height: 1.55;
+}
+
+.catalog-search {
+  display: grid;
+  grid-template-columns: auto 1fr auto;
+  align-items: center;
+  gap: 14px;
+  max-width: 900px;
+  min-height: 70px;
+  margin-top: 32px;
+  padding: 0 18px;
+  border: 1px solid var(--stroke-strong);
+  border-radius: var(--radius-lg);
+  color: var(--text-muted);
+  background: var(--surface-card);
+  transition: border-color var(--motion-fast), box-shadow var(--motion-fast);
+}
+
+.catalog-search:focus-within {
+  border-color: var(--accent-solid);
+  box-shadow: 0 0 0 3px color-mix(in oklab, var(--accent-solid) 18%, transparent);
+}
+
+.catalog-search input {
+  min-width: 0;
+  border: 0;
+  outline: 0;
+  color: var(--text-primary);
+  background: transparent;
+  font-size: 1.02rem;
+}
+
+.catalog-search kbd {
+  padding: 4px 7px;
+  border: 1px solid var(--stroke-subtle);
+  border-radius: 4px;
+  color: var(--text-muted);
+  background: var(--surface-elevated);
+  font-size: 0.7rem;
+}
+
+.catalog-mobile-categories {
+  display: none;
+}
+
+.catalog-toolbar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 24px;
+  margin-top: 22px;
+  padding-bottom: 24px;
+  border-bottom: 1px solid var(--stroke-subtle);
+}
+
+.catalog-toolbar > div {
+  display: flex;
+  gap: 10px;
+}
+
+.catalog-toolbar select {
+  min-width: 170px;
+  height: 44px;
+  padding: 0 36px 0 12px;
+  border: 1px solid var(--stroke-subtle);
+  border-radius: var(--radius-sm);
+  color: var(--text-primary);
+  background: var(--surface-card);
+  font-size: 0.82rem;
+}
+
+.catalog-toolbar > a {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  color: var(--accent-solid);
+  font-size: 0.84rem;
+  font-weight: 650;
+  text-decoration: none;
+}
+
+.catalog-results > header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 24px;
+  padding: 0 0 16px;
+}
+
+.catalog-results h2 {
+  margin: 0;
+  color: var(--text-primary);
+  font-size: 1rem;
+  font-weight: 700;
+}
+
+.catalog-results header p,
+.catalog-note {
+  margin: 5px 0 0;
+  color: var(--text-muted);
+  font-size: 0.72rem;
+}
+
+.catalog-results header button {
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+  min-height: 38px;
+  padding: 0 12px;
+  border: 1px solid var(--stroke-subtle);
+  border-radius: var(--radius-sm);
+  color: var(--text-primary);
+  background: var(--surface-card);
+  cursor: pointer;
+}
+
+.catalog-mode {
+  color: var(--text-muted);
+  font-family: var(--font-mono);
+  font-size: 0.66rem;
+}
+
+.catalog-note {
+  margin: -8px 0 14px;
+}
+
+.catalog-message {
+  padding: 10px 12px;
+  border-left: 3px solid var(--accent-solid);
+  background: var(--accent-soft);
+  font-size: 0.78rem;
+}
+
+.catalog-result-list {
+  border-top: 1px solid var(--stroke-subtle);
+}
+
+.catalog-loading {
+  border-top: 1px solid var(--stroke-subtle);
+}
+
+.catalog-loading div {
+  height: 142px;
+  border-bottom: 1px solid var(--stroke-subtle);
+  background: linear-gradient(100deg, var(--surface-card) 30%, var(--surface-elevated) 50%, var(--surface-card) 70%);
+  background-size: 300% 100%;
+  animation: catalog-shimmer 1.4s infinite linear;
+}
+
+@keyframes catalog-shimmer {
+  to { background-position: -150% 0; }
+}
+
+.catalog-empty {
+  display: grid;
+  min-height: 320px;
+  place-items: center;
+  align-content: center;
+  gap: 10px;
+  border-top: 1px solid var(--stroke-subtle);
+  text-align: center;
+}
+
+.catalog-empty h3,
+.catalog-empty p {
+  margin: 0;
+}
+
+.catalog-empty p {
+  color: var(--text-muted);
+}
+
+.catalog-empty button {
+  min-height: 42px;
+  margin-top: 8px;
+  padding: 0 14px;
+  border: 1px solid var(--text-primary);
+  border-radius: var(--radius-sm);
+  color: var(--surface-card);
+  background: var(--text-primary);
+}
+
+.catalog-support {
+  margin-top: 88px;
+  padding-top: 54px;
+  border-top: 1px solid var(--stroke-subtle);
+}
+
+.catalog-support h2,
+.catalog-support h3,
+.catalog-support p {
+  margin-top: 0;
+}
+
+.catalog-support__intro {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(280px, 0.8fr);
+  gap: 48px;
+  align-items: end;
+}
+
+.catalog-support__intro h2 {
+  max-width: 18ch;
+  margin-bottom: 0;
+  font-size: clamp(2rem, 3vw, 3.25rem);
+  letter-spacing: -0.045em;
+  line-height: 1;
+}
+
+.catalog-support__intro p,
+.catalog-support article p,
+.catalog-faq p {
+  color: var(--text-secondary);
+  font-size: 0.84rem;
+  line-height: 1.6;
+}
+
+.catalog-support__concepts {
+  display: grid;
+  grid-template-columns: repeat(5, 1fr);
+  margin-top: 36px;
+  border-top: 1px solid var(--stroke-subtle);
+  border-bottom: 1px solid var(--stroke-subtle);
+}
+
+.catalog-support__concepts article {
+  min-height: 150px;
+  padding: 22px 18px;
+  border-right: 1px solid var(--stroke-subtle);
+}
+
+.catalog-support__concepts article:last-child {
+  border-right: 0;
+}
+
+.catalog-support__concepts h3 {
+  font-size: 0.9rem;
+}
+
+.catalog-support__columns {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 48px;
+  margin-top: 52px;
+}
+
+.catalog-support__columns nav {
+  display: grid;
+  margin-top: 18px;
+  border-top: 1px solid var(--stroke-subtle);
+}
+
+.catalog-support__columns a {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  min-height: 48px;
+  border-bottom: 1px solid var(--stroke-subtle);
+  color: var(--text-primary);
+  font-size: 0.82rem;
+  text-decoration: none;
+}
+
+.catalog-faq {
+  margin-top: 52px;
+}
+
+.catalog-faq details {
+  border-top: 1px solid var(--stroke-subtle);
+}
+
+.catalog-faq details:last-child {
+  border-bottom: 1px solid var(--stroke-subtle);
+}
+
+.catalog-faq summary {
+  padding: 18px 0;
+  cursor: pointer;
+  color: var(--text-primary);
+  font-weight: 630;
+}
+
+.catalog-faq details p {
+  max-width: 850px;
+  padding-bottom: 18px;
+}
+
+.skill-detail {
+  padding: 0 32px 72px;
+}
+
+.skill-detail__hero {
+  position: relative;
+  margin: 0 -32px;
+  padding: 24px 32px 0;
+  border-bottom: 1px solid var(--stroke-subtle);
+  background: var(--surface-card);
+}
+
+.skill-detail__hero > [class*='pointer-events-none'] {
+  display: none;
+}
+
+.skill-detail__hero > a:first-of-type {
+  margin: 0 0 22px;
+  color: var(--accent-solid);
+}
+
+.skill-detail__summary {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 32px;
+  align-items: end;
+  padding: 0 0 24px;
+  border: 0;
+  background: transparent;
+}
+
+.skill-detail__summary h1 {
+  font-size: clamp(3rem, 5vw, 5.2rem) !important;
+  letter-spacing: -0.065em !important;
+  line-height: 0.95;
+}
+
+.skill-detail__summary [class*='rounded-full'] {
+  border-radius: var(--radius-sm) !important;
+}
+
+.skill-detail__summary > div:last-child button {
+  min-height: 46px;
+  border-radius: var(--radius-sm) !important;
+}
+
+.skill-detail__install-and-context {
+  margin: 0 -32px;
+  padding: 0 32px 22px;
+  border: 0;
+  border-top: 1px solid var(--accent-border);
+  background: color-mix(in oklab, var(--accent-soft) 45%, var(--surface-card));
+}
+
+.skill-detail__install-and-context > div:first-child {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 24px;
+  margin: 0 -32px 22px;
+  padding: 16px 32px;
+  border: 0;
+  border-bottom: 1px solid var(--accent-border);
+  background: transparent;
+}
+
+.skill-detail__install-and-context textarea {
+  min-height: 92px;
+  border-radius: var(--radius-sm) !important;
+}
+
+.skill-detail__related {
+  margin: 32px 0;
+  padding: 24px 0;
+  border: 0;
+  border-top: 1px solid var(--stroke-subtle);
+  border-bottom: 1px solid var(--stroke-subtle);
+  background: transparent;
+}
+
+.skill-detail__related a[class*='rounded-xl'] {
+  border-radius: var(--radius-sm) !important;
+  background: var(--surface-card) !important;
+}
+
+.skill-detail__reading {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) 280px;
+  gap: 56px;
+  max-width: 1320px;
+  margin: 40px auto 0;
+}
+
+.skill-detail__article {
+  min-width: 0;
+  padding-right: 24px;
+}
+
+.skill-detail__article table {
+  border-radius: var(--radius-sm) !important;
+}
+
+.skill-detail__toc {
+  position: sticky;
+  top: 104px;
+  align-self: start;
+  padding-left: 28px;
+  border-left: 1px solid var(--stroke-subtle);
+}
+
+.skill-detail__toc h2 {
+  margin: 0 0 16px;
+  font-size: 0.92rem;
+}
+
+.skill-detail__toc nav {
+  display: grid;
+  gap: 10px;
+}
+
+.skill-detail__toc nav a {
+  position: relative;
+  color: var(--text-secondary);
+  font-size: 0.78rem;
+  text-decoration: none;
+}
+
+.skill-detail__toc nav a:hover {
+  color: var(--accent-solid);
+}
+
+.skill-detail__toc dl {
+  display: grid;
+  gap: 10px;
+  margin: 24px 0 0;
+  padding-top: 18px;
+  border-top: 1px solid var(--stroke-subtle);
+  font-size: 0.7rem;
+}
+
+.skill-detail__toc dl div {
+  display: grid;
+  grid-template-columns: 84px 1fr;
+  gap: 8px;
+}
+
+.skill-detail__toc dt {
+  color: var(--text-muted);
+}
+
+.skill-detail__toc dd {
+  margin: 0;
+  overflow-wrap: anywhere;
+  color: var(--text-primary);
+  font-family: var(--font-mono);
+}
+
+.workbench-page {
+  position: relative;
+  min-height: calc(100vh - 72px);
+  padding: 0 24px 72px;
+  background: var(--surface-canvas);
+}
+
+.workbench-header {
+  position: relative;
+  margin: 0 -24px;
+  padding: 34px 24px 28px;
+  overflow: hidden;
+  border-bottom: 1px solid var(--stroke-subtle);
+  color: var(--text-primary);
+  background: var(--surface-card);
+}
+
+.workbench-header > [class*='absolute'] {
+  display: none;
+}
+
+.workbench-header > div {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 32px;
+  align-items: end;
+}
+
+.workbench-header p:first-child {
+  display: none;
+}
+
+.workbench-header h1 {
+  max-width: 760px;
+  margin: 0;
+  color: var(--text-primary);
+  font-size: clamp(2.2rem, 4vw, 4.1rem) !important;
+  letter-spacing: -0.055em !important;
+  line-height: 0.98;
+}
+
+.workbench-header h1 + p {
+  max-width: 720px;
+  margin-top: 14px !important;
+  color: var(--text-secondary) !important;
+}
+
+.workbench-header dl {
+  border-color: var(--stroke-subtle) !important;
+  background: var(--surface-card) !important;
+}
+
+.workbench-header dl > div {
+  border-color: var(--stroke-subtle) !important;
+}
+
+.workbench-header dd {
+  color: var(--text-primary) !important;
+}
+
+.workbench-header dl > div:last-child dd {
+  color: var(--accent-solid) !important;
+}
+
+.workbench-grid {
+  display: grid;
+  grid-template-columns: 250px minmax(0, 1fr) 360px;
+  align-items: start;
+  gap: 0;
+  margin: 24px 0 0;
+  border-top: 1px solid var(--stroke-subtle);
+}
+
+.workbench-filters,
+.workbench-selection {
+  position: sticky;
+  top: 96px;
+  max-height: calc(100vh - 118px);
+  overflow: auto;
+}
+
+.workbench-filters {
+  padding: 18px 20px 28px 0;
+  border-right: 1px solid var(--stroke-subtle);
+  color: var(--text-primary);
+  background: transparent;
+}
+
+.workbench-filters input,
+.workbench-filters select {
+  border-radius: var(--radius-sm);
+}
+
+.workbench-results {
+  min-width: 0;
+  padding: 18px 22px 32px;
+}
+
+.workbench-result-list {
+  display: grid;
+  gap: 12px;
+}
+
+.workbench-card {
+  min-height: 210px;
+  border-radius: var(--radius-sm);
+  box-shadow: none;
+}
+
+.workbench-selection {
+  grid-column: 3;
+  grid-row: 1;
+  color: #f8fafc;
+  background: #0c1116;
+}
+
+.workbench-results {
+  grid-column: 2;
+  grid-row: 1;
+}
+
+.workbench-mobile-selection {
+  display: none;
+}
+
+.plugins-page {
+  padding: 0 48px 72px;
+}
+
+.plugins-hero {
+  padding: 54px 0 30px;
+  border-bottom: 1px solid var(--stroke-subtle);
+}
+
+.plugins-hero h1 {
+  max-width: 20ch;
+  margin: 0;
+  color: var(--text-primary);
+  font-size: clamp(3rem, 5vw, 5rem);
+  font-weight: 780;
+  letter-spacing: -0.062em;
+  line-height: 0.97;
+}
+
+.plugins-hero > p {
+  max-width: 760px;
+  margin: 20px 0 0;
+  color: var(--text-secondary);
+  font-size: 1.08rem;
+  line-height: 1.55;
+}
+
+.plugins-hero > div {
+  display: flex;
+  align-items: center;
+  gap: 24px;
+  margin-top: 28px;
+}
+
+.plugins-hero a {
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+  color: var(--accent-solid);
+  font-size: 0.84rem;
+  font-weight: 650;
+  text-decoration: none;
+}
+
+.plugins-hero a:first-child {
+  min-height: 46px;
+  padding: 0 16px;
+  border-radius: var(--radius-sm);
+  color: white;
+  background: #087cf0;
+}
+
+.plugins-hero a:last-child {
+  margin-left: auto;
+  color: var(--text-muted);
+  font-size: 0.72rem;
+}
+
+.plugin-decisions {
+  padding: 22px 0;
+  border-bottom: 1px solid var(--stroke-subtle);
+}
+
+.plugin-decisions > h2 {
+  margin: 0 0 16px;
+  font-family: var(--font-mono);
+  font-size: 0.66rem;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+
+.plugin-decisions > div {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+}
+
+.plugin-decisions article {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 14px;
+  min-height: 98px;
+  padding: 12px 28px;
+  border-right: 1px solid var(--stroke-subtle);
+}
+
+.plugin-decisions article:first-child {
+  padding-left: 0;
+}
+
+.plugin-decisions article:last-child {
+  border-right: 0;
+}
+
+.plugin-decisions h3,
+.plugin-decisions p {
+  margin: 0;
+}
+
+.plugin-decisions h3 {
+  font-size: 0.88rem;
+}
+
+.plugin-decisions p {
+  margin-top: 8px;
+  color: var(--text-secondary);
+  font-size: 0.8rem;
+  line-height: 1.5;
+}
+
+.plugin-catalog {
+  padding-top: 28px;
+}
+
+.plugin-catalog > header {
+  display: flex;
+  align-items: end;
+  justify-content: space-between;
+  gap: 24px;
+  margin-bottom: 28px;
+}
+
+.plugin-catalog > header h2,
+.plugin-catalog > header p {
+  margin: 0;
+}
+
+.plugin-catalog > header h2 {
+  font-size: 1.35rem;
+}
+
+.plugin-catalog > header p {
+  margin-top: 4px;
+  color: var(--text-muted);
+  font-family: var(--font-mono);
+  font-size: 0.68rem;
+}
+
+.plugin-catalog > header label {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  align-items: center;
+  gap: 8px;
+  width: min(100%, 360px);
+  min-height: 44px;
+  padding: 0 12px;
+  border: 1px solid var(--stroke-subtle);
+  border-radius: var(--radius-sm);
+  color: var(--text-muted);
+  background: var(--surface-card);
+}
+
+.plugin-catalog > header input {
+  min-width: 0;
+  border: 0;
+  outline: 0;
+  background: transparent;
+}
+
+.plugin-tier {
+  margin-top: 28px;
+}
+
+.plugin-tier > h2 {
+  margin: 0 0 10px;
+  font-size: 1rem;
+}
+
+.plugin-table {
+  border-top: 1px solid var(--stroke-strong);
+}
+
+.plugin-table__head,
+.plugin-row {
+  display: grid;
+  grid-template-columns: 1.25fr 1fr 1.35fr 1.35fr 0.8fr;
+  gap: 18px;
+  align-items: center;
+}
+
+.plugin-table__head {
+  min-height: 38px;
+  border-bottom: 1px solid var(--stroke-subtle);
+  color: var(--text-muted);
+  font-family: var(--font-mono);
+  font-size: 0.6rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.plugin-row {
+  min-height: 118px;
+  padding: 14px 0;
+  border-bottom: 1px solid var(--stroke-subtle);
+  transition: background var(--motion-fast);
+}
+
+.plugin-row:hover {
+  background: color-mix(in oklab, var(--accent-soft) 28%, transparent);
+}
+
+.plugin-row p {
+  margin: 0;
+  color: var(--text-secondary);
+  font-size: 0.76rem;
+  line-height: 1.5;
+}
+
+.plugin-row__name {
+  display: grid;
+  grid-template-columns: 42px minmax(0, 1fr);
+  gap: 12px;
+  align-items: center;
+}
+
+.plugin-row__name > span {
+  display: grid;
+  width: 40px;
+  height: 40px;
+  place-items: center;
+  border: 1px solid var(--stroke-subtle);
+  border-radius: var(--radius-sm);
+}
+
+.plugin-row h3 {
+  margin: 0;
+  font-size: 0.84rem;
+}
+
+.plugin-row code {
+  display: block;
+  margin-top: 4px;
+  overflow: hidden;
+  color: var(--accent-solid);
+  font-size: 0.62rem;
+  text-overflow: ellipsis;
+}
+
+.plugin-row__skills,
+.plugin-row__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px 10px;
+  font-size: 0.68rem;
+}
+
+.plugin-row__skills a,
+.plugin-row__actions a {
+  color: var(--accent-solid);
+  text-decoration: none;
+}
+
+.plugin-row__skills span {
+  color: var(--text-muted);
+}
+
+.plugin-empty {
+  padding: 42px 0;
+  border-bottom: 1px solid var(--stroke-subtle);
+  color: var(--text-muted);
+}
+
+.topic-page {
+  padding: 0 48px 72px;
+}
+
+.topic-hero {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) 320px;
+  gap: 64px;
+  align-items: end;
+  padding: 54px 0 40px;
+  border-bottom: 1px solid var(--stroke-subtle);
+}
+
+.topic-hero h1 {
+  font-size: clamp(3rem, 5vw, 5.2rem) !important;
+  letter-spacing: -0.058em !important;
+  line-height: 0.98 !important;
+}
+
+.topic-hero > div > p:first-child {
+  color: var(--accent-solid) !important;
+  font-family: var(--font-mono);
+}
+
+.topic-hero a {
+  border-radius: var(--radius-sm) !important;
+}
+
+.topic-intent {
+  padding: 20px 0 4px 26px;
+  border: 0;
+  border-left: 1px solid var(--stroke-subtle);
+  background: transparent;
+}
+
+.topic-intent span {
+  border-radius: var(--radius-sm) !important;
+}
+
+.topic-sections {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  margin-top: 42px;
+  border-top: 1px solid var(--stroke-subtle);
+  border-bottom: 1px solid var(--stroke-subtle);
+}
+
+.topic-sections article {
+  min-height: 210px;
+  padding: 26px 22px;
+  border: 0;
+  border-right: 1px solid var(--stroke-subtle);
+  border-radius: 0 !important;
+  background: transparent !important;
+}
+
+.topic-sections article:last-child {
+  border-right: 0;
+}
+
+.topic-continue {
+  margin-top: 42px;
+  padding: 26px 0;
+  border: 0;
+  border-top: 1px solid var(--stroke-subtle);
+  border-bottom: 1px solid var(--stroke-subtle);
+  background: transparent;
+}
+
+.topic-continue a {
+  border-radius: var(--radius-sm) !important;
+}
+
+.topic-missing,
+.not-found-page {
+  display: flex;
+  min-height: calc(100vh - 216px);
+  max-width: 760px;
+  margin: 0 auto;
+  padding: 56px 24px;
+  align-items: flex-start;
+  justify-content: center;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.topic-missing {
+  align-items: center;
+  text-align: center;
+}
+
+.not-found-page p,
+.not-found-page h1 {
+  margin: 0;
+}
+
+.not-found-page h1 {
+  font-size: clamp(3rem, 7vw, 6rem);
+  letter-spacing: -0.06em;
+}
+
+.not-found-page a {
+  min-height: 46px;
+  padding: 12px 16px;
+  border-radius: var(--radius-sm) !important;
+}
+
+@media (max-width: 760px) {
+  html,
+  body,
+  #root,
+  .app-shell,
+  .app-main {
+    width: 100%;
+    max-width: 100%;
+  }
+
+  .app-main > * {
+    width: 100%;
+    max-width: 100%;
+  }
+
+  .app-header__inner {
+    grid-template-columns: 1fr auto;
+    height: 64px;
+    padding: 0 16px;
+  }
+
+  .brand-link__logo {
+    width: 30px;
+    height: 30px;
+  }
+
+  .brand-link__name {
+    font-size: 1rem;
+  }
+
+  .app-nav,
+  .github-link {
+    display: none;
+  }
+
+  .mobile-nav {
+    display: block;
+  }
+
+  .app-footer {
+    align-items: flex-start;
+    flex-direction: column;
+    padding: 22px 18px;
+  }
+
+  .skill-row__link {
+    grid-template-columns: 48px minmax(0, 1fr);
+    gap: 13px;
+    min-height: 168px;
+    width: 100%;
+    padding: 18px 54px 48px 0;
+  }
+
+  .skill-row__mark {
+    width: 46px;
+    height: 46px;
+  }
+
+  .skill-row__titleline {
+    align-items: flex-start;
+    flex-direction: column;
+    gap: 2px;
+  }
+
+  .skill-row__titleline h3 {
+    max-width: 100%;
+    font-size: 0.98rem;
+    white-space: normal;
+  }
+
+  .skill-row__meta {
+    gap: 10px;
+    flex-wrap: wrap;
+  }
+
+  .skill-row__open {
+    position: absolute;
+    right: 10px;
+    bottom: 11px;
+    min-height: 36px;
+    padding: 0 10px;
+  }
+
+  .skill-row__save {
+    top: 14px;
+    right: 10px;
+  }
+
+  .skill-row__save > div > span {
+    display: none;
+  }
+
+  .skill-row__save button {
+    justify-content: center;
+    width: 38px;
+    min-width: 38px;
+    height: 38px;
+    padding: 0 !important;
+  }
+
+  .skill-row__save button span {
+    display: none;
+  }
+
+  .catalog-layout {
+    display: block;
+    min-height: auto;
+  }
+
+  .catalog-rail {
+    display: none;
+  }
+
+  .catalog-content {
+    width: 100%;
+    max-width: 100%;
+    padding: 0 16px 48px;
+    box-sizing: border-box;
+  }
+
+  .catalog-hero {
+    padding: 28px 0 16px;
+  }
+
+  .catalog-hero h1 {
+    max-width: 100%;
+    font-size: clamp(2rem, 10vw, 2.65rem);
+    letter-spacing: -0.055em;
+    overflow-wrap: anywhere;
+  }
+
+  .catalog-hero > p {
+    max-width: 100%;
+    margin-top: 16px;
+    font-size: 0.95rem;
+    overflow-wrap: anywhere;
+  }
+
+  .catalog-search {
+    min-height: 58px;
+    margin-top: 24px;
+    padding: 0 13px;
+  }
+
+  .catalog-search kbd {
+    display: none;
+  }
+
+  .catalog-mobile-categories {
+    display: flex;
+    gap: 8px;
+    margin: 16px -16px 0;
+    padding: 0 16px 8px;
+    overflow-x: auto;
+  }
+
+  .catalog-mobile-categories button {
+    flex: 0 0 auto;
+    min-height: 40px;
+    padding: 0 12px;
+    border: 1px solid var(--stroke-subtle);
+    border-radius: var(--radius-sm);
+    color: var(--text-secondary);
+    background: var(--surface-card);
+  }
+
+  .catalog-mobile-categories button.is-active {
+    border-color: var(--accent-solid);
+    color: var(--accent-solid);
+  }
+
+  .catalog-toolbar {
+    align-items: stretch;
+    flex-direction: column;
+    gap: 14px;
+    margin-top: 12px;
+  }
+
+  .catalog-toolbar > div {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
+    width: 100%;
+  }
+
+  .catalog-toolbar select {
+    width: 100%;
+    min-width: 0;
+  }
+
+  .catalog-toolbar > a {
+    min-height: 44px;
+    justify-content: space-between;
+  }
+
+  .catalog-results > header {
+    align-items: center;
+  }
+
+  .catalog-results header p,
+  .catalog-note,
+  .catalog-mode {
+    display: none;
+  }
+
+  .catalog-support {
+    margin-top: 56px;
+    padding-top: 36px;
+  }
+
+  .catalog-support__intro,
+  .catalog-support__columns {
+    grid-template-columns: 1fr;
+    gap: 24px;
+  }
+
+  .catalog-support__intro h2 {
+    font-size: 2rem;
+  }
+
+  .catalog-support__concepts {
+    grid-template-columns: 1fr;
+  }
+
+  .catalog-support__concepts article {
+    min-height: auto;
+    border-right: 0;
+    border-bottom: 1px solid var(--stroke-subtle);
+  }
+
+  .skill-detail {
+    width: 100%;
+    max-width: 100%;
+    padding: 0 16px 48px;
+    box-sizing: border-box;
+  }
+
+  .skill-detail__hero {
+    margin: 0 -16px;
+    padding: 20px 16px 0;
+  }
+
+  .skill-detail__summary {
+    grid-template-columns: 1fr;
+    gap: 20px;
+    min-width: 0;
+  }
+
+  .skill-detail__summary h1 {
+    font-size: 2.8rem !important;
+  }
+
+  .skill-detail__summary > div:first-child > div:nth-child(2) {
+    flex-wrap: wrap;
+  }
+
+  .skill-detail__summary p {
+    overflow-wrap: anywhere;
+  }
+
+  .skill-detail__summary > div:last-child {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
+    width: 100%;
+  }
+
+  .skill-detail__summary > div:last-child button {
+    width: 100%;
+    min-width: 0 !important;
+    padding-right: 8px !important;
+    padding-left: 8px !important;
+    font-size: 0.72rem;
+    white-space: normal;
+  }
+
+  .skill-detail__install-and-context {
+    margin: 0 -16px;
+    padding: 0 16px 18px;
+  }
+
+  .skill-detail__install-and-context > div:first-child {
+    grid-template-columns: 1fr;
+    margin: 0 -16px 18px;
+    padding: 15px 16px;
+  }
+
+  .skill-detail__related {
+    margin: 24px 0;
+  }
+
+  .skill-detail__reading {
+    display: flex;
+    flex-direction: column-reverse;
+    gap: 24px;
+    margin-top: 24px;
+  }
+
+  .skill-detail__article {
+    padding-right: 0;
+  }
+
+  .skill-detail__toc {
+    position: static;
+    padding: 14px 16px;
+    border: 1px solid var(--stroke-subtle);
+    border-radius: var(--radius-sm);
+  }
+
+  .skill-detail__toc nav {
+    grid-template-columns: 1fr 1fr;
+  }
+
+  .skill-detail__toc dl {
+    display: none;
+  }
+
+  .workbench-page {
+    width: 100%;
+    max-width: 100%;
+    padding: 0 14px 92px;
+    box-sizing: border-box;
+    overflow: hidden;
+  }
+
+  .workbench-header {
+    margin: 0 -14px;
+    padding: 26px 14px 20px;
+  }
+
+  .workbench-header > div {
+    grid-template-columns: 1fr;
+    gap: 18px;
+  }
+
+  .workbench-header h1 {
+    max-width: 100%;
+    font-size: 1.78rem !important;
+    overflow-wrap: anywhere;
+  }
+
+  .workbench-header h1 + p {
+    font-size: 0.82rem !important;
+  }
+
+  .workbench-header dl {
+    width: 100%;
+    min-width: 0;
+  }
+
+  .workbench-header dl > div {
+    min-width: 0;
+    padding-right: 10px !important;
+    padding-left: 10px !important;
+  }
+
+  .workbench-grid {
+    display: flex;
+    width: 100%;
+    max-width: 100%;
+    flex-direction: column;
+    margin-top: 16px;
+  }
+
+  .workbench-filters,
+  .workbench-selection {
+    position: static;
+    width: 100%;
+    max-height: none;
+  }
+
+  .workbench-filters {
+    display: grid;
+    padding: 14px 0 18px;
+    border-right: 0;
+    border-bottom: 1px solid var(--stroke-subtle);
+  }
+
+  .workbench-filters > div:last-child {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr);
+    gap: 12px;
+  }
+
+  .workbench-filters label {
+    min-width: 0;
+  }
+
+  .workbench-filters input,
+  .workbench-filters select {
+    width: 100%;
+    min-width: 0;
+  }
+
+  .workbench-filters label:first-child {
+    grid-column: 1 / -1;
+  }
+
+  .workbench-results {
+    grid-column: auto;
+    grid-row: auto;
+    order: 2;
+    width: 100%;
+    padding: 18px 0;
+  }
+
+  .workbench-selection {
+    grid-column: auto;
+    grid-row: auto;
+    order: 3;
+    margin-top: 18px;
+  }
+
+  .workbench-mobile-selection {
+    position: fixed;
+    right: 0;
+    bottom: 0;
+    left: 0;
+    z-index: 50;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    min-height: 72px;
+    padding: 12px 16px;
+    color: white;
+    background: #087cf0;
+    text-decoration: none;
+  }
+
+  .workbench-mobile-selection strong {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    min-height: 44px;
+    padding: 0 13px;
+    border-radius: var(--radius-sm);
+    color: #0866d8;
+    background: white;
+    font-size: 0.78rem;
+  }
+
+  .plugins-page {
+    padding: 0 16px 48px;
+  }
+
+  .plugins-hero {
+    padding: 30px 0 24px;
+  }
+
+  .plugins-hero h1 {
+    font-size: 2.5rem;
+  }
+
+  .plugins-hero > p {
+    font-size: 0.92rem;
+  }
+
+  .plugins-hero > div {
+    align-items: flex-start;
+    flex-direction: column;
+    gap: 14px;
+  }
+
+  .plugins-hero a:last-child {
+    margin-left: 0;
+  }
+
+  .plugin-decisions > div {
+    grid-template-columns: 1fr;
+  }
+
+  .plugin-decisions article,
+  .plugin-decisions article:first-child {
+    min-height: auto;
+    padding: 16px 0;
+    border-right: 0;
+    border-bottom: 1px solid var(--stroke-subtle);
+  }
+
+  .plugin-catalog > header {
+    align-items: stretch;
+    flex-direction: column;
+  }
+
+  .plugin-catalog > header label {
+    width: 100%;
+  }
+
+  .plugin-table__head {
+    display: none;
+  }
+
+  .plugin-row {
+    grid-template-columns: 1fr;
+    gap: 12px;
+    min-height: auto;
+    padding: 18px 0;
+  }
+
+  .plugin-row__actions {
+    padding-top: 10px;
+    border-top: 1px solid var(--stroke-subtle);
+  }
+
+  .topic-page {
+    padding: 0 16px 48px;
+  }
+
+  .topic-hero {
+    grid-template-columns: 1fr;
+    gap: 24px;
+    padding: 30px 0 26px;
+  }
+
+  .topic-hero h1 {
+    font-size: 2.7rem !important;
+  }
+
+  .topic-intent {
+    padding: 18px 0 0;
+    border-top: 1px solid var(--stroke-subtle);
+    border-left: 0;
+  }
+
+  .topic-sections {
+    grid-template-columns: 1fr;
+    margin-top: 28px;
+  }
+
+  .topic-sections article {
+    min-height: auto;
+    border-right: 0;
+    border-bottom: 1px solid var(--stroke-subtle);
+  }
 }
 
 code,

--- a/apps/web-app/src/pages/Home.tsx
+++ b/apps/web-app/src/pages/Home.tsx
@@ -1,69 +1,38 @@
-import { useState, useEffect, useMemo } from 'react';
+import { useEffect, useMemo, useState } from 'react';
+import { Link } from 'react-router-dom';
 import { VirtuosoGrid } from 'react-virtuoso';
-import { useSkills } from '../context/SkillContext';
 import { SkillCard } from '../components/SkillCard';
 import { Icon } from '../components/ui/Icon';
-import type { SyncMessage, CategoryStats } from '../types';
-import { usePageMeta } from '../hooks/usePageMeta';
-import { buildHomeMeta, getHomeFaqItems } from '../utils/seo';
-import { Link } from 'react-router-dom';
+import { useSkills } from '../context/SkillContext';
 import { seoLandingPages } from '../data/seoLandingPages';
+import { usePageMeta } from '../hooks/usePageMeta';
+import type { CategoryStats, SyncMessage } from '../types';
+import { buildHomeMeta, getHomeFaqItems } from '../utils/seo';
 
 const conceptCards = [
-  {
-    title: 'Specialized plugins',
-    body: 'Focused installable distributions for domains like web apps, security, documents, data, DevOps, QA, OSS, mobile, automation, and agent/MCP work.',
-  },
-  {
-    title: 'Skills',
-    body: 'Reusable SKILL.md playbooks that teach an AI assistant how to execute a workflow with better structure and context.',
-  },
-  {
-    title: 'MCP tools',
-    body: 'External capabilities and system integrations the assistant can call. Tools provide actions; skills tell the assistant how to use them well.',
-  },
-  {
-    title: 'Bundles',
-    body: 'Curated starting sets of recommended skills for a role, domain, or team that wants a smaller shortlist first.',
-  },
-  {
-    title: 'Workflows',
-    body: 'Ordered execution playbooks that show how to combine multiple skills step by step for a concrete outcome.',
-  },
+  { title: 'Specialized plugins', body: 'Focused distributions for a domain or job.' },
+  { title: 'Skills', body: 'Reusable SKILL.md playbooks for repeatable execution.' },
+  { title: 'MCP tools', body: 'External capabilities the assistant can call.' },
+  { title: 'Bundles', body: 'Curated starting sets for a role or team.' },
+  { title: 'Workflows', body: 'Ordered playbooks for a concrete outcome.' },
 ] as const;
 
 const integrationGuides = [
-  {
-    name: 'Claude Code',
-    href: 'https://github.com/sickn33/agentic-awesome-skills/blob/main/docs/users/claude-code-skills.md',
-    body: 'Install paths, starter prompts, plugin marketplace flow, and first skills to try.',
-  },
-  {
-    name: 'Cursor',
-    href: 'https://github.com/sickn33/agentic-awesome-skills/blob/main/docs/users/cursor-skills.md',
-    body: 'A practical guide for chat-first UI, frontend, and full-stack workflows in Cursor.',
-  },
-  {
-    name: 'Codex CLI',
-    href: 'https://github.com/sickn33/agentic-awesome-skills/blob/main/docs/users/codex-cli-skills.md',
-    body: 'How to use Agentic Awesome Skills with Codex CLI for planning, implementation, testing, and review.',
-  },
-  {
-    name: 'Gemini CLI',
-    href: 'https://github.com/sickn33/agentic-awesome-skills/blob/main/docs/users/gemini-cli-skills.md',
-    body: 'A broad starting point for engineering, agent systems, integrations, and applied AI workflows.',
-  },
-  {
-    name: 'Antigravity',
-    href: 'https://github.com/sickn33/agentic-awesome-skills#choose-your-tool',
-    body: 'Installer targets for Antigravity IDE and Antigravity CLI, with reduced activation paths when the full library is too broad.',
-  },
+  { name: 'Claude Code', href: 'https://github.com/sickn33/agentic-awesome-skills/blob/main/docs/users/claude-code-skills.md' },
+  { name: 'Cursor', href: 'https://github.com/sickn33/agentic-awesome-skills/blob/main/docs/users/cursor-skills.md' },
+  { name: 'Codex CLI', href: 'https://github.com/sickn33/agentic-awesome-skills/blob/main/docs/users/codex-cli-skills.md' },
+  { name: 'Gemini CLI', href: 'https://github.com/sickn33/agentic-awesome-skills/blob/main/docs/users/gemini-cli-skills.md' },
+  { name: 'Antigravity', href: 'https://github.com/sickn33/agentic-awesome-skills#choose-your-tool' },
 ] as const;
 
 const syncFeatureEnabled = (
-  (import.meta as ImportMeta & { env: Record<string, string | undefined> }).env.VITE_ENABLE_SKILLS_SYNC
-  === 'true'
+  (import.meta as ImportMeta & { env: Record<string, string | undefined> }).env.VITE_ENABLE_SKILLS_SYNC === 'true'
 );
+
+function labelCategory(category: string): string {
+  if (category === 'all') return 'All categories';
+  return category.replace(/-/g, ' ').replace(/\b\w/g, (letter) => letter.toUpperCase());
+}
 
 export function Home(): React.ReactElement {
   const { skills, stars, loading, error, refreshSkills } = useSkills();
@@ -73,80 +42,55 @@ export function Home(): React.ReactElement {
   const [sortBy, setSortBy] = useState('default');
   const [syncing, setSyncing] = useState(false);
   const [syncMsg, setSyncMsg] = useState<SyncMessage | null>(null);
-  const repositoryLink = 'https://github.com/sickn33/agentic-awesome-skills';
-  const docsLink = 'https://github.com/sickn33/agentic-awesome-skills/blob/main/docs/users/usage.md';
-  const installLink = 'https://www.npmjs.com/package/agentic-awesome-skills';
-  const faqItems = getHomeFaqItems(skills.length);
-  const catalogCountLabel = skills.length > 0 ? skills.length.toLocaleString('en-US') : 'installable';
 
   usePageMeta(buildHomeMeta(skills.length));
 
-  useEffect(() => {
-    const timeoutId = window.setTimeout(() => {
-      setDebouncedSearch(search);
-    }, 300);
+  const faqItems = getHomeFaqItems(skills.length);
+  const catalogCountLabel = skills.length > 0 ? skills.length.toLocaleString('en-US') : '1,900+';
 
-    return () => {
-      window.clearTimeout(timeoutId);
-    };
+  useEffect(() => {
+    const timeoutId = window.setTimeout(() => setDebouncedSearch(search), 300);
+    return () => window.clearTimeout(timeoutId);
   }, [search]);
 
   const filteredSkills = useMemo(() => {
     let result = [...skills];
-
     if (debouncedSearch) {
-      const lowerSearch = debouncedSearch.toLowerCase();
-      result = result.filter(skill =>
-        skill.name.toLowerCase().includes(lowerSearch) ||
-        skill.description.toLowerCase().includes(lowerSearch)
-      );
+      const query = debouncedSearch.toLowerCase();
+      result = result.filter((skill) => (
+        skill.name.toLowerCase().includes(query)
+        || skill.description.toLowerCase().includes(query)
+        || skill.tags?.some((tag) => tag.toLowerCase().includes(query))
+      ));
     }
-
-    if (categoryFilter !== 'all') {
-      result = result.filter(skill => skill.category === categoryFilter);
-    }
-
-    // Apply sorting
-    if (sortBy === 'stars') {
-      result = [...result].sort((a, b) => (stars[b.id] || 0) - (stars[a.id] || 0));
-    } else if (sortBy === 'newest') {
-      result = [...result].sort((a, b) => (b.date_added || '').localeCompare(a.date_added || ''));
-    } else if (sortBy === 'az') {
-      result = [...result].sort((a, b) => a.name.localeCompare(b.name));
-    }
-
+    if (categoryFilter !== 'all') result = result.filter((skill) => skill.category === categoryFilter);
+    if (sortBy === 'stars') result.sort((a, b) => (stars[b.id] || 0) - (stars[a.id] || 0));
+    if (sortBy === 'newest') result.sort((a, b) => (b.date_added || '').localeCompare(a.date_added || ''));
+    if (sortBy === 'az') result.sort((a, b) => a.name.localeCompare(b.name));
     return result;
-  }, [debouncedSearch, categoryFilter, sortBy, skills, stars]);
+  }, [categoryFilter, debouncedSearch, skills, sortBy, stars]);
 
-  // Sort categories by count (most skills first), with 'uncategorized' at the end
   const { categories, categoryStats } = useMemo(() => {
     const stats: CategoryStats = {};
-    skills.forEach(skill => {
-      stats[skill.category] = (stats[skill.category] || 0) + 1;
-    });
-
-    const cats = ['all', ...Object.keys(stats)
-      .filter(cat => cat !== 'uncategorized')
-      .sort((a, b) => stats[b] - stats[a]),
-      ...(stats['uncategorized'] ? ['uncategorized'] : [])
-    ];
-
-    return { categories: cats, categoryStats: stats };
+    skills.forEach((skill) => { stats[skill.category] = (stats[skill.category] || 0) + 1; });
+    const ordered = Object.keys(stats)
+      .filter((category) => category !== 'uncategorized')
+      .sort((a, b) => stats[b] - stats[a]);
+    if (stats.uncategorized) ordered.push('uncategorized');
+    return { categories: ['all', ...ordered], categoryStats: stats };
   }, [skills]);
 
   const handleSync = async () => {
     setSyncing(true);
     setSyncMsg(null);
     try {
-      const res = await fetch('/api/refresh-skills', { method: 'POST' });
-      const data = await res.json();
+      const response = await fetch('/api/refresh-skills', { method: 'POST' });
+      const data = await response.json();
       if (data.success) {
-        if (data.upToDate) {
-          setSyncMsg({ type: 'info', text: 'Skills are already up to date.' });
-        } else {
-          setSyncMsg({ type: 'success', text: `Synced ${data.count} skills. Rollback ref: ${data.rollbackRef}` });
-          await refreshSkills();
-        }
+        setSyncMsg(data.upToDate
+          ? { type: 'info', text: 'Skills are already up to date.' }
+          : { type: 'success', text: `Synced ${data.count} skills.` });
+        if (!data.upToDate) await refreshSkills();
       } else {
         setSyncMsg({ type: 'error', text: String(data.error) });
       }
@@ -154,349 +98,167 @@ export function Home(): React.ReactElement {
       setSyncMsg({ type: 'error', text: 'Network error' });
     } finally {
       setSyncing(false);
-      setTimeout(() => setSyncMsg(null), 5000);
+      window.setTimeout(() => setSyncMsg(null), 5000);
     }
   };
 
   return (
-    <div className="relative flex min-h-[calc(100vh-8rem)] flex-col">
-      <div className="pointer-events-none absolute inset-x-0 top-0 -z-10 h-[28rem] bg-[radial-gradient(circle_at_20%_12%,rgba(15,23,42,0.12),transparent_48%),radial-gradient(circle_at_84%_8%,rgba(99,102,241,0.16),transparent_54%)] dark:bg-[radial-gradient(circle_at_20%_12%,rgba(148,163,184,0.15),transparent_45%),radial-gradient(circle_at_84%_8%,rgba(129,140,248,0.2),transparent_52%)]" />
-
-      <div className="mb-9 space-y-8">
-        <section className="rounded-2xl border border-slate-200/80 bg-white p-6 shadow-[0_20px_55px_-32px_rgba(15,23,42,0.55)] sm:p-8 dark:border-slate-800/80 dark:bg-slate-900">
-          <p className="mb-3 text-xs font-semibold uppercase tracking-[0.22em] text-slate-500 dark:text-slate-400">
-            Skills Library
-          </p>
-          <h1 className="max-w-[20ch] text-2xl font-bold tracking-tight text-slate-900 [text-wrap:balance] sm:text-[3.25rem] sm:leading-[0.97] dark:text-slate-100">
-            Build agent workflows with production-grade skill playbooks
-          </h1>
-          <p className="mt-4 max-w-4xl text-sm leading-relaxed text-slate-600 sm:text-base dark:text-slate-300">
-            Agentic Awesome Skills is the searchable catalog for an independent GitHub repository of installable
-            AI agent skills, Antigravity CLI playbooks, specialized plugins, bundles, and workflows. Search fast,
-            shortlist by category, and launch your first tested workflow from one focused workspace.
-          </p>
-          <p className="mt-3 max-w-4xl text-xs leading-relaxed text-slate-500 sm:text-sm dark:text-slate-400">
-            Independent community project. Not affiliated with, sponsored by, endorsed by, or authorized by Google.
-            Google, Antigravity, Gemini, and related product names are used only to describe compatibility.
-          </p>
-
-          <div className="mt-6 flex flex-col gap-3 sm:flex-row sm:flex-wrap sm:items-stretch">
-            <a
-              href={repositoryLink}
-              target="_blank"
-              rel="noreferrer"
-              className="inline-flex items-center justify-center rounded-lg border border-slate-400/80 bg-white/80 px-4 py-2.5 text-sm font-semibold text-slate-900 shadow-[inset_0_1px_0_rgba(255,255,255,0.9),0_10px_20px_-16px_rgba(15,23,42,0.7)] transition-colors hover:border-slate-500 hover:bg-slate-100 dark:border-slate-600 dark:bg-slate-800/70 dark:text-slate-100 dark:hover:bg-slate-700"
-            >
-              Open the GitHub repository
-            </a>
-            <Link
-              to="/workbench"
-              className="inline-flex items-center justify-center rounded-lg bg-slate-900 px-4 py-2.5 text-sm font-semibold text-white transition-colors hover:bg-slate-800 dark:bg-slate-100 dark:text-slate-900 dark:hover:bg-white"
-            >
-              Compose an exact install
-            </Link>
-            <a
-              href={installLink}
-              target="_blank"
-              rel="noreferrer"
-              className="inline-flex items-center justify-center rounded-lg border border-slate-400/80 bg-white/80 px-4 py-2.5 text-sm font-semibold text-slate-900 shadow-[inset_0_1px_0_rgba(255,255,255,0.9),0_10px_20px_-16px_rgba(15,23,42,0.7)] transition-colors hover:border-slate-500 hover:bg-slate-100 dark:border-slate-600 dark:bg-slate-800/70 dark:text-slate-100 dark:hover:bg-slate-700"
-            >
-              Install with npm
-            </a>
-            <a
-              href={docsLink}
-              target="_blank"
-              rel="noreferrer"
-              className="inline-flex items-center justify-center rounded-lg border border-slate-400/80 bg-white/80 px-4 py-2.5 text-sm font-semibold text-slate-900 shadow-[inset_0_1px_0_rgba(255,255,255,0.9),0_10px_20px_-16px_rgba(15,23,42,0.7)] transition-colors hover:border-slate-500 hover:bg-slate-100 dark:border-slate-600 dark:bg-slate-800/70 dark:text-slate-100 dark:hover:bg-slate-700"
-            >
-              Read getting started docs
-            </a>
-            <Link
-              to="/plugins"
-              className="inline-flex items-center justify-center rounded-lg border border-slate-400/80 bg-white/80 px-4 py-2.5 text-sm font-semibold text-slate-900 shadow-[inset_0_1px_0_rgba(255,255,255,0.9),0_10px_20px_-16px_rgba(15,23,42,0.7)] transition-colors hover:border-slate-500 hover:bg-slate-100 dark:border-slate-600 dark:bg-slate-800/70 dark:text-slate-100 dark:hover:bg-slate-700"
-            >
-              Compare specialized plugins
-            </Link>
-            <Link
-              to="/topics/github-ai-skills-repository"
-              className="inline-flex items-center justify-center rounded-lg border border-slate-400/80 bg-white/80 px-4 py-2.5 text-sm font-semibold text-slate-900 shadow-[inset_0_1px_0_rgba(255,255,255,0.9),0_10px_20px_-16px_rgba(15,23,42,0.7)] transition-colors hover:border-slate-500 hover:bg-slate-100 dark:border-slate-600 dark:bg-slate-800/70 dark:text-slate-100 dark:hover:bg-slate-700"
-            >
-              GitHub skills guide
-            </Link>
-          </div>
-
-          <div className="mt-5 flex flex-wrap items-center gap-2 text-xs text-slate-500 dark:text-slate-400">
-            <span className="font-medium">Large catalog safety</span>
-            <Link to="/workbench" className="font-semibold text-slate-800 underline underline-offset-4 hover:text-teal-700 dark:text-slate-200 dark:hover:text-teal-300">
-              Inspect evidence, select exact IDs, and preview before writing.
-            </Link>
-          </div>
-        </section>
-
-        <div className="relative overflow-hidden rounded-2xl border border-slate-300/70 bg-[color-mix(in_oklab,var(--surface-elevated)_92%,white_8%)] p-4 shadow-[0_14px_30px_-24px_rgba(15,23,42,0.8)] md:p-5 dark:border-slate-700/80 dark:bg-[var(--surface-elevated)]">
-          <div className="pointer-events-none absolute inset-y-0 left-0 w-1 bg-[var(--accent-solid)]/65" />
-          <div className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
-            <div>
-              <h2 className="mb-1 text-3xl font-bold tracking-tight text-slate-900 dark:text-slate-100">Explore Skills</h2>
-              <p className="text-sm text-slate-600 dark:text-slate-400">
-                Discover {catalogCountLabel} agentic capabilities for your AI assistant.
-              </p>
-            </div>
-
-            <div className="flex flex-wrap items-center gap-3">
-              {syncMsg && (
-                <span className={`rounded-full px-3 py-1.5 text-sm font-medium ${syncMsg.type === 'success'
-                  ? 'bg-emerald-100 text-emerald-800 dark:bg-emerald-900/30 dark:text-emerald-300'
-                  : syncMsg.type === 'info'
-                    ? 'bg-sky-100 text-sky-800 dark:bg-sky-900/30 dark:text-sky-300'
-                    : 'bg-rose-100 text-rose-800 dark:bg-rose-900/30 dark:text-rose-300'
-                  }`}>
-                  {syncMsg.text}
-                </span>
-              )}
-              {syncFeatureEnabled ? (
-                <button
-                  onClick={handleSync}
-                  disabled={syncing}
-                  className="flex items-center space-x-2 rounded-lg bg-slate-900 px-4 py-2.5 text-sm font-medium text-white transition-colors hover:bg-slate-800 disabled:cursor-wait disabled:opacity-50 dark:bg-slate-100 dark:text-slate-900 dark:hover:bg-white"
-                >
-                  <Icon name="refresh" size={16} className={syncing ? 'h-4 w-4 animate-spin' : 'h-4 w-4'} />
-                  <span>{syncing ? 'Syncing...' : 'Sync Skills'}</span>
-                </button>
-              ) : (
-                <span className="rounded-full border border-slate-200 bg-slate-100 px-3 py-1.5 text-sm font-medium text-slate-700 dark:border-slate-700 dark:bg-slate-800 dark:text-slate-300">
-                  Public catalog mode
-                </span>
-              )}
-            </div>
-          </div>
-        </div>
-
-        {!syncFeatureEnabled && (
-          <p className="-mt-4 text-sm text-slate-500 dark:text-slate-400">
-            Catalog sync is a maintainer-only workflow in local builds, so the public Pages site always shows the last published catalog.
-          </p>
-        )}
-
-        <div className="sticky top-0 z-40 rounded-2xl border border-slate-200/80 bg-white p-4 shadow-sm dark:border-slate-800 dark:bg-slate-900">
-          <div className="flex flex-col gap-4 md:flex-row md:items-center md:gap-3">
-            <div className="relative flex-1">
-              <Icon name="search" size={16} className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-slate-500" />
-              <input
-                type="text"
-                placeholder="Search skills (e.g., react, security, python)..."
-                aria-label="Search skills"
-                className="w-full rounded-lg border border-slate-300 bg-white px-9 py-2.5 text-sm outline-none transition-colors focus:border-slate-500 focus:ring-2 focus:ring-slate-200 dark:border-slate-700 dark:bg-slate-950 dark:text-slate-50 dark:focus:border-slate-500 dark:focus:ring-slate-800"
-                value={search}
-                onChange={(e) => setSearch(e.target.value)}
-              />
-            </div>
-
-            <div className="flex items-center gap-2 overflow-x-auto pb-2 md:pb-0 scrollbar-hide">
-              <Icon name="filter" size={16} className="h-4 w-4 shrink-0 text-slate-500" />
-              <select
-                aria-label="Filter by category"
-                className="h-10 min-w-[165px] rounded-lg border border-slate-300 bg-white px-3 text-sm outline-none transition-colors focus:border-slate-500 focus:ring-2 focus:ring-slate-200 dark:border-slate-700 dark:bg-slate-950 dark:text-slate-50 dark:focus:border-slate-500 dark:focus:ring-slate-800"
-                value={categoryFilter}
-                onChange={(e) => setCategoryFilter(e.target.value)}
-              >
-                {categories.map(cat => (
-                  <option key={cat} value={cat}>
-                    {cat === 'all'
-                      ? 'All Categories'
-                      : `${cat.charAt(0).toUpperCase() + cat.slice(1)} (${categoryStats[cat] || 0})`
-                    }
-                  </option>
-                ))}
-              </select>
-
-              <Icon name="sort" size={16} className="ml-1 h-4 w-4 shrink-0 text-slate-500" />
-              <select
-                aria-label="Sort skills"
-                className="h-10 min-w-[145px] rounded-lg border border-slate-300 bg-white px-3 text-sm outline-none transition-colors focus:border-slate-500 focus:ring-2 focus:ring-slate-200 dark:border-slate-700 dark:bg-slate-950 dark:text-slate-50 dark:focus:border-slate-500 dark:focus:ring-slate-800"
-                value={sortBy}
-                onChange={(e) => setSortBy(e.target.value)}
-              >
-                <option value="default">Default</option>
-                <option value="stars">Community saves</option>
-                <option value="newest">Newest</option>
-                <option value="az">A to Z</option>
-              </select>
-            </div>
-          </div>
-        </div>
-      </div>
-
-      <div className="-mx-4 min-h-[60vh] flex-1 sm:min-h-[68vh] lg:min-h-[72vh]">
-        {loading ? (
-          <div data-testid="loader" className="grid gap-6 px-4 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
-            {[...Array(8)].map((_, i) => (
-              <div key={i} className="h-56 animate-pulse rounded-xl border border-slate-200 bg-gradient-to-br from-slate-100 to-slate-50 p-6 dark:border-slate-800 dark:from-slate-900 dark:to-slate-950" />
-            ))}
-          </div>
-        ) : error && skills.length === 0 ? (
-          <div className="px-4 py-14 text-center sm:px-6 lg:px-8">
-            <div className="mx-auto flex h-12 w-12 items-center justify-center rounded-full bg-rose-100 text-rose-600 dark:bg-rose-900/30 dark:text-rose-300">
-              <Icon name="alertCircle" size={24} className="h-6 w-6" />
-            </div>
-            <h3 className="mt-4 text-lg font-semibold text-slate-900 dark:text-slate-100">Unable to load skills</h3>
-            <p className="mt-2 text-slate-500 dark:text-slate-400">{error}</p>
+    <div className="catalog-layout">
+      <aside className="catalog-rail" aria-label="Skill categories">
+        <p className="catalog-rail__label">Browse</p>
+        <nav>
+          {categories.map((category) => (
             <button
-              onClick={() => void refreshSkills()}
-              className="mt-5 inline-flex items-center justify-center rounded-lg bg-slate-900 px-4 py-2.5 text-sm font-semibold text-white transition-colors hover:bg-slate-800 dark:bg-slate-100 dark:text-slate-900 dark:hover:bg-white"
+              key={category}
+              type="button"
+              className={categoryFilter === category ? 'is-active' : ''}
+              aria-pressed={categoryFilter === category}
+              onClick={() => setCategoryFilter(category)}
             >
-              Retry loading catalog
+              <span>{labelCategory(category)}</span>
+              <span>{category === 'all' ? skills.length : categoryStats[category] || 0}</span>
             </button>
+          ))}
+        </nav>
+        <Link to="/workbench" className="catalog-rail__workbench">
+          <Icon name="fileCode" size={17} />
+          Saved & exact installs
+        </Link>
+      </aside>
+
+      <div className="catalog-content">
+        <section className="catalog-hero">
+          <h1>Find the right skill.<br />Ship the better agent.</h1>
+          <p>Search {catalogCountLabel} installable skills, plugins, and workflows — curated for real agent work.</p>
+
+          <label className="catalog-search">
+            <span className="sr-only">Search skills</span>
+            <Icon name="search" size={23} />
+            <input
+              type="search"
+              aria-label="Search skills"
+              placeholder="Search skills, tools, or workflows"
+              value={search}
+              onChange={(event) => setSearch(event.target.value)}
+            />
+            <kbd>⌘K</kbd>
+          </label>
+
+          <div className="catalog-mobile-categories" aria-label="Quick category filters">
+            {categories.slice(0, 6).map((category) => (
+              <button
+                key={category}
+                type="button"
+                className={categoryFilter === category ? 'is-active' : ''}
+                onClick={() => setCategoryFilter(category)}
+              >
+                {labelCategory(category)}
+              </button>
+            ))}
           </div>
-        ) : filteredSkills.length === 0 ? (
-          <div className="px-4 py-14 text-center sm:px-6 lg:px-8">
-            <div className="mx-auto flex h-12 w-12 items-center justify-center rounded-full bg-slate-100 text-slate-500 dark:bg-slate-800 dark:text-slate-300">
-              <Icon name="alertCircle" size={24} className="h-6 w-6" />
+
+          <div className="catalog-toolbar">
+            <div>
+              <label>
+                <span className="sr-only">Filter by category</span>
+                <select aria-label="Filter by category" value={categoryFilter} onChange={(event) => setCategoryFilter(event.target.value)}>
+                  {categories.map((category) => (
+                    <option key={category} value={category}>
+                      {labelCategory(category)}{category === 'all' ? '' : ` (${categoryStats[category] || 0})`}
+                    </option>
+                  ))}
+                </select>
+              </label>
+              <label>
+                <span className="sr-only">Sort skills</span>
+                <select aria-label="Sort skills" value={sortBy} onChange={(event) => setSortBy(event.target.value)}>
+                  <option value="default">Recommended</option>
+                  <option value="stars">Community saves</option>
+                  <option value="newest">Newest</option>
+                  <option value="az">A to Z</option>
+                </select>
+              </label>
             </div>
-            <h3 className="mt-4 text-lg font-semibold text-slate-900 dark:text-slate-100">No skills found</h3>
-            <p className="mt-2 text-slate-500 dark:text-slate-400">Try adjusting your search or category filters.</p>
+            <Link to="/workbench">Compose an exact install <Icon name="arrowRight" size={16} /></Link>
           </div>
-        ) : (
-          <VirtuosoGrid
-            useWindowScroll
-            totalCount={filteredSkills.length}
-            listClassName="grid gap-6 px-4 pb-8 sm:grid-cols-2 lg:grid-cols-4 xl:grid-cols-4"
-            itemContent={(index) => {
-              const skill = filteredSkills[index];
-              return <SkillCard key={skill.id} skill={skill} starCount={stars[skill.id] || 0} />;
-            }}
-          />
-        )}
-      </div>
+        </section>
 
-      <div className="mt-12 space-y-10">
-        <section className="rounded-2xl border border-slate-200/80 bg-white p-6 shadow-sm sm:p-7 dark:border-slate-800 dark:bg-slate-900">
-          <p className="mb-3 text-xs font-semibold uppercase tracking-[0.2em] text-slate-500 dark:text-slate-400">
-            Concepts
-          </p>
-          <h2 className="text-2xl font-bold tracking-tight text-slate-900 dark:text-slate-100">
-            Understand the system before scaling your setup
-          </h2>
-          <p className="mt-3 max-w-4xl text-sm leading-relaxed text-slate-600 sm:text-base dark:text-slate-300">
-            The catalog is easier to navigate when you separate reusable playbooks from external tool integrations.
-            Skills explain execution quality, MCP tools expose systems, bundles reduce decision overhead, and workflows
-            map the operating sequence.
-          </p>
-          <div className="mt-6 grid gap-4 md:grid-cols-2 xl:grid-cols-4">
+        <section className="catalog-results" aria-labelledby="catalog-results-title">
+          <header>
+            <div>
+              <h2 id="catalog-results-title">{filteredSkills.length.toLocaleString('en-US')} skills</h2>
+              <p>Inspect evidence, select exact IDs, and preview before writing.</p>
+            </div>
+            {syncFeatureEnabled ? (
+              <button type="button" onClick={() => void handleSync()} disabled={syncing}>
+                <Icon name="refresh" size={16} className={syncing ? 'animate-spin' : ''} />
+                {syncing ? 'Syncing…' : 'Sync skills'}
+              </button>
+            ) : <span className="catalog-mode">Public catalog mode</span>}
+          </header>
+
+          {!syncFeatureEnabled && (
+            <p className="catalog-note">Catalog sync is a maintainer-only workflow; this public view shows the last published catalog.</p>
+          )}
+          {syncMsg && <p className={`catalog-message catalog-message--${syncMsg.type}`}>{syncMsg.text}</p>}
+
+          {loading ? (
+            <div data-testid="loader" className="catalog-loading" aria-label="Loading skills">
+              {[...Array(5)].map((_, index) => <div key={index} />)}
+            </div>
+          ) : error && skills.length === 0 ? (
+            <div className="catalog-empty">
+              <Icon name="alertCircle" size={28} />
+              <h3>Unable to load skills</h3>
+              <p>{error}</p>
+              <button type="button" onClick={() => void refreshSkills()}>Retry loading catalog</button>
+            </div>
+          ) : filteredSkills.length === 0 ? (
+            <div className="catalog-empty">
+              <Icon name="search" size={28} />
+              <h3>No skills found</h3>
+              <p>Try a broader search or another category.</p>
+              <button type="button" onClick={() => { setSearch(''); setCategoryFilter('all'); }}>Clear filters</button>
+            </div>
+          ) : (
+            <VirtuosoGrid
+              useWindowScroll
+              totalCount={filteredSkills.length}
+              listClassName="catalog-result-list"
+              itemContent={(index) => {
+                const skill = filteredSkills[index];
+                return <SkillCard key={skill.id} skill={skill} starCount={stars[skill.id] || 0} />;
+              }}
+            />
+          )}
+        </section>
+
+        <section className="catalog-support" aria-label="Catalog guides">
+          <div className="catalog-support__intro">
+            <h2>Understand the system behind the catalog</h2>
+            <p>Skills, tools, bundles, plugins, and workflows solve different parts of the same job.</p>
+          </div>
+          <div className="catalog-support__concepts">
             {conceptCards.map((card) => (
-              <article
-                key={card.title}
-                className="rounded-xl border border-slate-200 bg-gradient-to-br from-white to-slate-50 p-4 dark:border-slate-800 dark:from-slate-900 dark:to-slate-950"
-              >
-                <h3 className="text-base font-semibold text-slate-900 dark:text-slate-100">{card.title}</h3>
-                <p className="mt-2 text-sm leading-relaxed text-slate-600 dark:text-slate-300">{card.body}</p>
-              </article>
+              <article key={card.title}><h3>{card.title}</h3><p>{card.body}</p></article>
             ))}
           </div>
-          <div className="mt-5 flex flex-wrap gap-3">
-            <a
-              href="https://github.com/sickn33/agentic-awesome-skills/blob/main/docs/users/skills-vs-mcp-tools.md"
-              target="_blank"
-              rel="noreferrer"
-              className="inline-flex items-center justify-center rounded-lg border border-slate-300 px-4 py-2.5 text-sm font-semibold text-slate-800 transition-colors hover:bg-slate-100 dark:border-slate-700 dark:text-slate-200 dark:hover:bg-slate-800"
-            >
-              Read skills vs MCP/tools
-            </a>
-            <a
-              href="https://github.com/sickn33/agentic-awesome-skills/blob/main/docs/users/bundles.md"
-              target="_blank"
-              rel="noreferrer"
-              className="inline-flex items-center justify-center rounded-lg border border-slate-300 px-4 py-2.5 text-sm font-semibold text-slate-800 transition-colors hover:bg-slate-100 dark:border-slate-700 dark:text-slate-200 dark:hover:bg-slate-800"
-            >
-              Browse bundles
-            </a>
-            <a
-              href="https://github.com/sickn33/agentic-awesome-skills/blob/main/docs/users/workflows.md"
-              target="_blank"
-              rel="noreferrer"
-              className="inline-flex items-center justify-center rounded-lg border border-slate-300 px-4 py-2.5 text-sm font-semibold text-slate-800 transition-colors hover:bg-slate-100 dark:border-slate-700 dark:text-slate-200 dark:hover:bg-slate-800"
-            >
-              Explore workflows
-            </a>
+          <div className="catalog-support__columns">
+            <div>
+              <h2>Runtime guides</h2>
+              <nav>{integrationGuides.map((guide) => <a key={guide.name} href={guide.href} target="_blank" rel="noreferrer">{guide.name}<Icon name="arrowRight" size={14} /></a>)}</nav>
+            </div>
+            <div>
+              <h2>Search topics</h2>
+              <nav>{seoLandingPages.map((page) => <Link key={page.slug} to={`/topics/${page.slug}`}>{page.h1}<Icon name="arrowRight" size={14} /></Link>)}</nav>
+            </div>
           </div>
-        </section>
-
-        <section className="rounded-2xl border border-slate-200/80 bg-white p-6 shadow-sm sm:p-7 dark:border-slate-800 dark:bg-slate-900">
-          <p className="mb-3 text-xs font-semibold uppercase tracking-[0.2em] text-slate-500 dark:text-slate-400">
-            Integration Guides
-          </p>
-          <h2 className="text-2xl font-bold tracking-tight text-slate-900 dark:text-slate-100">
-            Start from the guide that matches your assistant runtime
-          </h2>
-          <div className="mt-6 grid gap-4 md:grid-cols-2">
-            {integrationGuides.map((guide) => (
-              <a
-                key={guide.name}
-                href={guide.href}
-                target="_blank"
-                rel="noreferrer"
-                className="rounded-xl border border-slate-200 bg-gradient-to-br from-white to-slate-50 p-4 transition-colors hover:border-slate-400 dark:border-slate-800 dark:from-slate-900 dark:to-slate-950 dark:hover:border-slate-600"
-              >
-                <h3 className="text-base font-semibold text-slate-900 dark:text-slate-100">{guide.name}</h3>
-                <p className="mt-2 text-sm leading-relaxed text-slate-600 dark:text-slate-300">{guide.body}</p>
-              </a>
-            ))}
-          </div>
-        </section>
-
-        <section className="rounded-2xl border border-slate-200/80 bg-white p-6 shadow-sm sm:p-7 dark:border-slate-800 dark:bg-slate-900">
-          <p className="mb-3 text-xs font-semibold uppercase tracking-[0.2em] text-slate-500 dark:text-slate-400">
-            Search Topics
-          </p>
-          <h2 className="text-2xl font-bold tracking-tight text-slate-900 dark:text-slate-100">
-            Direct entry points for high-intent searches
-          </h2>
-          <p className="mt-3 max-w-4xl text-sm leading-relaxed text-slate-600 sm:text-base dark:text-slate-300">
-            These guides map common discovery queries to the right catalog surface, GitHub source, and plugin or installer path.
-          </p>
-          <div className="mt-6 grid gap-4 md:grid-cols-2">
-            {seoLandingPages.map((page) => (
-              <Link
-                key={page.slug}
-                to={`/topics/${page.slug}`}
-                className="rounded-xl border border-slate-200 bg-gradient-to-br from-white to-slate-50 p-4 transition-colors hover:border-slate-400 dark:border-slate-800 dark:from-slate-900 dark:to-slate-950 dark:hover:border-slate-600"
-              >
-                <p className="text-xs font-semibold uppercase tracking-[0.18em] text-slate-500 dark:text-slate-400">
-                  {page.eyebrow}
-                </p>
-                <h3 className="mt-2 text-base font-semibold text-slate-900 dark:text-slate-100">{page.h1}</h3>
-                <p className="mt-2 text-sm leading-relaxed text-slate-600 dark:text-slate-300">{page.summary}</p>
-              </Link>
-            ))}
-          </div>
-        </section>
-
-        <section className="rounded-2xl border border-slate-200/80 bg-white p-6 shadow-sm sm:p-7 dark:border-slate-800 dark:bg-slate-900">
-          <p className="mb-3 text-xs font-semibold uppercase tracking-[0.2em] text-slate-500 dark:text-slate-400">
-            Quick FAQ
-          </p>
-          <h2 className="text-2xl font-bold tracking-tight text-slate-900 dark:text-slate-100">
-            Answers to the first questions most users ask
-          </h2>
-          <div className="mt-6 grid gap-4 lg:grid-cols-2">
+          <div className="catalog-faq">
+            <h2>Quick FAQ</h2>
             {faqItems.map((item) => (
-              <article
-                key={item.question}
-                className="rounded-xl border border-slate-200 bg-gradient-to-br from-white to-slate-50 p-4 dark:border-slate-800 dark:from-slate-900 dark:to-slate-950"
-              >
-                <h3 className="text-base font-semibold text-slate-900 dark:text-slate-100">{item.question}</h3>
-                <p className="mt-2 text-sm leading-relaxed text-slate-600 dark:text-slate-300">{item.answer}</p>
-              </article>
+              <details key={item.question}><summary>{item.question}</summary><p>{item.answer}</p></details>
             ))}
           </div>
-          <a
-            href="https://github.com/sickn33/agentic-awesome-skills/blob/main/docs/users/faq.md"
-            target="_blank"
-            rel="noreferrer"
-            className="mt-5 inline-flex items-center justify-center rounded-lg border border-slate-300 px-4 py-2.5 text-sm font-semibold text-slate-800 transition-colors hover:bg-slate-100 dark:border-slate-700 dark:text-slate-200 dark:hover:bg-slate-800"
-          >
-            Read the full FAQ
-          </a>
         </section>
       </div>
     </div>

--- a/apps/web-app/src/pages/NotFound.tsx
+++ b/apps/web-app/src/pages/NotFound.tsx
@@ -12,7 +12,7 @@ export default function NotFound(): React.ReactElement {
   });
 
   return (
-    <section className="mx-auto flex min-h-[40vh] max-w-xl flex-col items-start justify-center gap-4 p-8">
+    <section className="not-found-page">
       <p className="text-sm font-semibold uppercase tracking-[0.16em] text-[var(--text-muted)]">404</p>
       <h1 className="text-3xl font-bold text-[var(--text-primary)]">Page not found</h1>
       <p className="text-[var(--text-secondary)]">The requested catalog page does not exist or has moved.</p>

--- a/apps/web-app/src/pages/Plugins.tsx
+++ b/apps/web-app/src/pages/Plugins.tsx
@@ -1,181 +1,105 @@
+import { useMemo, useState } from 'react';
 import { Link } from 'react-router-dom';
-import { specializedPlugins } from '../data/specializedPlugins';
+import { Icon } from '../components/ui/Icon';
+import { specializedPlugins, type SpecializedPlugin } from '../data/specializedPlugins';
 import { usePageMeta } from '../hooks/usePageMeta';
 import { buildPluginsMeta } from '../utils/seo';
 
 const repoBaseUrl = 'https://github.com/sickn33/agentic-awesome-skills';
-
-function pluginFolderUrl(pluginId: string): string {
-  return `${repoBaseUrl}/tree/main/plugins/agentic-bundle-${pluginId}`;
-}
-
-function pluginDocUrl(): string {
-  return `${repoBaseUrl}/blob/main/docs/users/plugins.md`;
-}
-
-function bundleDocUrl(): string {
-  return `${repoBaseUrl}/blob/main/docs/users/bundles.md`;
-}
-
-function gettingStartedDocUrl(): string {
-  return `${repoBaseUrl}/blob/main/docs/users/getting-started.md`;
-}
+const pluginFolderUrl = (pluginId: string) => `${repoBaseUrl}/tree/main/plugins/agentic-bundle-${pluginId}`;
+const pluginDocUrl = () => `${repoBaseUrl}/blob/main/docs/users/plugins.md`;
+const bundleDocUrl = () => `${repoBaseUrl}/blob/main/docs/users/bundles.md`;
+const gettingStartedDocUrl = () => `${repoBaseUrl}/blob/main/docs/users/getting-started.md`;
 
 export function Plugins(): React.ReactElement {
+  const [query, setQuery] = useState('');
   usePageMeta(buildPluginsMeta(specializedPlugins.length));
 
-  const tierOne = specializedPlugins.filter((plugin) => plugin.priority === 'tier-1');
-  const tierTwo = specializedPlugins.filter((plugin) => plugin.priority === 'tier-2');
+  const filtered = useMemo(() => {
+    const normalized = query.trim().toLowerCase();
+    if (!normalized) return specializedPlugins;
+    return specializedPlugins.filter((plugin) => [plugin.name, plugin.audience, plugin.why, ...plugin.skills]
+      .some((value) => value.toLowerCase().includes(normalized)));
+  }, [query]);
+
+  const tierOne = filtered.filter((plugin) => plugin.priority === 'tier-1');
+  const tierTwo = filtered.filter((plugin) => plugin.priority === 'tier-2');
 
   return (
-    <div className="relative min-h-[calc(100vh-8rem)]">
-      <div className="pointer-events-none absolute inset-x-0 top-0 -z-10 h-[28rem] bg-[radial-gradient(circle_at_20%_12%,rgba(15,23,42,0.12),transparent_48%),radial-gradient(circle_at_84%_8%,rgba(99,102,241,0.16),transparent_54%)] dark:bg-[radial-gradient(circle_at_20%_12%,rgba(148,163,184,0.15),transparent_45%),radial-gradient(circle_at_84%_8%,rgba(129,140,248,0.2),transparent_52%)]" />
+    <div className="plugins-page">
+      <header className="plugins-hero">
+        <h1>Choose the focused AAS plugin for the job.</h1>
+        <p>AAS specialized plugins are domain-specific distributions of the full skill library — smaller scope, clearer activation, faster starts.</p>
+        <div>
+          <a href={pluginDocUrl()} target="_blank" rel="noreferrer">Read plugin install guide <Icon name="arrowRight" size={16} /></a>
+          <Link to="/">Browse full skill catalog <Icon name="arrowRight" size={16} /></Link>
+          <a href={gettingStartedDocUrl()} target="_blank" rel="noreferrer">Install one skill with GitHub CLI</a>
+        </div>
+      </header>
 
-      <div className="space-y-8 p-5 sm:p-7">
-        <section className="rounded-2xl border border-slate-200/80 bg-white p-6 shadow-[0_20px_55px_-32px_rgba(15,23,42,0.55)] sm:p-8 dark:border-slate-800/80 dark:bg-slate-900">
-          <p className="mb-3 text-xs font-semibold uppercase tracking-[0.22em] text-slate-500 dark:text-slate-400">
-            Specialized Plugins
-          </p>
-          <h1 className="max-w-[24ch] text-3xl font-bold tracking-tight text-slate-900 [text-wrap:balance] sm:text-[3.25rem] sm:leading-[0.97] dark:text-slate-100">
-            Choose the focused AAS plugin for your AI coding workflow
-          </h1>
-          <p className="mt-4 max-w-4xl text-sm leading-relaxed text-slate-600 sm:text-base dark:text-slate-300">
-            AAS specialized plugins are focused, domain-specific distributions of the full skill library.
-            Start here when you know the job: web apps, security, data analytics, documents, DevOps, QA,
-            OSS maintenance, mobile apps, automation, or agent and MCP systems.
-          </p>
-          <div className="mt-6 flex flex-col gap-3 sm:flex-row sm:flex-wrap">
-            <a
-              href={pluginDocUrl()}
-              target="_blank"
-              rel="noreferrer"
-              className="inline-flex items-center justify-center rounded-lg bg-slate-900 px-4 py-2.5 text-sm font-semibold text-white transition-colors hover:bg-slate-800 dark:bg-slate-100 dark:text-slate-900 dark:hover:bg-white"
-            >
-              Read plugin install guide
-            </a>
-            <Link
-              to="/"
-              className="inline-flex items-center justify-center rounded-lg border border-slate-400/80 bg-white/80 px-4 py-2.5 text-sm font-semibold text-slate-900 shadow-[inset_0_1px_0_rgba(255,255,255,0.9),0_10px_20px_-16px_rgba(15,23,42,0.7)] transition-colors hover:border-slate-500 hover:bg-slate-100 dark:border-slate-600 dark:bg-slate-800/70 dark:text-slate-100 dark:hover:bg-slate-700"
-            >
-              Browse full skill catalog
-            </Link>
-            <a
-              href={gettingStartedDocUrl()}
-              target="_blank"
-              rel="noreferrer"
-              className="inline-flex items-center justify-center rounded-lg border border-slate-400/80 bg-white/80 px-4 py-2.5 text-sm font-semibold text-slate-900 shadow-[inset_0_1px_0_rgba(255,255,255,0.9),0_10px_20px_-16px_rgba(15,23,42,0.7)] transition-colors hover:border-slate-500 hover:bg-slate-100 dark:border-slate-600 dark:bg-slate-800/70 dark:text-slate-100 dark:hover:bg-slate-700"
-            >
-              Install one skill with GitHub CLI
-            </a>
-          </div>
-        </section>
+      <section className="plugin-decisions" aria-labelledby="plugin-decisions-title">
+        <h2 id="plugin-decisions-title">Plugins, bundles, and workflows serve different decisions</h2>
+        <div>
+          <article><Icon name="book" size={22} /><div><h3>Plugin</h3><p>What should I install or activate for this domain?</p></div></article>
+          <article><Icon name="fileCode" size={22} /><div><h3>Bundle</h3><p>Which skills naturally belong together for a role?</p></div></article>
+          <article><Icon name="sort" size={22} /><div><h3>Workflow</h3><p>What order should the assistant follow to get a result?</p></div></article>
+        </div>
+      </section>
 
-        <section className="rounded-2xl border border-slate-200/80 bg-white p-6 shadow-sm sm:p-7 dark:border-slate-800 dark:bg-slate-900">
-          <p className="mb-3 text-xs font-semibold uppercase tracking-[0.2em] text-slate-500 dark:text-slate-400">
-            Quick Answer
-          </p>
-          <h2 className="text-2xl font-bold tracking-tight text-slate-900 dark:text-slate-100">
-            Plugins, bundles, and workflows serve different decisions
-          </h2>
-          <div className="mt-5 grid gap-4 md:grid-cols-3">
-            <article className="rounded-xl border border-slate-200 bg-slate-50 p-4 dark:border-slate-800 dark:bg-slate-950">
-              <h3 className="text-base font-semibold text-slate-900 dark:text-slate-100">Plugin</h3>
-              <p className="mt-2 text-sm leading-relaxed text-slate-600 dark:text-slate-300">
-                What should I install or activate for this domain?
-              </p>
-            </article>
-            <article className="rounded-xl border border-slate-200 bg-slate-50 p-4 dark:border-slate-800 dark:bg-slate-950">
-              <h3 className="text-base font-semibold text-slate-900 dark:text-slate-100">Bundle</h3>
-              <p className="mt-2 text-sm leading-relaxed text-slate-600 dark:text-slate-300">
-                Which skills naturally belong together for a role?
-              </p>
-            </article>
-            <article className="rounded-xl border border-slate-200 bg-slate-50 p-4 dark:border-slate-800 dark:bg-slate-950">
-              <h3 className="text-base font-semibold text-slate-900 dark:text-slate-100">Workflow</h3>
-              <p className="mt-2 text-sm leading-relaxed text-slate-600 dark:text-slate-300">
-                What order should the assistant follow to get a result?
-              </p>
-            </article>
-          </div>
-        </section>
-
-        <PluginSection title="Tier 1 Plugins" plugins={tierOne} />
-        <PluginSection title="Tier 2 Plugins" plugins={tierTwo} />
-      </div>
+      <section className="plugin-catalog" aria-labelledby="plugin-catalog-title">
+        <header>
+          <div><h2 id="plugin-catalog-title">Focused distributions</h2><p>{filtered.length} plugins</p></div>
+          <label>
+            <Icon name="search" size={18} />
+            <span className="sr-only">Filter plugins</span>
+            <input value={query} onChange={(event) => setQuery(event.target.value)} placeholder="Filter plugins" aria-label="Filter plugins" />
+          </label>
+        </header>
+        <PluginSection title="Tier 1 plugins" plugins={tierOne} />
+        <PluginSection title="Tier 2 plugins" plugins={tierTwo} />
+        {filtered.length === 0 && <p className="plugin-empty">No plugins match “{query}”.</p>}
+      </section>
     </div>
   );
 }
 
-function PluginSection({
-  title,
-  plugins,
-}: {
-  title: string;
-  plugins: typeof specializedPlugins;
-}): React.ReactElement {
+function PluginSection({ title, plugins }: { title: string; plugins: SpecializedPlugin[] }): React.ReactElement | null {
+  if (plugins.length === 0) return null;
   return (
-    <section className="space-y-4">
-      <div>
-        <p className="mb-2 text-xs font-semibold uppercase tracking-[0.2em] text-slate-500 dark:text-slate-400">
-          AAS plugin catalog
-        </p>
-        <h2 className="text-2xl font-bold tracking-tight text-slate-900 dark:text-slate-100">{title}</h2>
-      </div>
-      <div className="grid gap-4 xl:grid-cols-2">
-        {plugins.map((plugin) => (
-          <article
-            key={plugin.id}
-            id={plugin.id}
-            className="rounded-xl border border-slate-200 bg-white p-5 shadow-sm dark:border-slate-800 dark:bg-slate-900"
-          >
-            <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
-              <div>
-                <h3 className="text-xl font-bold tracking-tight text-slate-900 dark:text-slate-100">{plugin.name}</h3>
-                <p className="mt-2 text-sm leading-relaxed text-slate-600 dark:text-slate-300">{plugin.audience}</p>
-              </div>
-              <span className="w-fit rounded-full border border-slate-200 bg-slate-100 px-3 py-1 text-xs font-semibold uppercase tracking-[0.14em] text-slate-600 dark:border-slate-700 dark:bg-slate-800 dark:text-slate-300">
-                {plugin.priority}
-              </span>
-            </div>
-            <p className="mt-4 text-sm leading-relaxed text-slate-600 dark:text-slate-300">{plugin.why}</p>
-            <div className="mt-4 flex flex-wrap gap-2">
-              {plugin.skills.slice(0, 6).map((skillId) => (
-                <Link
-                  key={skillId}
-                  to={`/skill/${encodeURIComponent(skillId)}`}
-                  className="rounded-full border border-slate-200 bg-slate-50 px-2.5 py-1 text-xs font-medium text-slate-700 transition-colors hover:border-slate-400 hover:bg-slate-100 dark:border-slate-700 dark:bg-slate-950 dark:text-slate-300 dark:hover:border-slate-500"
-                >
-                  @{skillId}
-                </Link>
-              ))}
-              {plugin.skills.length > 6 && (
-                <span className="rounded-full border border-slate-200 bg-slate-50 px-2.5 py-1 text-xs font-medium text-slate-500 dark:border-slate-700 dark:bg-slate-950 dark:text-slate-400">
-                  +{plugin.skills.length - 6} more
-                </span>
-              )}
-            </div>
-            <div className="mt-5 flex flex-col gap-2 sm:flex-row sm:flex-wrap">
-              <a
-                href={pluginFolderUrl(plugin.id)}
-                target="_blank"
-                rel="noreferrer"
-                className="inline-flex items-center justify-center rounded-lg border border-slate-300 px-3 py-2 text-sm font-semibold text-slate-800 transition-colors hover:bg-slate-100 dark:border-slate-700 dark:text-slate-200 dark:hover:bg-slate-800"
-              >
-                View plugin folder
-              </a>
-              <a
-                href={bundleDocUrl()}
-                target="_blank"
-                rel="noreferrer"
-                className="inline-flex items-center justify-center rounded-lg border border-slate-300 px-3 py-2 text-sm font-semibold text-slate-800 transition-colors hover:bg-slate-100 dark:border-slate-700 dark:text-slate-200 dark:hover:bg-slate-800"
-              >
-                Read bundle notes
-              </a>
-            </div>
-          </article>
-        ))}
+    <section className="plugin-tier">
+      <h2>{title}</h2>
+      <div className="plugin-table" role="table" aria-label={title}>
+        <div className="plugin-table__head" role="row">
+          <span role="columnheader">Plugin</span>
+          <span role="columnheader">Audience</span>
+          <span role="columnheader">Why this plugin</span>
+          <span role="columnheader">Included skills</span>
+          <span role="columnheader">Actions</span>
+        </div>
+        {plugins.map((plugin) => <PluginRow key={plugin.id} plugin={plugin} />)}
       </div>
     </section>
+  );
+}
+
+function PluginRow({ plugin }: { plugin: SpecializedPlugin }): React.ReactElement {
+  return (
+    <article className="plugin-row" id={plugin.id} role="row">
+      <div role="cell" className="plugin-row__name">
+        <span aria-hidden="true"><Icon name="fileCode" size={20} /></span>
+        <div><h3>{plugin.name}</h3><code>{plugin.id}</code></div>
+      </div>
+      <p role="cell">{plugin.audience}</p>
+      <p role="cell">{plugin.why}</p>
+      <div role="cell" className="plugin-row__skills">
+        {plugin.skills.slice(0, 4).map((skillId) => <Link key={skillId} to={`/skill/${encodeURIComponent(skillId)}`}>@{skillId}</Link>)}
+        {plugin.skills.length > 4 && <span>+{plugin.skills.length - 4} more</span>}
+      </div>
+      <div role="cell" className="plugin-row__actions">
+        <a href={pluginFolderUrl(plugin.id)} target="_blank" rel="noreferrer">View plugin</a>
+        <a href={bundleDocUrl()} target="_blank" rel="noreferrer">Bundle notes</a>
+      </div>
+    </article>
   );
 }
 

--- a/apps/web-app/src/pages/SkillDetail.tsx
+++ b/apps/web-app/src/pages/SkillDetail.tsx
@@ -18,6 +18,28 @@ function looksLikeHtmlDocument(text: string): boolean {
   return trimmed.startsWith('<!doctype html') || trimmed.startsWith('<html');
 }
 
+const inFlightMarkdownRequests = new Map<string, Promise<string>>();
+
+function fetchMarkdownOnce(url: string, scope: string): Promise<string> {
+  const requestKey = `${scope}:${url}`;
+  const existing = inFlightMarkdownRequests.get(requestKey);
+  if (existing) return existing;
+
+  const request = fetch(url).then(async (response) => {
+    if (!response.ok) throw new Error(`Request failed (${response.status}) for ${url}`);
+    const text = await response.text();
+    if (looksLikeHtmlDocument(text)) throw new Error(`HTML fallback returned instead of markdown for ${url}`);
+    return text;
+  });
+
+  inFlightMarkdownRequests.set(requestKey, request);
+  void request.then(
+    () => inFlightMarkdownRequests.delete(requestKey),
+    () => inFlightMarkdownRequests.delete(requestKey),
+  );
+  return request;
+}
+
 /** Split YAML frontmatter (--- ... ---) and markdown body */
 function splitFrontmatter(md: string): { frontmatter: string; body: string } {
   const match = md.match(/^(---[\s\S]*?---)\s*\n?/);
@@ -51,6 +73,14 @@ function parseFrontmatterRows(frontmatter: string): Array<{ key: string; value: 
       return key ? { key, value } : null;
     })
     .filter((row): row is { key: string; value: string } => row !== null);
+}
+
+function slugifyHeading(value: string): string {
+  return value
+    .toLowerCase()
+    .replace(/[`*_~[\]()]/g, '')
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-|-$/g, '');
 }
 
 interface RouteParams {
@@ -99,6 +129,14 @@ export function SkillDetail(): React.ReactElement {
   const communityCount = useMemo(() => (id ? stars[id] || 0 : 0), [stars, id]);
   const { frontmatter, body: markdownBody } = useMemo(() => splitFrontmatter(content), [content]);
   const frontmatterRows = useMemo(() => parseFrontmatterRows(frontmatter), [frontmatter]);
+  const headingLinks = useMemo(() => markdownBody
+    .split('\n')
+    .flatMap((line) => {
+      const match = line.match(/^##\s+(.+)$/);
+      if (!match) return [];
+      const label = match[1].replace(/[`*_~]/g, '').trim();
+      return label ? [{ label, id: slugifyHeading(label) }] : [];
+    }), [markdownBody]);
   const relatedTopicPages = useMemo(
     () => skill ? getRelatedSeoLandingPagesForSkill(skill) : [],
     [skill],
@@ -114,31 +152,26 @@ export function SkillDetail(): React.ReactElement {
         const cleanPath = skill.path.startsWith('skills/')
           ? skill.path.replace('skills/', '')
           : skill.path;
+        const canonicalSkillPath = cleanPath.replace(/\/SKILL\.md$/i, '');
+        const canonicalUrl = new URL(
+          `${import.meta.env.BASE_URL}skills/${canonicalSkillPath}/SKILL.md`,
+          window.location.origin,
+        ).href;
 
-        const candidateUrls = getSkillMarkdownCandidateUrls({
+        const candidateUrls = Array.from(new Set([canonicalUrl, ...getSkillMarkdownCandidateUrls({
           baseUrl: import.meta.env.BASE_URL,
           origin: window.location.origin,
           pathname: window.location.pathname,
           documentBaseUrl: window.document.baseURI,
           skillPath: `skills/${cleanPath}`,
-        });
+        })]));
 
         let markdown: string | null = null;
         let lastError: Error | null = null;
 
         for (const url of candidateUrls) {
           try {
-            const mdRes = await fetch(url);
-            if (!mdRes.ok) {
-              throw new Error(`Request failed (${mdRes.status}) for ${url}`);
-            }
-
-            const text = await mdRes.text();
-            if (looksLikeHtmlDocument(text)) {
-              throw new Error(`HTML fallback returned instead of markdown for ${url}`);
-            }
-
-            markdown = text;
+            markdown = await fetchMarkdownOnce(url, skill.id);
             break;
           } catch (err) {
             lastError = err instanceof Error ? err : new Error(String(err));
@@ -233,8 +266,8 @@ export function SkillDetail(): React.ReactElement {
   }
 
   return (
-    <div className="mx-auto max-w-5xl">
-      <div className="relative mb-8 overflow-hidden rounded-3xl border border-slate-200/80 bg-gradient-to-br from-white via-slate-50 to-teal-50 p-6 shadow-sm dark:border-slate-800 dark:from-slate-950 dark:via-slate-950 dark:to-teal-950/20 sm:p-8">
+    <div className="skill-detail">
+      <div className="skill-detail__hero">
         <div className="pointer-events-none absolute -right-16 -top-16 h-44 w-44 rounded-full bg-teal-300/20 blur-3xl dark:bg-teal-500/20" />
         <div className="pointer-events-none absolute -bottom-24 -left-20 h-56 w-56 rounded-full bg-slate-300/20 blur-3xl dark:bg-slate-600/20" />
 
@@ -246,7 +279,7 @@ export function SkillDetail(): React.ReactElement {
           Back to Catalog
         </Link>
 
-        <div className="relative flex flex-col justify-between gap-5 rounded-2xl border border-slate-200/80 bg-white/95 p-6 shadow-sm backdrop-blur dark:border-slate-800 dark:bg-slate-900/80 md:flex-row md:items-center">
+        <div className="skill-detail__summary">
           <div className="flex-1">
             <div className="mb-2 flex flex-wrap items-center gap-2">
               <span className="rounded-full bg-teal-100 px-2.5 py-0.5 text-xs font-semibold uppercase tracking-wide text-teal-700 dark:bg-teal-900/50 dark:text-teal-300">
@@ -296,7 +329,7 @@ export function SkillDetail(): React.ReactElement {
           </div>
         </div>
 
-        <div className="mt-6 rounded-2xl border border-slate-200/80 bg-white/95 p-6 shadow-sm backdrop-blur dark:border-slate-800 dark:bg-slate-900/80">
+        <div className="skill-detail__install-and-context">
           <div className="mb-4 border border-slate-300 bg-slate-50/70 p-4 dark:border-slate-700 dark:bg-slate-900">
             <p className="text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">
               Exact install input
@@ -335,7 +368,7 @@ export function SkillDetail(): React.ReactElement {
       </div>
 
       {relatedTopicPages.length > 0 && (
-        <section className="mb-8 rounded-3xl border border-slate-200/80 bg-white p-6 shadow-sm dark:border-slate-800 dark:bg-slate-900 sm:p-7">
+        <section className="skill-detail__related">
           <p className="mb-3 text-xs font-semibold uppercase tracking-[0.2em] text-slate-500 dark:text-slate-400">
             Related topic guides
           </p>
@@ -377,8 +410,8 @@ export function SkillDetail(): React.ReactElement {
         </section>
       )}
 
-      <div className="overflow-hidden rounded-3xl border border-slate-200/80 bg-white shadow-sm dark:border-slate-800 dark:bg-slate-900">
-        <div className="p-6 sm:p-8">
+      <div className="skill-detail__reading">
+        <article className="skill-detail__article">
           {frontmatterRows.length > 0 && (
             <div className="mb-6">
               <p className="mb-2 text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">
@@ -420,12 +453,33 @@ export function SkillDetail(): React.ReactElement {
               <Markdown
                 remarkPlugins={[remarkGfm]}
                 rehypePlugins={[rehypeHighlight]}
+                components={{
+                  h2: ({ children }) => {
+                    const label = String(children);
+                    return <h2 id={slugifyHeading(label)}>{children}</h2>;
+                  },
+                }}
               >
                 {markdownBody}
               </Markdown>
             </Suspense>
           </div>
-        </div>
+        </article>
+        <aside className="skill-detail__toc" aria-label="On this page">
+          <h2>On this page</h2>
+          {headingLinks.length > 0 ? (
+            <nav>
+              {headingLinks.map((heading) => <a key={heading.id} href={`#${heading.id}`}>{heading.label}</a>)}
+            </nav>
+          ) : <p>Skill documentation</p>}
+          <dl>
+            <div><dt>Canonical ID</dt><dd>{skill.id}</dd></div>
+            <div><dt>Category</dt><dd>{skill.category}</dd></div>
+            <div><dt>Risk</dt><dd>{skill.risk || 'unknown'}</dd></div>
+            {skill.source && <div><dt>Source</dt><dd>{skill.source}</dd></div>}
+            {skill.date_added && <div><dt>Added</dt><dd>{skill.date_added}</dd></div>}
+          </dl>
+        </aside>
       </div>
     </div>
   );

--- a/apps/web-app/src/pages/TopicLanding.tsx
+++ b/apps/web-app/src/pages/TopicLanding.tsx
@@ -12,7 +12,7 @@ export function TopicLanding(): React.ReactElement {
 
   if (!page) {
     return (
-      <div className="px-6 py-14 text-center sm:px-8">
+      <div className="topic-missing">
         <p className="text-xs font-semibold uppercase tracking-[0.2em] text-slate-500 dark:text-slate-400">
           Topic guide
         </p>
@@ -46,8 +46,8 @@ export function TopicLanding(): React.ReactElement {
   const relatedTopicPages = seoLandingPages.filter((landing) => landing.slug !== page.slug).slice(0, 3);
 
   return (
-    <article className="space-y-10 px-6 py-8 sm:px-8 lg:px-10">
-      <section className="grid gap-8 lg:grid-cols-[minmax(0,1fr)_22rem] lg:items-start">
+    <article className="topic-page">
+      <section className="topic-hero">
         <div>
           <p className="mb-3 text-xs font-semibold uppercase tracking-[0.2em] text-slate-500 dark:text-slate-400">
             {page.eyebrow}
@@ -84,7 +84,7 @@ export function TopicLanding(): React.ReactElement {
           </div>
         </div>
 
-        <aside className="rounded-2xl border border-slate-200 bg-slate-50 p-5 dark:border-slate-800 dark:bg-slate-950">
+        <aside className="topic-intent">
           <h2 className="text-base font-semibold tracking-normal text-slate-900 dark:text-slate-100">
             Search intent covered
           </h2>
@@ -101,7 +101,7 @@ export function TopicLanding(): React.ReactElement {
         </aside>
       </section>
 
-      <section className="grid gap-4 md:grid-cols-3">
+      <section className="topic-sections">
         {page.sections.map((section) => (
           <article
             key={section.heading}
@@ -117,7 +117,7 @@ export function TopicLanding(): React.ReactElement {
         ))}
       </section>
 
-      <section className="rounded-2xl border border-slate-200 bg-white p-5 dark:border-slate-800 dark:bg-slate-900">
+      <section className="topic-continue">
         <div className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
           <div>
             <h2 className="text-xl font-bold tracking-normal text-slate-900 dark:text-slate-100">

--- a/apps/web-app/src/pages/Workbench.tsx
+++ b/apps/web-app/src/pages/Workbench.tsx
@@ -91,7 +91,7 @@ function WorkbenchCard({
 
   return (
     <article
-      className={`relative flex h-full flex-col border bg-white p-4 transition-colors dark:bg-slate-950 ${selected
+      className={`workbench-card relative flex h-full flex-col border bg-white p-4 transition-colors dark:bg-slate-950 ${selected
         ? 'border-teal-500 shadow-[inset_4px_0_0_0_rgb(13_148_136)] dark:border-teal-500'
         : 'border-slate-200 hover:border-slate-400 dark:border-slate-800 dark:hover:border-slate-600'
         }`}
@@ -284,8 +284,8 @@ export function Workbench(): React.ReactElement {
   };
 
   return (
-    <div className="min-h-[calc(100vh-8rem)] bg-slate-100/70 p-4 sm:p-6 dark:bg-slate-950">
-      <header className="relative overflow-hidden border border-slate-300 bg-slate-950 px-5 py-6 text-slate-100 shadow-[0_24px_60px_-38px_rgba(15,23,42,0.9)] sm:px-7 dark:border-slate-700">
+    <div className="workbench-page">
+      <header className="workbench-header">
         <div className="absolute inset-y-0 left-0 w-1.5 bg-teal-400" />
         <div className="grid gap-6 lg:grid-cols-[minmax(0,1fr)_auto] lg:items-end">
           <div>
@@ -314,8 +314,8 @@ export function Workbench(): React.ReactElement {
         </div>
       </header>
 
-      <div className="mt-5 grid items-start gap-5 xl:grid-cols-[17rem_minmax(0,1fr)_23rem]">
-        <aside className="order-1 border border-slate-300 bg-white p-4 xl:sticky xl:top-20 dark:border-slate-800 dark:bg-slate-900" aria-label="Workbench filters">
+      <div className="workbench-grid">
+        <aside className="workbench-filters" aria-label="Workbench filters">
           <div className="flex items-center justify-between gap-3">
             <h2 className="font-mono text-xs font-semibold uppercase tracking-[0.16em] text-slate-800 dark:text-slate-200">Query</h2>
             <button type="button" onClick={resetFilters} className="text-xs font-semibold text-slate-500 underline underline-offset-4 hover:text-slate-900 dark:hover:text-slate-100">
@@ -397,7 +397,7 @@ export function Workbench(): React.ReactElement {
           </div>
         </aside>
 
-        <aside className="order-2 border border-slate-300 bg-slate-950 text-slate-100 xl:order-3 xl:sticky xl:top-20" aria-label="Selected skill ledger">
+        <aside id="selection-panel" className="workbench-selection" aria-label="Selected skill ledger">
           <div className="border-b border-slate-700 px-4 py-4">
             <p className="font-mono text-[10px] uppercase tracking-[0.2em] text-teal-300">Selection ledger</p>
             <div className="mt-2 flex items-end justify-between gap-3">
@@ -484,7 +484,7 @@ export function Workbench(): React.ReactElement {
           </div>
         </aside>
 
-        <main className="order-3 min-w-0 xl:order-2" aria-label="Workbench results">
+        <main className="workbench-results" aria-label="Workbench results">
           <div className="mb-3 flex items-center justify-between gap-4 border-b border-slate-300 pb-3 dark:border-slate-800">
             <p aria-live="polite" className="font-mono text-xs text-slate-600 dark:text-slate-400">
               {filteredSkills.length.toLocaleString('en-US')} matching canonical skills
@@ -515,7 +515,7 @@ export function Workbench(): React.ReactElement {
             <VirtuosoGrid
               useWindowScroll
               totalCount={filteredSkills.length}
-              listClassName="grid gap-3 md:grid-cols-2 2xl:grid-cols-3"
+              listClassName="workbench-result-list"
               itemContent={(index) => {
                 const skill = filteredSkills[index];
                 return <WorkbenchCard key={skill.id} skill={skill} selected={selectedSet.has(skill.id)} host={host} onToggle={toggleSkill} />;
@@ -524,6 +524,12 @@ export function Workbench(): React.ReactElement {
           )}
         </main>
       </div>
+      {selectedSkills.length > 0 && (
+        <a className="workbench-mobile-selection" href="#selection-panel">
+          <span>{selectedSkills.length} selected</span>
+          <strong>Review install <Icon name="arrowRight" size={16} /></strong>
+        </a>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
# Pull Request Description

Redesign the public React/Vite catalog into a focused editorial tool across Explore, skill detail, Workbench, Plugins, topic landing, not-found, navigation, and responsive layouts.

The implementation preserves canonical catalog data, route meanings, SEO metadata, exact-install safety, stars, clipboard actions, and maintainer-only synchronization behavior.

## Change Classification

- [ ] Skill PR
- [ ] Docs PR
- [x] Infra PR

## Quality Bar Checklist ✅

**All applicable items must be checked before merging.**

- [x] **Standards**: I have read `docs/contributors/quality-bar.md` and `docs/contributors/security-guardrails.md`.
- [x] **Metadata**: No `SKILL.md` metadata changed; `npm run validate` passed.
- [x] **Risk Label**: No skill risk labels changed.
- [x] **Triggers**: No skill trigger sections changed.
- [x] **Limitations**: No skill limitations changed.
- [x] **Security**: No offensive skill content changed.
- [x] **Safety scan**: `npm run security:docs` passed.
- [x] **Automated Skill Review**: No `SKILL.md` changed.
- [x] **Manual Logic Review**: UI behavior, install safety, failure states, and markdown loading were reviewed.
- [x] **Local Test**: Build, browser rendering, 136 tests, coverage, lint, and SEO verification passed.
- [x] **Repo Checks**: Repository validation and test suite passed.
- [x] **Source-Only PR**: No generated registry artifacts are included.
- [x] **Credits**: No external source content was imported.
- [x] **License provenance**: No external skill source was imported.
- [x] **Maintainer Edits**: The branch is owned by the repository maintainer.

## Verification

- `npm run app:build`
- `npm run app:test`
- `npm run app:test:coverage`
- `cd apps/web-app && npm run lint`
- `cd apps/web-app && npm run verify:seo`
- `npm run validate`
- `npm run test`
- `npm run security:docs`

## Screenshots

Desktop routes were verified at 1440x1100 for Explore, skill detail, Workbench, and Plugins.
