### PR TITLE
fix(ci): repair Tessl review workspace

### DIFF
--- a/.github/workflows/skill-review.yml
+++ b/.github/workflows/skill-review.yml
@@ -24,7 +24,9 @@ jobs:
     runs-on: ubuntu-latest
     env:
       TESSL_REVIEW_THRESHOLD: '80'
-      TESSL_WORKSPACE: agentic-awesome-skills
+      # Tessl workspaces are account-scoped; keep the repository variable as
+      # an override so a future workspace migration does not require code changes.
+      TESSL_WORKSPACE: ${{ vars.TESSL_WORKSPACE || 'sickn33' }}
     permissions:
       contents: read
     steps:

--- a/tools/scripts/review_changed_skills.cjs
+++ b/tools/scripts/review_changed_skills.cjs
@@ -5,7 +5,7 @@ const path = require('node:path');
 const { execFileSync, spawnSync } = require('node:child_process');
 
 const DEFAULT_THRESHOLD = '80';
-const DEFAULT_WORKSPACE = 'agentic-awesome-skills';
+const DEFAULT_WORKSPACE = 'sickn33';
 
 function runGit(args, options = {}) {
   return execFileSync('git', args, {

--- a/tools/scripts/tests/review_changed_skills.test.js
+++ b/tools/scripts/tests/review_changed_skills.test.js
@@ -55,14 +55,14 @@ assert.deepStrictEqual(
     label: 'pr-123-skills-alpha',
     reviewPlugin: 'aas-reviewer',
     threshold: '85',
-    workspace: 'agentic-awesome-skills',
+    workspace: 'sickn33',
   }),
   [
     'review',
     'run',
     'skills/alpha',
     '--workspace',
-    'agentic-awesome-skills',
+    'sickn33',
     '--json',
     '--threshold',
     '85',
@@ -70,6 +70,20 @@ assert.deepStrictEqual(
     'aas-reviewer',
     '--label',
     'pr-123-skills-alpha',
+  ],
+);
+
+assert.deepStrictEqual(
+  buildReviewArgs('skills/alpha'),
+  [
+    'review',
+    'run',
+    'skills/alpha',
+    '--workspace',
+    'sickn33',
+    '--json',
+    '--threshold',
+    '80',
   ],
 );
 

--- a/walkthrough.md
+++ b/walkthrough.md
@@ -257,3 +257,9 @@
 - Added maintainer automation for repo-state hygiene: `sync:contributors` updates the README contributor list from GitHub contributors, `check:stale-claims`/`audit:consistency` catch drift in count-sensitive docs, and `sync:repo-state` now chains the local maintainer sweep into a single command.
 - Hardened automation surfaces beyond the local CLI: `main` CI now runs the unified repo-state sync, tracked web artifacts are refreshed through `sync:web-assets`, release verification now uses a deterministic `sync:release-state` path plus `npm pack --dry-run`, the npm publish workflow reruns those checks before publishing, and a weekly `Repo Hygiene` GitHub Actions workflow now sweeps slow drift on `main`.
 - Added two maintainer niceties on top of the hardening work: `check:warning-budget` freezes the accepted `135` validation warnings so they cannot silently grow, and `audit:maintainer` prints a read-only health snapshot of warning budget, consistency drift, and git cleanliness.
+
+# Maintenance Walkthrough - 2026-07-16 Tessl Workspace Repair
+
+- Corrected the Skill Review workflow and trusted review helper to use the account-scoped `sickn33` Tessl workspace instead of the nonexistent repository-name workspace.
+- Added a repository-variable override so future Tessl workspace migrations can be handled through `TESSL_WORKSPACE` without another workflow patch.
+- Updated the review command regression test to lock the corrected workspace argument.


### PR DESCRIPTION
# Pull Request Description

Repair the Tessl Skill Review gate by replacing the nonexistent repository-name workspace with the account-scoped `sickn33` workspace. The workflow now reads the `TESSL_WORKSPACE` repository variable and keeps `sickn33` as a safe code fallback; the trusted review helper and its regression tests use the same default.

The repository variable has also been set to `sickn33` in GitHub.

## Change Classification

- [ ] Skill PR
- [ ] Docs PR
- [x] Infra PR

## Quality Bar Checklist ✅

- [x] **Standards**: I have read `docs/contributors/quality-bar.md` and `docs/contributors/security-guardrails.md`.
- [x] **Metadata**: Not applicable; no `SKILL.md` frontmatter changed.
- [x] **Risk Label**: Not applicable; no skill changed.
- [x] **Triggers**: Not applicable; no skill changed.
- [x] **Limitations**: Not applicable; no skill changed.
- [x] **Security**: Not applicable; no offensive skill changed.
- [x] **Safety scan**: Not applicable; no `SKILL.md` guidance changed.
- [x] **Automated Skill Review**: Not applicable; no `SKILL.md` changed.
- [x] **Manual Logic Review**: Reviewed workspace selection, variable fallback, and failure behavior.
- [x] **Local Test**: `node tools/scripts/tests/review_changed_skills.test.js` and `npm test` pass.
- [x] **Repo Checks**: `npm run validate:references` passes.
- [x] **Source-Only PR**: No generated registry artifacts are included.
- [x] **Credits**: Not applicable; no external source imported.
- [x] **License provenance**: Not applicable; no external skill imported.
- [x] **Maintainer Edits**: Repository-owned branch.

## Failure evidence

PR #854 failed before semantic review with `Workspace not found: agentic-awesome-skills`. Tessl workspaces are account-scoped, and the repository is published under the `sickn33` Tessl identity.
