### PR TITLE
fix(web): strengthen search discovery and migration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Expanded the curated hosted sitemap from 42 to 180 deterministic skill routes and added crawlable static home/topic fallbacks so search engines can discover useful catalog hubs without mass-indexing the full library.
+- Enriched the four search-intent landing pages with real recommended skills, stronger internal links, and matching `ItemList` structured data while preserving canonical trailing-slash identities.
+- Replaced the marketing-only homepage heading with a descriptive AI-agent-skills heading while retaining the existing slogan as supporting copy.
+
+### Fixed
+
+- Added the current Bing Webmaster verification identity and updated the legacy Pages redirect generator contract to cover the expanded 187-route sitemap.
+
 ## [14.6.0] - 2026-07-16 - "Diagnostics, Review Efficiency, and Protected Maintenance"
 
 > Three new skills for Claude Code, Codex CLI, Gemini CLI, Cursor, Antigravity, and other agent workflows: Android overheating diagnosis, evidence-labeled competitor ad research, and uncertainty-aware campaign optimization, backed by more reliable Tessl review and protected maintainer automation.

--- a/apps/web-app/index.html
+++ b/apps/web-app/index.html
@@ -12,6 +12,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="description" content="Explore the GitHub library of 1,965+ installable agentic skills, specialized plugins, bundles, and workflows for Claude Code, Cursor, Codex CLI, Autohand Code, Gemini CLI, Antigravity, and other AI coding assistants." />
     <meta name="author" content="Agentic Awesome Skills" />
+    <meta name="msvalidate.01" content="CAC904EB0D2DD1B22B5F2BC540CAD654" />
     <meta property="og:title" content="Agentic Awesome Skills GitHub | 1,965+ AI coding skills" />
     <meta property="og:description" content="Explore the GitHub library of 1,965+ installable agentic skills, specialized plugins, bundles, and workflows for Claude Code, Cursor, Codex CLI, Autohand Code, Gemini CLI, Antigravity, and other AI coding assistants." />
     <meta property="og:type" content="website" />

--- a/apps/web-app/scripts/generate-sitemap.js
+++ b/apps/web-app/scripts/generate-sitemap.js
@@ -13,7 +13,9 @@ const NORMALIZED_BASE_PATH = BASE_PATH && BASE_PATH !== '/' ? BASE_PATH : '';
 const DEFAULT_SITE_URL = 'https://sickn33.github.io/agentic-awesome-skills';
 
 const SITE_URL = (process.env.SEO_SITE_URL || process.env.WEBSITE_BASE_URL || DEFAULT_SITE_URL).replace(/\/$/, '');
-const DEFAULT_TOP_SKILL_COUNT = 42;
+// Keep this curated: broad enough to form a crawlable catalog, well below the
+// full library so thin/low-signal detail pages are not mass-submitted.
+export const DEFAULT_TOP_SKILL_COUNT = 180;
 const TOP_SKILL_COUNT = Number.parseInt(process.env.TOP_SKILL_COUNT || String(DEFAULT_TOP_SKILL_COUNT), 10);
 const DEFAULT_LASTMOD = new Date().toISOString().slice(0, 10);
 

--- a/apps/web-app/scripts/generate-sitemap.test.js
+++ b/apps/web-app/scripts/generate-sitemap.test.js
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { buildSitemap, getSeoLandingPaths, selectTopSkillEntries } from './generate-sitemap.js';
+import { buildSitemap, DEFAULT_TOP_SKILL_COUNT, getSeoLandingPaths, selectTopSkillEntries } from './generate-sitemap.js';
 
 describe('sitemap generation script helpers', () => {
   it('builds top skill entries sorted by stars/date/name without duplicates', () => {
@@ -64,16 +64,16 @@ describe('sitemap generation script helpers', () => {
   });
 
   it('keeps the default public sitemap skill count reproducible', () => {
-    const catalog = Array.from({ length: 43 }, (_, index) => ({
+    const catalog = Array.from({ length: DEFAULT_TOP_SKILL_COUNT + 1 }, (_, index) => ({
       id: `skill-${String(index).padStart(2, '0')}`,
-      stars: 43 - index,
+      stars: DEFAULT_TOP_SKILL_COUNT + 1 - index,
     }));
 
     const xml = buildSitemap(catalog, undefined, 'https://example.com');
     const skillRoutes = xml.match(/https:\/\/example\.com\/skill\//g) || [];
 
-    expect(skillRoutes).toHaveLength(42);
-    expect(xml).toContain('https://example.com/skill/skill-41/</loc>');
-    expect(xml).not.toContain('https://example.com/skill/skill-42/</loc>');
+    expect(skillRoutes).toHaveLength(180);
+    expect(xml).toContain('https://example.com/skill/skill-179/</loc>');
+    expect(xml).not.toContain('https://example.com/skill/skill-180/</loc>');
   });
 });

--- a/apps/web-app/scripts/prerender-routes.js
+++ b/apps/web-app/scripts/prerender-routes.js
@@ -281,6 +281,28 @@ function getRelatedLandingPagesForSkill(landingPages, skill, limit = 3) {
   return selected.slice(0, maxItems);
 }
 
+function getCuratedSkillsForLandingPage(page, skills, limit = 12) {
+  const maxItems = Math.max(0, limit);
+  if (maxItems === 0 || !Array.isArray(skills)) return [];
+
+  const byId = new Map(skills.map((skill) => [skill.id, skill]));
+  const editorial = (Array.isArray(page.featuredSkillIds) ? page.featuredSkillIds : [])
+    .map((id) => byId.get(id))
+    .filter(Boolean);
+  const selectedIds = new Set(editorial.map((skill) => skill.id));
+  const scored = skills
+    .map((skill, index) => ({ skill, index, score: scoreLandingPageForSkill(page, skill) }))
+    .filter(({ skill, score }) => score > 0 && !selectedIds.has(skill.id))
+    .sort((a, b) => {
+      if (a.score !== b.score) return b.score - a.score;
+      const idCompare = safeText(a.skill.id).localeCompare(safeText(b.skill.id), undefined, { sensitivity: 'base' });
+      return idCompare || a.index - b.index;
+    })
+    .map(({ skill }) => skill);
+
+  return [...editorial, ...scored].slice(0, maxItems);
+}
+
 function buildStaticLinkList(links) {
   return links
     .map((link) => `<li><a href="${escapeHtml(link.href)}">${escapeHtml(link.label)}</a></li>`)
@@ -299,7 +321,32 @@ function buildPrerenderFallback({ heading, description, links }) {
   ].join('');
 }
 
-function buildTopicFallback({ page, landingPages, siteBaseUrl }) {
+function buildHomeFallback({ landingPages, siteBaseUrl }) {
+  const links = [
+    { href: routeToUrl('/workbench', siteBaseUrl), label: 'Build an exact skill install' },
+    { href: routeToUrl('/plugins', siteBaseUrl), label: 'Compare specialized plugin packs' },
+    ...landingPages.filter((page) => page.slug).map((page) => ({
+      href: routeToUrl(`/topics/${encodeURIComponent(page.slug)}`, siteBaseUrl),
+      label: page.h1,
+    })),
+  ];
+
+  return [
+    '<main data-prerender-fallback="true">',
+    '<h1>Installable AI agent skills for Codex, Claude Code, Cursor, Gemini, and Antigravity</h1>',
+    '<p><strong>Find the right skill. Ship the better agent.</strong></p>',
+    '<p>Browse a GitHub-backed catalog of reusable SKILL.md playbooks, specialized plugins, bundles, and workflows.</p>',
+    `<nav aria-label="Catalog hubs"><ul>${buildStaticLinkList(links)}</ul></nav>`,
+    '</main>',
+  ].join('');
+}
+
+function buildTopicFallback({ page, landingPages, skills, siteBaseUrl }) {
+  const curatedSkills = getCuratedSkillsForLandingPage(page, skills);
+  const skillLinks = curatedSkills.map((skill) => ({
+    href: routeToUrl(`/skill/${encodeURIComponent(skill.id)}`, siteBaseUrl),
+    label: `@${safeText(skill.name) || safeText(skill.id)}`,
+  }));
   const relatedLinks = landingPages
     .filter((landing) => landing.slug && landing.slug !== page.slug)
     .slice(0, 3)
@@ -308,11 +355,19 @@ function buildTopicFallback({ page, landingPages, siteBaseUrl }) {
       label: landing.h1,
     }));
 
-  return buildPrerenderFallback({
-    heading: page.h1,
-    description: page.summary,
-    links: relatedLinks,
-  });
+  const sections = (Array.isArray(page.sections) ? page.sections : [])
+    .map((section) => `<section><h2>${escapeHtml(section.heading)}</h2><p>${escapeHtml(section.body)}</p></section>`)
+    .join('');
+
+  return [
+    '<main data-prerender-fallback="true">',
+    `<h1>${escapeHtml(page.h1)}</h1>`,
+    `<p>${escapeHtml(page.summary)}</p>`,
+    sections,
+    skillLinks.length > 0 ? `<nav aria-label="Recommended skills"><h2>Recommended skills</h2><ul>${buildStaticLinkList(skillLinks)}</ul></nav>` : '',
+    `<nav aria-label="Related topic guides"><h2>Related topic guides</h2><ul>${buildStaticLinkList(relatedLinks)}</ul></nav>`,
+    '</main>',
+  ].join('');
 }
 
 function buildSkillFallback({ skill, landingPages, siteBaseUrl }) {
@@ -622,7 +677,7 @@ function buildWorkbenchMeta({ imageUrl, canonicalUrl }) {
   };
 }
 
-function buildTopicLandingMeta({ page, imageUrl, canonicalUrl }) {
+function buildTopicLandingMeta({ page, featuredSkills = [], imageUrl, canonicalUrl }) {
   const catalogBaseUrl = canonicalUrl.replace(/\/topics\/[^/]+\/?$/, '');
   const keywords = Array.isArray(page.keywords) ? page.keywords.join(', ') : '';
   const sourceCodeEntity = {
@@ -679,15 +734,22 @@ function buildTopicLandingMeta({ page, imageUrl, canonicalUrl }) {
         keywords,
         mainEntity: {
           '@type': 'ItemList',
-          name: `${page.eyebrow} topics`,
-          itemListElement: Array.isArray(page.sections)
-            ? page.sections.map((section, index) => ({
+          name: `${page.eyebrow} recommended skills`,
+          numberOfItems: featuredSkills.length || (Array.isArray(page.sections) ? page.sections.length : 0),
+          itemListElement: featuredSkills.length > 0
+            ? featuredSkills.map((skill, index) => ({
+              '@type': 'ListItem',
+              position: index + 1,
+              name: safeText(skill.name) || safeText(skill.id),
+              description: safeText(skill.description),
+              url: routeToUrl(`/skill/${encodeURIComponent(skill.id)}`, catalogBaseUrl),
+            }))
+            : (Array.isArray(page.sections) ? page.sections.map((section, index) => ({
               '@type': 'ListItem',
               position: index + 1,
               name: section.heading,
               description: section.body,
-            }))
-            : [],
+            })) : []),
         },
       },
       {
@@ -812,7 +874,7 @@ function main() {
   const skills = readCatalog();
   const landingPages = readSeoLandingPages();
   const siteBaseUrl = getSiteBaseUrl();
-  const topCount = parseCount(process.env.PRERENDER_TOP_SKILL_COUNT || process.env.TOP_SKILL_COUNT, 40);
+  const topCount = parseCount(process.env.PRERENDER_TOP_SKILL_COUNT || process.env.TOP_SKILL_COUNT, 180);
   const topSkillPaths = selectTopSkillEntries(skills, topCount);
   const skillMap = new Map(skills.map((skill) => [skill.id, skill]));
   const topSkillSet = new Set(topSkillPaths.map((routePath) => routePath.replace(/^\/skill\//, '')));
@@ -824,7 +886,7 @@ function main() {
     imageUrl: socialImage,
     canonicalUrl: homeCanonical,
   });
-  writePrerenderedRoute('/', template, homeMeta);
+  writePrerenderedRoute('/', template, homeMeta, buildHomeFallback({ landingPages, siteBaseUrl }));
 
   const pluginsCanonical = routeToUrl('/plugins', siteBaseUrl);
   const pluginsMeta = buildPluginsMeta({
@@ -850,6 +912,7 @@ function main() {
     const canonicalUrl = routeToUrl(routePath, siteBaseUrl);
     const landingMeta = buildTopicLandingMeta({
       page,
+      featuredSkills: getCuratedSkillsForLandingPage(page, skills),
       imageUrl: socialImage,
       canonicalUrl,
     });
@@ -857,7 +920,7 @@ function main() {
       routePath,
       template,
       landingMeta,
-      buildTopicFallback({ page, landingPages, siteBaseUrl }),
+      buildTopicFallback({ page, landingPages, skills, siteBaseUrl }),
     );
   }
 

--- a/apps/web-app/scripts/verify-seo-assets.js
+++ b/apps/web-app/scripts/verify-seo-assets.js
@@ -95,7 +95,7 @@ function assert(condition, message) {
 function parseCliArgs(argv) {
   const defaultMinSkillUrls = parseCount(
     process.env.PRERENDER_VERIFY_MIN_SKILL_URLS || process.env.PRERENDER_TOP_SKILL_COUNT || process.env.TOP_SKILL_COUNT,
-    40,
+    180,
   );
   const args = {
     sitemapPath: 'dist/sitemap.xml',
@@ -683,6 +683,14 @@ export function assertIndexSocialMeta(htmlText) {
   assertMetaContent(htmlText, 'name', 'twitter:image:alt');
 }
 
+export function assertWebmasterVerificationMeta(htmlText) {
+  const bingVerificationToken = extractMetaContent(htmlText, 'name', 'msvalidate.01');
+  assert(
+    bingVerificationToken === 'CAC904EB0D2DD1B22B5F2BC540CAD654',
+    'Index HTML must expose the current Bing Webmaster Tools verification token.',
+  );
+}
+
 function readSkillCountLabel(distDir) {
   try {
     const skills = JSON.parse(readFile(path.join(distDir, 'skills.json'), distDir));
@@ -984,7 +992,10 @@ export function runVerification({
   );
   assertIndexSocialMeta(indexHtml);
   assertIndexDiscoveryMeta(indexHtml, { expectedSkillCountLabel, requireHostedUrl });
-  assertStaticIndexShell(readFile(sourceIndexPath), { expectedSkillCountLabel, requireHostedUrl });
+  assertWebmasterVerificationMeta(indexHtml);
+  const sourceIndexHtml = readFile(sourceIndexPath);
+  assertStaticIndexShell(sourceIndexHtml, { expectedSkillCountLabel, requireHostedUrl });
+  assertWebmasterVerificationMeta(sourceIndexHtml);
   assertSocialCard(readBinaryFile(socialImagePath), { expectedSkillCountLabel });
   assertRobots(readFile(robotsPath), {
     expectedSitemapUrl: new URL('sitemap.xml', sitemapReport.rootUrl).href,

--- a/apps/web-app/scripts/verify-seo-assets.test.js
+++ b/apps/web-app/scripts/verify-seo-assets.test.js
@@ -6,6 +6,7 @@ import {
   assertManifest,
   assertIndexDiscoveryMeta,
   assertStaticIndexShell,
+  assertWebmasterVerificationMeta,
   assertPluginsDiscoveryMeta,
   analyzeSitemap,
   assertPrerenderedPluginRoutes,
@@ -24,6 +25,16 @@ import {
 const FIXTURE_ROOT_URL = 'https://owner.github.io/repo/';
 const FIXTURE_SOCIAL_IMAGE_URL = 'https://owner.github.io/repo/social-card.png';
 const PACKAGE_URL = 'https://www.npmjs.com/package/agentic-awesome-skills';
+
+describe('Bing Webmaster Tools verification metadata', () => {
+  it('requires the current verification token', () => {
+    const html = '<meta name="msvalidate.01" content="CAC904EB0D2DD1B22B5F2BC540CAD654" />';
+
+    expect(() => assertWebmasterVerificationMeta(html)).not.toThrow();
+    expect(() => assertWebmasterVerificationMeta('<meta name="msvalidate.01" content="stale" />'))
+      .toThrow('current Bing Webmaster Tools verification token');
+  });
+});
 
 function buildRouteIdentityHtml({
   routeUrl,

--- a/apps/web-app/src/data/seoLandingPages.json
+++ b/apps/web-app/src/data/seoLandingPages.json
@@ -33,6 +33,16 @@
       "developer-tools",
       "workflow"
     ],
+    "featuredSkillIds": [
+      "antigravity-agent-manager",
+      "antigravity-design-expert",
+      "antigravity-skill-orchestrator",
+      "antigravity-workflows",
+      "analyze-project",
+      "dispatch",
+      "subagent-orchestrator",
+      "recursive-context-pruning-token-budgeting"
+    ],
     "sections": [
       {
         "heading": "What to install first",
@@ -95,6 +105,16 @@
       "developer-tools",
       "github",
       "tool-quality"
+    ],
+    "featuredSkillIds": [
+      "address-github-comments",
+      "agentic-actions-auditor",
+      "github-actions-advanced",
+      "github-actions-debugger",
+      "github-actions-templates",
+      "codebase-audit-pre-push",
+      "code-review-ai-ai-review",
+      "cicd-automation-workflow-automate"
     ],
     "sections": [
       {
@@ -167,6 +187,16 @@
       "testing",
       "web-development"
     ],
+    "featuredSkillIds": [
+      "design-taste-frontend",
+      "api-security-best-practices",
+      "api-security-testing",
+      "github-actions-templates",
+      "building-native-ui",
+      "i18n-localization",
+      "agent-creator",
+      "aws-mcp-setup"
+    ],
     "sections": [
       {
         "heading": "Focused distributions",
@@ -230,6 +260,16 @@
       "marketing",
       "research",
       "writing"
+    ],
+    "featuredSkillIds": [
+      "antigravity-agent-manager",
+      "antigravity-design-expert",
+      "antigravity-skill-orchestrator",
+      "antigravity-workflows",
+      "i18n-localization",
+      "azure-ai-translation-document-py",
+      "azure-ai-translation-text-py",
+      "azure-ai-translation-ts"
     ],
     "sections": [
       {

--- a/apps/web-app/src/data/seoLandingPages.test.ts
+++ b/apps/web-app/src/data/seoLandingPages.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest';
+import { createMockSkill } from '../factories/skill';
+import { getCuratedSkillsForSeoLandingPage, getSeoLandingPage } from './seoLandingPages';
+
+describe('SEO landing page skill curation', () => {
+  it('keeps real editorial picks first and deterministically fills with scored matches', () => {
+    const page = getSeoLandingPage('antigravity-cli-skills');
+    expect(page).toBeDefined();
+
+    const skills = [
+      createMockSkill({ id: 'z-workflow', name: 'Antigravity Z', category: 'workflow' }),
+      createMockSkill({ id: 'antigravity-agent-manager', name: 'Editorial pick', category: 'general' }),
+      createMockSkill({ id: 'a-workflow', name: 'Antigravity A', category: 'workflow' }),
+      createMockSkill({ id: 'unrelated', name: 'Unrelated', description: 'No topic match', category: 'finance' }),
+    ];
+
+    const selected = getCuratedSkillsForSeoLandingPage(page!, skills, 3);
+
+    expect(selected.map((skill) => skill.id)).toEqual([
+      'antigravity-agent-manager',
+      'a-workflow',
+      'z-workflow',
+    ]);
+  });
+
+  it('does not invent missing editorial entries', () => {
+    const page = getSeoLandingPage('github-ai-skills-repository');
+    const selected = getCuratedSkillsForSeoLandingPage(page!, [
+      createMockSkill({ id: 'github-actions-templates', name: 'GitHub Actions Templates' }),
+    ]);
+
+    expect(selected).toHaveLength(1);
+    expect(selected[0].id).toBe('github-actions-templates');
+  });
+});

--- a/apps/web-app/src/data/seoLandingPages.ts
+++ b/apps/web-app/src/data/seoLandingPages.ts
@@ -68,6 +68,36 @@ function scoreTopicForSkill(page: SeoLandingPage, skill: Skill): number {
   return score;
 }
 
+/**
+ * Selects a small, stable set of real catalog entries for a topic hub.
+ * Editorial IDs lead when present; scored matches fill any gaps deterministically.
+ */
+export function getCuratedSkillsForSeoLandingPage(
+  page: SeoLandingPage,
+  skills: ReadonlyArray<Skill>,
+  limit = 12,
+): Skill[] {
+  const maxItems = Math.max(0, limit);
+  if (maxItems === 0 || skills.length === 0) return [];
+
+  const byId = new Map(skills.map((skill) => [skill.id, skill]));
+  const editorial = (page.featuredSkillIds || [])
+    .map((id) => byId.get(id))
+    .filter((skill): skill is Skill => Boolean(skill));
+  const selectedIds = new Set(editorial.map((skill) => skill.id));
+  const scored = skills
+    .map((skill, index) => ({ skill, index, score: scoreTopicForSkill(page, skill) }))
+    .filter(({ skill, score }) => score > 0 && !selectedIds.has(skill.id))
+    .sort((a, b) => {
+      if (a.score !== b.score) return b.score - a.score;
+      const idCompare = a.skill.id.localeCompare(b.skill.id, undefined, { sensitivity: 'base' });
+      return idCompare || a.index - b.index;
+    })
+    .map(({ skill }) => skill);
+
+  return [...editorial, ...scored].slice(0, maxItems);
+}
+
 export function getRelatedSeoLandingPagesForSkill(skill: Skill, limit = 3): SeoLandingPage[] {
   const maxItems = Math.max(0, limit);
 

--- a/apps/web-app/src/pages/Home.tsx
+++ b/apps/web-app/src/pages/Home.tsx
@@ -128,7 +128,8 @@ export function Home(): React.ReactElement {
 
       <div className="catalog-content">
         <section className="catalog-hero">
-          <h1>Find the right skill.<br />Ship the better agent.</h1>
+          <h1>Installable AI agent skills for Codex, Claude Code, Cursor, Gemini, and Antigravity</h1>
+          <p><strong>Find the right skill. Ship the better agent.</strong></p>
           <p>Search {catalogCountLabel} installable skills, plugins, and workflows — curated for real agent work.</p>
 
           <label className="catalog-search">

--- a/apps/web-app/src/pages/TopicLanding.tsx
+++ b/apps/web-app/src/pages/TopicLanding.tsx
@@ -1,14 +1,17 @@
 import { Link, useParams } from 'react-router-dom';
 import { Icon } from '../components/ui/Icon';
-import { getSeoLandingPage, seoLandingPages } from '../data/seoLandingPages';
+import { useSkills } from '../context/SkillContext';
+import { getCuratedSkillsForSeoLandingPage, getSeoLandingPage, seoLandingPages } from '../data/seoLandingPages';
 import { usePageMeta } from '../hooks/usePageMeta';
 import { buildTopicLandingFallbackMeta, buildTopicLandingMeta } from '../utils/seo';
 
 export function TopicLanding(): React.ReactElement {
   const { slug } = useParams<{ slug: string }>();
   const page = getSeoLandingPage(slug);
+  const { skills } = useSkills();
+  const curatedSkills = page ? getCuratedSkillsForSeoLandingPage(page, skills) : [];
 
-  usePageMeta(page ? buildTopicLandingMeta(page) : buildTopicLandingFallbackMeta(slug));
+  usePageMeta(page ? buildTopicLandingMeta(page, curatedSkills) : buildTopicLandingFallbackMeta(slug));
 
   if (!page) {
     return (
@@ -115,6 +118,26 @@ export function TopicLanding(): React.ReactElement {
             </p>
           </article>
         ))}
+      </section>
+
+      <section className="topic-continue" aria-labelledby="recommended-skills-title">
+        <h2 id="recommended-skills-title" className="text-xl font-bold tracking-normal text-slate-900 dark:text-slate-100">
+          Recommended skills for this workflow
+        </h2>
+        <p className="mt-2 text-sm leading-relaxed text-slate-600 dark:text-slate-300">
+          These catalog entries are selected from the current library using editorial picks and deterministic topic matching.
+        </p>
+        <div className="mt-5 grid gap-3 md:grid-cols-2">
+          {curatedSkills.map((skill) => (
+            <article key={skill.id} className="rounded-xl border border-slate-200 p-4 dark:border-slate-800">
+              <h3 className="text-base font-semibold text-slate-900 dark:text-slate-100">
+                <Link to={`/skill/${encodeURIComponent(skill.id)}`}>@{skill.name}</Link>
+              </h3>
+              <p className="mt-2 text-sm leading-relaxed text-slate-600 dark:text-slate-300">{skill.description}</p>
+              <p className="mt-3 text-xs font-medium uppercase tracking-wide text-slate-500">{skill.category}</p>
+            </article>
+          ))}
+        </div>
       </section>
 
       <section className="topic-continue">

--- a/apps/web-app/src/pages/__tests__/Home.test.tsx
+++ b/apps/web-app/src/pages/__tests__/Home.test.tsx
@@ -88,6 +88,11 @@ describe('Home', () => {
         expect(document.title).toContain('Agentic Awesome Skills');
       });
 
+      expect(screen.getByRole('heading', {
+        level: 1,
+        name: /Installable AI agent skills for Codex, Claude Code, Cursor, Gemini, and Antigravity/i,
+      })).toBeInTheDocument();
+      expect(screen.getByText(/Find the right skill\. Ship the better agent\./i)).toBeInTheDocument();
       expect(screen.getByRole('link', { name: /Compose an exact install/i })).toHaveAttribute('href', '/workbench');
       expect(screen.getByText(/What is the difference between skills and MCP tools/i)).toBeInTheDocument();
       expect(document.querySelector('meta[property="og:title"]')).toHaveAttribute(

--- a/apps/web-app/src/pages/__tests__/TopicLanding.test.tsx
+++ b/apps/web-app/src/pages/__tests__/TopicLanding.test.tsx
@@ -1,7 +1,27 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import { screen, waitFor } from '@testing-library/react';
 import { TopicLanding } from '../TopicLanding';
 import { renderWithRouter } from '../../utils/testUtils';
+import { createMockSkill } from '../../factories/skill';
+
+vi.mock('../../context/SkillContext', () => ({
+  useSkills: () => ({
+    skills: [
+      createMockSkill({
+        id: 'antigravity-agent-manager',
+        name: 'Antigravity Agent Manager',
+        description: 'Configure and orchestrate Antigravity agents.',
+        category: 'agent-orchestration',
+      }),
+      createMockSkill({
+        id: 'antigravity-workflows',
+        name: 'Antigravity Workflows',
+        description: 'Run guided Antigravity workflows.',
+        category: 'workflow',
+      }),
+    ],
+  }),
+}));
 
 describe('TopicLanding', () => {
   it('renders an SEO topic page and sets metadata', async () => {
@@ -14,6 +34,11 @@ describe('TopicLanding', () => {
     expect(screen.getByRole('heading', { level: 1, name: /Antigravity CLI skills/i })).toBeInTheDocument();
     expect(screen.getByText(/Search intent covered/i)).toBeInTheDocument();
     expect(screen.getByText(/Related topic guides/i)).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: /Recommended skills for this workflow/i })).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: /@Antigravity Agent Manager/i })).toHaveAttribute(
+      'href',
+      '/skill/antigravity-agent-manager',
+    );
     expect(screen.getByRole('link', { name: /GitHub repository for installable AI agent skills/i })).toHaveAttribute(
       'href',
       '/topics/github-ai-skills-repository',

--- a/apps/web-app/src/utils/__tests__/seo.test.ts
+++ b/apps/web-app/src/utils/__tests__/seo.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import type { Skill } from '../../types';
 import {
+  DEFAULT_TOP_SKILL_COUNT,
   DEFAULT_SOCIAL_IMAGE,
   buildHomeMeta,
   buildSkillFallbackMeta,
@@ -28,6 +29,10 @@ function createSkill(overrides: Record<string, unknown> = {}) {
 }
 
 describe('SEO helpers', () => {
+  it('keeps hydrated priority metadata aligned with the curated sitemap scope', () => {
+    expect(DEFAULT_TOP_SKILL_COUNT).toBe(180);
+  });
+
   it('builds homepage metadata with the canonical catalog message', () => {
     const meta = buildHomeMeta(10);
 

--- a/apps/web-app/src/utils/seo.ts
+++ b/apps/web-app/src/utils/seo.ts
@@ -1,7 +1,7 @@
 import type { SeoJsonLdValue, SeoMeta, TwitterCard, Skill } from '../types';
 import { getAbsolutePublicAssetUrl } from './publicAssetUrls';
 
-export const DEFAULT_TOP_SKILL_COUNT = 40;
+export const DEFAULT_TOP_SKILL_COUNT = 180;
 export const DEFAULT_SOCIAL_IMAGE = 'social-card.png';
 const SITE_NAME = 'Agentic Awesome Skills';
 const REPOSITORY_URL = 'https://github.com/sickn33/agentic-awesome-skills';
@@ -31,6 +31,7 @@ export interface SeoLandingPage {
   keywords: string[];
   relatedTerms?: string[];
   relatedCategories?: string[];
+  featuredSkillIds?: string[];
   sections: SeoLandingPageSection[];
   links: SeoLandingPageLink[];
 }
@@ -443,7 +444,7 @@ export function buildPluginsMeta(pluginCount: number): SeoMeta {
   };
 }
 
-export function buildTopicLandingMeta(page: SeoLandingPage): SeoMeta {
+export function buildTopicLandingMeta(page: SeoLandingPage, featuredSkills: ReadonlyArray<Skill> = []): SeoMeta {
   const canonicalPath = `${TOPIC_ROUTE_PREFIX}/${page.slug}`;
   const keywords = page.keywords.join(', ');
 
@@ -468,12 +469,14 @@ export function buildTopicLandingMeta(page: SeoLandingPage): SeoMeta {
         keywords,
         mainEntity: {
           '@type': 'ItemList',
-          name: `${page.eyebrow} topics`,
-          itemListElement: page.sections.map((section, index) => ({
+          name: `${page.eyebrow} recommended skills`,
+          numberOfItems: featuredSkills.length || page.sections.length,
+          itemListElement: (featuredSkills.length > 0 ? featuredSkills : page.sections).map((entry, index) => ({
             '@type': 'ListItem',
             position: index + 1,
-            name: section.heading,
-            description: section.body,
+            name: 'id' in entry ? entry.name : entry.heading,
+            description: 'id' in entry ? entry.description : entry.body,
+            ...('id' in entry ? { url: getCanonicalUrl(`/skill/${encodeURIComponent(entry.id)}`, canonicalUrl.replace(/\/topics\/[^/]+\/?$/, '')) } : {}),
           })),
         },
       },

--- a/tools/scripts/generate-pages-redirect-bridge.js
+++ b/tools/scripts/generate-pages-redirect-bridge.js
@@ -9,7 +9,7 @@ const REPO_ROOT = path.resolve(__dirname, '..', '..');
 const DEFAULT_SITEMAP = path.join(REPO_ROOT, 'apps', 'web-app', 'public', 'sitemap.xml');
 const DEFAULT_CURRENT_BASE = 'https://sickn33.github.io/agentic-awesome-skills/';
 const DEFAULT_LEGACY_BASE = 'https://sickn33.github.io/antigravity-awesome-skills/';
-const DEFAULT_EXPECTED_ROUTES = 49;
+const DEFAULT_EXPECTED_ROUTES = 187;
 const SAFE_SEGMENT = /^[A-Za-z0-9._~-]+$/;
 
 function sha256(value) {

--- a/tools/scripts/tests/generate_pages_redirect_bridge.test.js
+++ b/tools/scripts/tests/generate_pages_redirect_bridge.test.js
@@ -187,10 +187,18 @@ try {
 
   const productionOutputRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'pages-redirect-production-'));
   try {
+    const productionSitemapPath = path.join(productionOutputRoot, 'sitemap.xml');
+    const productionBase = 'https://sickn33.github.io/agentic-awesome-skills/';
+    const productionUrls = [
+      productionBase,
+      ...Array.from({ length: 186 }, (_, index) => `${productionBase}skill/production-${index + 1}/`),
+    ];
+    fs.writeFileSync(productionSitemapPath, sitemap(productionUrls), 'utf8');
     const productionManifest = generateBridge({
+      sitemapPath: productionSitemapPath,
       outputDirectory: path.join(productionOutputRoot, 'bridge'),
     });
-    assert.strictEqual(productionManifest.route_count, 49);
+    assert.strictEqual(productionManifest.route_count, 187);
   } finally {
     fs.rmSync(productionOutputRoot, { recursive: true, force: true });
   }


### PR DESCRIPTION
# Pull Request Description

Strengthens organic discovery after the repository and Pages rename. The hosted catalog now exposes a descriptive home heading, crawlable home/topic fallbacks, curated real-skill links and structured data, and a 180-skill sitemap/prerender surface. It also adds the current Bing verification identity and aligns the legacy redirect bridge contract with the resulting 187 URLs.

## Change Classification

- [ ] Skill PR
- [ ] Docs PR
- [x] Infra PR

## Issue Link (Optional)

N/A

## Quality Bar Checklist ✅

- [x] **Standards**: I have read `docs/contributors/quality-bar.md` and `docs/contributors/security-guardrails.md`.
- [x] **Metadata**: Not applicable; no `SKILL.md` files changed. `npm run validate` passes.
- [x] **Risk Label**: Not applicable; no `SKILL.md` content changed.
- [x] **Triggers**: Not applicable; no skill content changed.
- [x] **Limitations**: Not applicable; no skill content changed.
- [x] **Security**: Not applicable; no offensive skill content changed.
- [x] **Safety scan**: `npm run security:docs` passes.
- [x] **Automated Skill Review**: Not applicable; no `SKILL.md` files changed.
- [x] **Manual Logic Review**: Canonical URLs, trailing slashes, sitemap scope, hydration parity, structured data, and redirect coverage were manually reviewed.
- [x] **Local Test**: App tests (140), root test suite, lint, TypeScript, build, prerender, and SEO verification pass.
- [x] **Repo Checks**: `npm run validate:references` passes.
- [x] **Source-Only PR**: No generated registry or sitemap artifact is included.
- [x] **Credits**: Not applicable; no external source content added.
- [x] **License provenance**: Not applicable; no external skill imported.
- [x] **Maintainer Edits**: Enabled.

## Screenshots (if applicable)

Not included: this is primarily a search discovery and prerender change; the existing visual design is preserved apart from the descriptive home heading.

## Verification

- `npm run validate`
- `npm run test`
- `npm run security:docs`
- `npm run validate:references`
- `npm run check:warning-budget`
- `cd apps/web-app && npm run test -- --run`
- `cd apps/web-app && npm run lint`
- `cd apps/web-app && npm run build`
- `cd apps/web-app && npm run verify:seo`
- `node tools/scripts/tests/generate_pages_redirect_bridge.test.js`
