### PR TITLE
fix: cover every current skill in legacy bridge

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Added the current Bing Webmaster verification identity and updated the legacy Pages redirect generator contract to cover the expanded 187-route sitemap.
+- Expanded the legacy Pages bridge to every one of the 1,965 current catalog skills plus seven structural routes, while keeping crawler discovery limited to the curated 187-route sitemap and making migration-readiness checks enforce the same exact catalog coverage.
 
 ## [14.6.0] - 2026-07-16 - "Diagnostics, Review Efficiency, and Protected Maintenance"
 

--- a/tools/scripts/audit_search_migration_readiness.js
+++ b/tools/scripts/audit_search_migration_readiness.js
@@ -16,6 +16,11 @@ const DEFAULT_CURRENT_PAGES_URL = 'https://sickn33.github.io/agentic-awesome-ski
 const DEFAULT_LEGACY_PAGES_URL = 'https://sickn33.github.io/antigravity-awesome-skills/';
 const SNAPSHOT_DIRECTORY = /^\d{4}-\d{2}-\d{2}$/;
 const DEFAULT_MAX_EVIDENCE_AGE_DAYS = 7;
+const SAFE_SEGMENT = /^[A-Za-z0-9._~-]+$/;
+
+function isSafeSegment(value) {
+  return typeof value === 'string' && value !== '.' && value !== '..' && SAFE_SEGMENT.test(value);
+}
 const DASHBOARD_FILES = {
   gsc: {
     file: 'google-search-console.json',
@@ -70,7 +75,31 @@ function parseSitemap(filePath, errors) {
     .map((match) => withTrailingSlash(match[1]))
     .filter(Boolean);
   if (!locations.length) errors.push('current sitemap: contains no valid <loc> URLs');
+  if (new Set(locations).size !== locations.length) errors.push('current sitemap: contains duplicate URLs after normalization');
   return [...new Set(locations)].sort();
+}
+
+function parseSkillUrls(filePath, currentPagesUrl, errors) {
+  const payload = readJson(filePath, errors, 'skills index');
+  if (!payload) return [];
+  if (!Array.isArray(payload) || !payload.length) {
+    errors.push('skills index: expected a non-empty array');
+    return [];
+  }
+  const urls = [];
+  const seen = new Set();
+  payload.forEach((entry, index) => {
+    const id = entry && entry.id;
+    if (!id || !isSafeSegment(id)) {
+      errors.push(`skills index: entry ${index} has an unsafe or missing id`);
+    } else if (seen.has(id)) {
+      errors.push(`skills index: duplicate id ${id}`);
+    } else {
+      seen.add(id);
+      urls.push(new URL(`skill/${id}/`, currentPagesUrl).toString());
+    }
+  });
+  return urls.sort();
 }
 
 function inferLegacyPagesUrl(currentPagesUrl) {
@@ -228,10 +257,10 @@ function manifestPairs(payload) {
   return [];
 }
 
-function redirectCoverage(manifestPath, currentUrls, currentPagesUrl, legacyPagesUrl, errors) {
-  if (!manifestPath) return { status: 'fail', expected: currentUrls.length, covered: 0, missing: currentUrls, message: 'No redirect manifest was supplied.' };
+function redirectCoverage(manifestPath, expectedCurrentUrls, currentPagesUrl, legacyPagesUrl, errors) {
+  if (!manifestPath) return { status: 'fail', expected: expectedCurrentUrls.length, covered: 0, missing: expectedCurrentUrls, message: 'No redirect manifest was supplied.' };
   const payload = readJson(manifestPath, errors, 'redirect manifest');
-  if (!payload) return { status: 'fail', expected: currentUrls.length, covered: 0, missing: currentUrls, message: 'Redirect manifest is unreadable.' };
+  if (!payload) return { status: 'fail', expected: expectedCurrentUrls.length, covered: 0, missing: expectedCurrentUrls, message: 'Redirect manifest is unreadable.' };
   const redirects = new Map();
   const duplicates = [];
   const invalid = [];
@@ -246,23 +275,23 @@ function redirectCoverage(manifestPath, currentUrls, currentPagesUrl, legacyPage
       redirects.set(from, to);
     }
   }
-  const expectedPairs = new Map(currentUrls.map((currentUrl) => [
+  const expectedPairs = new Map(expectedCurrentUrls.map((currentUrl) => [
     withTrailingSlash(currentUrl.replace(currentPagesUrl, legacyPagesUrl)),
     currentUrl,
   ]));
-  const missing = currentUrls.filter((currentUrl) => {
+  const missing = expectedCurrentUrls.filter((currentUrl) => {
     const legacyUrl = withTrailingSlash(currentUrl.replace(currentPagesUrl, legacyPagesUrl));
     return redirects.get(legacyUrl) !== currentUrl;
   });
   const unexpected = [...redirects.entries()]
     .filter(([from, to]) => expectedPairs.get(from) !== to)
     .map(([from, to]) => ({ from, to }));
-  const exact = currentUrls.length && !missing.length && !duplicates.length && !invalid.length && !unexpected.length
+  const exact = expectedCurrentUrls.length && !missing.length && !duplicates.length && !invalid.length && !unexpected.length
     && redirects.size === expectedPairs.size;
   return {
     status: exact ? 'pass' : 'fail',
-    expected: currentUrls.length,
-    covered: currentUrls.length - missing.length,
+    expected: expectedCurrentUrls.length,
+    covered: expectedCurrentUrls.length - missing.length,
     missing,
     duplicates,
     invalid,
@@ -298,6 +327,7 @@ function auditMigrationReadiness(options = {}) {
   const repoRoot = path.resolve(options.repoRoot || path.resolve(__dirname, '..', '..'));
   const errors = [];
   const sitemapPath = path.resolve(repoRoot, options.sitemapPath || 'apps/web-app/public/sitemap.xml');
+  const skillsIndexPath = path.resolve(repoRoot, options.skillsIndexPath || 'skills_index.json');
   const snapshotRoot = path.resolve(repoRoot, options.snapshotRoot || '.codex/traffic-snapshots');
   const currentPackagePath = path.resolve(repoRoot, options.currentPackagePath || 'package.json');
   const asOfDate = options.asOfDate || new Date().toISOString().slice(0, 10);
@@ -307,6 +337,8 @@ function auditMigrationReadiness(options = {}) {
   const currentUrls = parseSitemap(sitemapPath, errors);
   const currentPagesUrl = withTrailingSlash(options.currentPagesUrl || DEFAULT_CURRENT_PAGES_URL);
   const legacyPagesUrl = withTrailingSlash(options.legacyPagesUrl || DEFAULT_LEGACY_PAGES_URL || inferLegacyPagesUrl(currentPagesUrl));
+  const currentSkillUrls = currentPagesUrl ? parseSkillUrls(skillsIndexPath, currentPagesUrl, errors) : [];
+  const expectedRedirectUrls = [...new Set([...currentUrls, ...currentSkillUrls])].sort();
   const identitiesDistinct = Boolean(currentPagesUrl && legacyPagesUrl && currentPagesUrl !== legacyPagesUrl);
   const currentSitemap = {
     status: identitiesDistinct && currentUrls.includes(currentPagesUrl) && currentUrls.every((url) => url.startsWith(currentPagesUrl)) ? 'pass' : 'fail',
@@ -328,7 +360,7 @@ function auditMigrationReadiness(options = {}) {
     google_search_console: dashboardEvidence(snapshotRoot, DASHBOARD_FILES.gsc, currentPagesUrl, legacyPagesUrl, errors, asOfDate, maxEvidenceAgeDays),
     bing_webmaster: dashboardEvidence(snapshotRoot, DASHBOARD_FILES.bing, currentPagesUrl, legacyPagesUrl, errors, asOfDate, maxEvidenceAgeDays),
     redirect_manifest_coverage: redirectCoverage(
-      options.redirectManifestPath && path.resolve(repoRoot, options.redirectManifestPath), currentUrls, currentPagesUrl, legacyPagesUrl, errors,
+      options.redirectManifestPath && path.resolve(repoRoot, options.redirectManifestPath), expectedRedirectUrls, currentPagesUrl, legacyPagesUrl, errors,
     ),
     npm_identities: packageIdentity(
       currentPackagePath,
@@ -368,6 +400,7 @@ function parseArgs(argv) {
   const options = {};
   const aliases = {
     '--repo-root': 'repoRoot', '--snapshot-root': 'snapshotRoot', '--sitemap': 'sitemapPath',
+    '--skills-index': 'skillsIndexPath',
     '--redirect-manifest': 'redirectManifestPath', '--current-package': 'currentPackagePath',
     '--legacy-package': 'legacyPackagePath', '--current-pages-url': 'currentPagesUrl',
     '--legacy-pages-url': 'legacyPagesUrl', '--current-package-name': 'currentPackageName', '--output': 'outputPath',

--- a/tools/scripts/generate-pages-redirect-bridge.js
+++ b/tools/scripts/generate-pages-redirect-bridge.js
@@ -7,10 +7,16 @@ const path = require('path');
 
 const REPO_ROOT = path.resolve(__dirname, '..', '..');
 const DEFAULT_SITEMAP = path.join(REPO_ROOT, 'apps', 'web-app', 'public', 'sitemap.xml');
+const DEFAULT_SKILLS_INDEX = path.join(REPO_ROOT, 'skills_index.json');
 const DEFAULT_CURRENT_BASE = 'https://sickn33.github.io/agentic-awesome-skills/';
 const DEFAULT_LEGACY_BASE = 'https://sickn33.github.io/antigravity-awesome-skills/';
 const DEFAULT_EXPECTED_ROUTES = 187;
+const DEFAULT_EXPECTED_SKILLS = 1965;
 const SAFE_SEGMENT = /^[A-Za-z0-9._~-]+$/;
+
+function isSafeSegment(value) {
+  return typeof value === 'string' && value !== '.' && value !== '..' && SAFE_SEGMENT.test(value);
+}
 
 function sha256(value) {
   return crypto.createHash('sha256').update(value).digest('hex');
@@ -61,6 +67,25 @@ function parseSitemap(source) {
   return rawLocations;
 }
 
+function parseSkillIds(source) {
+  let payload;
+  try {
+    payload = JSON.parse(source);
+  } catch (error) {
+    throw new Error(`skills index is not valid JSON: ${error.message}`);
+  }
+  if (!Array.isArray(payload) || !payload.length) throw new Error('skills index must be a non-empty array');
+  const ids = payload.map((entry, index) => {
+    const id = entry && entry.id;
+    if (!id || !isSafeSegment(id)) {
+      throw new Error(`skills index entry ${index} has an unsafe or missing id`);
+    }
+    return id;
+  });
+  if (new Set(ids).size !== ids.length) throw new Error('skills index contains duplicate ids');
+  return ids;
+}
+
 function safeRelativeRoute(currentUrl, currentBase) {
   if (currentUrl.protocol !== 'https:' || currentUrl.origin !== currentBase.origin || currentUrl.search || currentUrl.hash) {
     throw new Error(`sitemap URL is outside the current HTTPS identity: ${currentUrl.toString()}`);
@@ -71,7 +96,7 @@ function safeRelativeRoute(currentUrl, currentBase) {
   const relative = currentUrl.pathname.slice(currentBase.pathname.length);
   const segments = relative.split('/').filter(Boolean);
   for (const segment of segments) {
-    if (segment === '.' || segment === '..' || !SAFE_SEGMENT.test(segment)) {
+    if (!isSafeSegment(segment)) {
       throw new Error(`sitemap URL contains an unsafe path segment: ${currentUrl.toString()}`);
     }
   }
@@ -81,7 +106,7 @@ function safeRelativeRoute(currentUrl, currentBase) {
 function outputRelativePath(legacyBase, relativeRoute) {
   const baseSegments = legacyBase.pathname.split('/').filter(Boolean);
   for (const segment of baseSegments) {
-    if (segment === '.' || segment === '..' || !SAFE_SEGMENT.test(segment)) {
+    if (!isSafeSegment(segment)) {
       throw new Error('legacy base contains an unsafe path segment');
     }
   }
@@ -165,7 +190,7 @@ function assertSafeOutput(outputDirectory, repoRoot) {
   }
 }
 
-function writeBridge(stagingDirectory, redirects, manifest, legacyBase) {
+function writeBridge(stagingDirectory, redirects, sitemapRedirects, manifest, legacyBase) {
   for (const redirect of redirects) {
     const filePath = path.join(stagingDirectory, ...redirect.output_file.split('/'));
     fs.mkdirSync(path.dirname(filePath), { recursive: true });
@@ -173,7 +198,7 @@ function writeBridge(stagingDirectory, redirects, manifest, legacyBase) {
   }
   const legacyDirectory = path.join(stagingDirectory, ...legacyBase.pathname.split('/').filter(Boolean));
   fs.mkdirSync(legacyDirectory, { recursive: true });
-  fs.writeFileSync(path.join(legacyDirectory, 'sitemap.xml'), legacySitemap(redirects), 'utf8');
+  fs.writeFileSync(path.join(legacyDirectory, 'sitemap.xml'), legacySitemap(sitemapRedirects), 'utf8');
   fs.writeFileSync(path.join(stagingDirectory, 'redirect-manifest.json'), `${JSON.stringify(manifest, null, 2)}\n`, 'utf8');
   fs.writeFileSync(path.join(stagingDirectory, '.nojekyll'), '', 'utf8');
 }
@@ -181,6 +206,7 @@ function writeBridge(stagingDirectory, redirects, manifest, legacyBase) {
 function generateBridge(options) {
   const repoRoot = path.resolve(options.repoRoot || REPO_ROOT);
   const sitemapPath = path.resolve(options.sitemapPath || DEFAULT_SITEMAP);
+  const skillsIndexPath = path.resolve(options.skillsIndexPath || DEFAULT_SKILLS_INDEX);
   if (!options.outputDirectory) throw new Error('--output is required');
   const outputDirectory = path.resolve(options.outputDirectory);
   const currentBase = canonicalBase(options.currentBase || DEFAULT_CURRENT_BASE, 'current base');
@@ -188,17 +214,42 @@ function generateBridge(options) {
   if (currentBase.toString() === legacyBase.toString()) throw new Error('current and legacy bases must be distinct');
   const expectedRoutes = Number(options.expectedRoutes ?? DEFAULT_EXPECTED_ROUTES);
   if (!Number.isSafeInteger(expectedRoutes) || expectedRoutes <= 0) throw new Error('expected route count must be a positive integer');
+  const expectedSkills = Number(options.expectedSkills ?? DEFAULT_EXPECTED_SKILLS);
+  if (!Number.isSafeInteger(expectedSkills) || expectedSkills <= 0) throw new Error('expected skill count must be a positive integer');
   assertSafeOutput(outputDirectory, repoRoot);
 
   const sitemapSource = fs.readFileSync(sitemapPath, 'utf8');
+  const skillsIndexSource = fs.readFileSync(skillsIndexPath, 'utf8');
   const locations = parseSitemap(sitemapSource);
+  const skillIds = parseSkillIds(skillsIndexSource);
   if (locations.length !== expectedRoutes) {
     throw new Error(`sitemap route count ${locations.length} does not match locked expectation ${expectedRoutes}`);
   }
+  if (skillIds.length !== expectedSkills) {
+    throw new Error(`skills index count ${skillIds.length} does not match locked expectation ${expectedSkills}`);
+  }
 
-  const redirects = locations.map((location) => {
+  const skillIdSet = new Set(skillIds);
+  const sitemapRoutes = locations.map((location) => {
     const currentUrl = new URL(location);
     const relativeRoute = safeRelativeRoute(currentUrl, currentBase);
+    const segments = relativeRoute.split('/');
+    if (segments[0] === 'skill' && (segments.length !== 2 || !skillIdSet.has(segments[1]))) {
+      throw new Error(`sitemap skill route is absent from the current skills index: ${currentUrl.toString()}`);
+    }
+    return { currentUrl, relativeRoute };
+  });
+  const normalisedSitemapUrls = sitemapRoutes.map(({ currentUrl }) => currentUrl.toString());
+  if (new Set(normalisedSitemapUrls).size !== normalisedSitemapUrls.length) {
+    throw new Error('sitemap contains duplicate URLs after normalization');
+  }
+  const allRoutes = new Map(sitemapRoutes.map(({ currentUrl, relativeRoute }) => [currentUrl.toString(), { currentUrl, relativeRoute }]));
+  for (const id of skillIds) {
+    const currentUrl = new URL(`skill/${id}/`, currentBase);
+    allRoutes.set(currentUrl.toString(), { currentUrl, relativeRoute: `skill/${id}` });
+  }
+
+  const toRedirect = ({ currentUrl, relativeRoute }) => {
     const from = new URL(relativeRoute ? `${relativeRoute}/` : '', legacyBase).toString();
     const to = currentUrl.toString();
     return {
@@ -206,7 +257,9 @@ function generateBridge(options) {
       to,
       output_file: outputRelativePath(legacyBase, relativeRoute),
     };
-  });
+  };
+  const redirects = [...allRoutes.values()].map(toRedirect);
+  const sitemapRedirects = sitemapRoutes.map(toRedirect).sort((left, right) => left.from.localeCompare(right.from));
   if (!redirects.some(({ to }) => to === currentBase.toString())) throw new Error('sitemap does not contain the current root route');
   if (new Set(redirects.map(({ from }) => from)).size !== redirects.length) throw new Error('legacy mapping is not one-to-one');
   if (new Set(redirects.map(({ output_file }) => output_file)).size !== redirects.length) throw new Error('multiple routes map to the same output file');
@@ -218,13 +271,18 @@ function generateBridge(options) {
   }
 
   const manifest = {
-    schema_version: 1,
+    schema_version: 2,
     deployment_scope: 'separate GitHub Pages user-site subdirectory',
     not_for_current_project_pages: true,
     source_sitemap_sha256: sha256(sitemapSource),
+    source_skills_index_sha256: sha256(skillsIndexSource),
     current_base: currentBase.toString(),
     legacy_base: legacyBase.toString(),
+    source_sitemap_route_count: locations.length,
+    current_skill_route_count: skillIds.length,
     route_count: redirects.length,
+    legacy_sitemap_route_count: sitemapRedirects.length,
+    legacy_sitemap_policy: 'curated current sitemap routes only',
     legacy_sitemap: legacySitemapPath,
     redirects,
   };
@@ -233,7 +291,7 @@ function generateBridge(options) {
   let stagingDirectory = null;
   try {
     stagingDirectory = fs.mkdtempSync(path.join(path.dirname(outputDirectory), `.${path.basename(outputDirectory)}.${process.pid}.`));
-    writeBridge(stagingDirectory, redirects, manifest, legacyBase);
+    writeBridge(stagingDirectory, redirects, sitemapRedirects, manifest, legacyBase);
     fs.renameSync(stagingDirectory, outputDirectory);
   } finally {
     if (stagingDirectory && fs.existsSync(stagingDirectory)) fs.rmSync(stagingDirectory, { recursive: true, force: true });
@@ -246,9 +304,11 @@ function parseArgs(argv) {
   const aliases = {
     '--output': 'outputDirectory',
     '--sitemap': 'sitemapPath',
+    '--skills-index': 'skillsIndexPath',
     '--current-base': 'currentBase',
     '--legacy-base': 'legacyBase',
     '--expected-routes': 'expectedRoutes',
+    '--expected-skills': 'expectedSkills',
   };
   for (let index = 0; index < argv.length; index += 1) {
     const arg = argv[index];
@@ -268,7 +328,7 @@ function parseArgs(argv) {
 function main() {
   const options = parseArgs(process.argv.slice(2));
   if (options.help) {
-    process.stdout.write('Usage: node tools/scripts/generate-pages-redirect-bridge.js --output NEW_DIR [--sitemap FILE] [--expected-routes N]\n');
+    process.stdout.write('Usage: node tools/scripts/generate-pages-redirect-bridge.js --output NEW_DIR [--sitemap FILE] [--skills-index FILE] [--expected-routes N] [--expected-skills N]\n');
     return;
   }
   const manifest = generateBridge(options);
@@ -288,6 +348,7 @@ module.exports = {
   generateBridge,
   htmlEscape,
   parseArgs,
+  parseSkillIds,
   parseSitemap,
   redirectHtml,
 };

--- a/tools/scripts/tests/audit_search_migration_readiness.test.js
+++ b/tools/scripts/tests/audit_search_migration_readiness.test.js
@@ -18,10 +18,12 @@ function fixture({ currentProperties = true, legacyOnly = false, malformed = fal
   const legacy = 'https://example.github.io/antigravity-awesome-skills/';
   fs.mkdirSync(path.join(root, 'apps/web-app/public'), { recursive: true });
   fs.writeFileSync(path.join(root, 'apps/web-app/public/sitemap.xml'), `<?xml version="1.0"?><urlset><url><loc>${current}</loc></url><url><loc>${current}plugins/</loc></url></urlset>`);
+  writeJson(path.join(root, 'skills_index.json'), [{ id: 'catalog-only' }]);
   writeJson(path.join(root, 'package.json'), { name: 'agentic-awesome-skills', version: '14.2.0' });
   writeJson(path.join(root, 'legacy-package.json'), { name: 'antigravity-awesome-skills', version: '13.13.0', deprecated: 'Moved to agentic-awesome-skills' });
   writeJson(path.join(root, 'redirects.json'), { redirects: [
     { from: legacy, to: current }, { from: `${legacy}plugins/`, to: `${current}plugins/` },
+    { from: `${legacy}skill/catalog-only/`, to: `${current}skill/catalog-only/` },
   ] });
   const property = legacyOnly ? legacy : current;
   const snapshot = new Date().toISOString().slice(0, 10);
@@ -172,6 +174,32 @@ function options(root) {
 
 {
   const { root } = fixture();
+  const redirects = JSON.parse(fs.readFileSync(path.join(root, 'redirects.json'), 'utf8'));
+  redirects.redirects = redirects.redirects.filter(({ to }) => !to.endsWith('/skill/catalog-only/'));
+  writeJson(path.join(root, 'redirects.json'), redirects);
+  const report = auditMigrationReadiness(options(root));
+  assert.strictEqual(report.status, 'not_ready', 'every current catalog skill requires an exact redirect');
+  assert.deepStrictEqual(report.checks.redirect_manifest_coverage.missing, ['https://example.github.io/agentic-awesome-skills/skill/catalog-only/']);
+}
+
+for (const unsafeId of ['../escape', '.', '..']) {
+  const { root } = fixture();
+  writeJson(path.join(root, 'skills_index.json'), [{ id: unsafeId }]);
+  const report = auditMigrationReadiness(options(root));
+  assert.strictEqual(report.status, 'not_ready', `unsafe catalog id ${unsafeId} must fail closed`);
+  assert(report.errors.some((error) => error.includes('unsafe or missing id')));
+}
+
+{
+  const { root, current } = fixture();
+  fs.writeFileSync(path.join(root, 'apps/web-app/public/sitemap.xml'), `<?xml version="1.0"?><urlset><url><loc>${current}</loc></url><url><loc>https://EXAMPLE.github.io:443/agentic-awesome-skills/</loc></url></urlset>`);
+  const report = auditMigrationReadiness(options(root));
+  assert.strictEqual(report.status, 'not_ready', 'normalized duplicate sitemap URLs must fail closed');
+  assert(report.errors.some((error) => error.includes('duplicate URLs after normalization')));
+}
+
+{
+  const { root } = fixture();
   fs.writeFileSync(path.join(root, 'apps/web-app/public/sitemap.xml'), '<?xml version="1.0"?><urlset><url><loc>https://evil.example/not-the-project/</loc></url></urlset>');
   writeJson(path.join(root, 'package.json'), { name: 'unrelated-package', version: '1.0.0' });
   const report = auditMigrationReadiness({ ...options(root), currentPagesUrl: undefined, legacyPagesUrl: undefined, currentPackageName: undefined });
@@ -185,7 +213,7 @@ function options(root) {
   const report = auditMigrationReadiness(options(root));
   assert.strictEqual(report.status, 'ready');
   assert.deepStrictEqual(report.failed_checks, []);
-  assert.strictEqual(report.checks.redirect_manifest_coverage.covered, 2);
+  assert.strictEqual(report.checks.redirect_manifest_coverage.covered, 3);
 }
 
 {

--- a/tools/scripts/tests/generate_pages_redirect_bridge.test.js
+++ b/tools/scripts/tests/generate_pages_redirect_bridge.test.js
@@ -9,11 +9,30 @@ const { generateBridge } = require(scriptPath);
 
 const fixtureRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'pages-redirect-bridge-'));
 const sitemapPath = path.join(fixtureRoot, 'sitemap.xml');
+const skillsIndexPath = path.join(fixtureRoot, 'skills_index.json');
 const current = 'https://example.github.io/agentic-awesome-skills/';
 const legacy = 'https://example.github.io/antigravity-awesome-skills/';
 
 function sitemap(locations) {
   return `<?xml version="1.0"?><urlset>${locations.map((location) => `<url><loc>${location}</loc></url>`).join('')}</urlset>`;
+}
+
+function writeSkills(filePath, ids) {
+  fs.writeFileSync(filePath, `${JSON.stringify(ids.map((id) => ({ id })), null, 2)}\n`, 'utf8');
+}
+
+function bridgeOptions(outputDirectory, overrides = {}) {
+  return {
+    repoRoot: fixtureRoot,
+    sitemapPath,
+    skillsIndexPath,
+    outputDirectory,
+    currentBase: current,
+    legacyBase: legacy,
+    expectedRoutes: 4,
+    expectedSkills: 2,
+    ...overrides,
+  };
 }
 
 function readTree(root) {
@@ -32,96 +51,99 @@ function readTree(root) {
 try {
   const locations = [current, `${current}plugins/`, `${current}topics/github-ai-skills-repository/`, `${current}skill/brainstorming/`];
   fs.writeFileSync(sitemapPath, sitemap(locations), 'utf8');
+  writeSkills(skillsIndexPath, ['brainstorming', 'catalog-only']);
+
   const outputOne = path.join(fixtureRoot, '.codex', 'bridge-one');
-  const manifest = generateBridge({
-    repoRoot: fixtureRoot,
-    sitemapPath,
-    outputDirectory: outputOne,
-    currentBase: current,
-    legacyBase: legacy,
-    expectedRoutes: 4,
-  });
-  assert.strictEqual(manifest.route_count, 4);
-  assert.strictEqual(manifest.redirects.length, 4);
-  assert.strictEqual(new Set(manifest.redirects.map((redirect) => redirect.from)).size, 4);
-  assert.strictEqual(new Set(manifest.redirects.map((redirect) => redirect.output_file)).size, 4);
+  const manifest = generateBridge(bridgeOptions(outputOne));
+  assert.strictEqual(manifest.schema_version, 2);
+  assert.strictEqual(manifest.source_sitemap_route_count, 4);
+  assert.strictEqual(manifest.current_skill_route_count, 2);
+  assert.strictEqual(manifest.route_count, 5);
+  assert.strictEqual(manifest.legacy_sitemap_route_count, 4);
+  assert.strictEqual(manifest.redirects.length, 5);
+  assert.strictEqual(new Set(manifest.redirects.map((redirect) => redirect.from)).size, 5);
+  assert.strictEqual(new Set(manifest.redirects.map((redirect) => redirect.output_file)).size, 5);
 
   for (const relative of [
     'antigravity-awesome-skills/index.html',
     'antigravity-awesome-skills/plugins/index.html',
     'antigravity-awesome-skills/topics/github-ai-skills-repository/index.html',
     'antigravity-awesome-skills/skill/brainstorming/index.html',
+    'antigravity-awesome-skills/skill/catalog-only/index.html',
   ]) {
     assert(fs.existsSync(path.join(outputOne, relative)), `missing generated route: ${relative}`);
   }
+  assert(!fs.existsSync(path.join(outputOne, 'antigravity-awesome-skills/skill/removed-skill/index.html')));
+  assert(!manifest.redirects.some(({ from }) => from === `${legacy}skill/removed-skill/`));
+
   const pluginHtml = fs.readFileSync(path.join(outputOne, 'antigravity-awesome-skills/plugins/index.html'), 'utf8');
   assert.match(pluginHtml, /http-equiv="refresh" content="0; url=https:\/\/example\.github\.io\/agentic-awesome-skills\/plugins\/"/);
   assert.match(pluginHtml, /rel="canonical" href="https:\/\/example\.github\.io\/agentic-awesome-skills\/plugins\/"/);
   assert.match(pluginHtml, /<a href="https:\/\/example\.github\.io\/agentic-awesome-skills\/plugins\/">/);
-  assert.strictEqual((fs.readFileSync(path.join(outputOne, 'antigravity-awesome-skills/sitemap.xml'), 'utf8').match(/<loc>/g) || []).length, 4);
+  const legacySitemapSource = fs.readFileSync(path.join(outputOne, 'antigravity-awesome-skills/sitemap.xml'), 'utf8');
+  assert.strictEqual((legacySitemapSource.match(/<loc>/g) || []).length, 4, 'legacy sitemap stays on the curated source sitemap');
+  assert(!legacySitemapSource.includes('/skill/catalog-only/'), 'catalog-only redirects must not expand crawler discovery');
 
   const outputTwo = path.join(fixtureRoot, '.codex', 'bridge-two');
-  generateBridge({
-    repoRoot: fixtureRoot,
-    sitemapPath,
-    outputDirectory: outputTwo,
-    currentBase: current,
-    legacyBase: legacy,
-    expectedRoutes: 4,
-  });
+  generateBridge(bridgeOptions(outputTwo));
   assert.deepStrictEqual(readTree(outputTwo), readTree(outputOne), 'identical input produces byte-identical output');
 
-  assert.throws(() => generateBridge({
-    repoRoot: fixtureRoot,
-    sitemapPath,
-    outputDirectory: outputOne,
-    currentBase: current,
-    legacyBase: legacy,
-    expectedRoutes: 4,
-  }), /output path already exists/);
+  assert.throws(() => generateBridge(bridgeOptions(outputOne)), /output path already exists/);
 
   const foreignSitemap = path.join(fixtureRoot, 'foreign.xml');
   fs.writeFileSync(foreignSitemap, sitemap([current, 'https://attacker.example/skill/escape/']), 'utf8');
-  assert.throws(() => generateBridge({
-    repoRoot: fixtureRoot,
+  assert.throws(() => generateBridge(bridgeOptions(path.join(fixtureRoot, '.codex', 'foreign'), {
     sitemapPath: foreignSitemap,
-    outputDirectory: path.join(fixtureRoot, '.codex', 'foreign'),
-    currentBase: current,
-    legacyBase: legacy,
     expectedRoutes: 2,
-  }), /outside the current HTTPS identity/);
+  })), /outside the current HTTPS identity/);
 
   const duplicateSitemap = path.join(fixtureRoot, 'duplicate.xml');
   fs.writeFileSync(duplicateSitemap, sitemap([current, current]), 'utf8');
-  assert.throws(() => generateBridge({
-    repoRoot: fixtureRoot,
+  assert.throws(() => generateBridge(bridgeOptions(path.join(fixtureRoot, '.codex', 'duplicate'), {
     sitemapPath: duplicateSitemap,
-    outputDirectory: path.join(fixtureRoot, '.codex', 'duplicate'),
-    currentBase: current,
-    legacyBase: legacy,
     expectedRoutes: 2,
-  }), /duplicate/);
+  })), /duplicate/);
+
+  const normalizedDuplicateSitemap = path.join(fixtureRoot, 'normalized-duplicate.xml');
+  fs.writeFileSync(normalizedDuplicateSitemap, sitemap([current, 'https://EXAMPLE.github.io:443/agentic-awesome-skills/']), 'utf8');
+  assert.throws(() => generateBridge(bridgeOptions(path.join(fixtureRoot, '.codex', 'normalized-duplicate'), {
+    sitemapPath: normalizedDuplicateSitemap,
+    expectedRoutes: 2,
+  })), /duplicate URLs after normalization/);
 
   const doubleEncodedSitemap = path.join(fixtureRoot, 'double-encoded.xml');
   fs.writeFileSync(doubleEncodedSitemap, sitemap([current, `${current}skill/&amp;lt;escape/`]), 'utf8');
-  assert.throws(() => generateBridge({
-    repoRoot: fixtureRoot,
+  assert.throws(() => generateBridge(bridgeOptions(path.join(fixtureRoot, '.codex', 'double-encoded'), {
     sitemapPath: doubleEncodedSitemap,
-    outputDirectory: path.join(fixtureRoot, '.codex', 'double-encoded'),
-    currentBase: current,
-    legacyBase: legacy,
     expectedRoutes: 2,
-  }), /unsafe path segment/, 'XML entities must be decoded exactly once');
+  })), /unsafe path segment/, 'XML entities must be decoded exactly once');
+
+  const orphanSitemap = path.join(fixtureRoot, 'orphan.xml');
+  fs.writeFileSync(orphanSitemap, sitemap([current, `${current}skill/removed-skill/`]), 'utf8');
+  assert.throws(() => generateBridge(bridgeOptions(path.join(fixtureRoot, '.codex', 'orphan'), {
+    sitemapPath: orphanSitemap,
+    expectedRoutes: 2,
+  })), /absent from the current skills index/);
+
+  for (const [name, entries, pattern] of [
+    ['duplicate-skills', [{ id: 'brainstorming' }, { id: 'brainstorming' }], /duplicate ids/],
+    ['unsafe-skills', [{ id: 'brainstorming' }, { id: '../escape' }], /unsafe or missing id/],
+    ['missing-skills', [{ id: 'brainstorming' }, {}], /unsafe or missing id/],
+    ['dot-skill', [{ id: 'brainstorming' }, { id: '.' }], /unsafe or missing id/],
+    ['dot-dot-skill', [{ id: 'brainstorming' }, { id: '..' }], /unsafe or missing id/],
+  ]) {
+    const invalidSkillsIndex = path.join(fixtureRoot, `${name}.json`);
+    fs.writeFileSync(invalidSkillsIndex, JSON.stringify(entries), 'utf8');
+    assert.throws(() => generateBridge(bridgeOptions(path.join(fixtureRoot, '.codex', name), {
+      skillsIndexPath: invalidSkillsIndex,
+    })), pattern);
+  }
+  assert.throws(() => generateBridge(bridgeOptions(path.join(fixtureRoot, '.codex', 'skill-count'), {
+    expectedSkills: 3,
+  })), /skills index count 2 does not match locked expectation 3/);
 
   const trackedOutput = path.join(fixtureRoot, 'apps', 'web-app', 'public', 'bridge');
-  assert.throws(() => generateBridge({
-    repoRoot: fixtureRoot,
-    sitemapPath,
-    outputDirectory: trackedOutput,
-    currentBase: current,
-    legacyBase: legacy,
-    expectedRoutes: 4,
-  }), /only under ignored \.codex/);
+  assert.throws(() => generateBridge(bridgeOptions(trackedOutput)), /only under ignored \.codex/);
 
   const symlinkRepo = path.join(fixtureRoot, 'symlink-repo');
   const trackedPublic = path.join(symlinkRepo, 'apps', 'web-app', 'public');
@@ -129,13 +151,18 @@ try {
   const symlinkSitemap = path.join(symlinkRepo, 'sitemap.xml');
   fs.writeFileSync(symlinkSitemap, sitemap(locations), 'utf8');
   fs.symlinkSync(trackedPublic, path.join(symlinkRepo, '.codex'));
-  assert.throws(() => generateBridge({
+  const symlinkOptions = {
     repoRoot: symlinkRepo,
     sitemapPath: symlinkSitemap,
-    outputDirectory: path.join(symlinkRepo, '.codex', 'bridge'),
+    skillsIndexPath,
     currentBase: current,
     legacyBase: legacy,
     expectedRoutes: 4,
+    expectedSkills: 2,
+  };
+  assert.throws(() => generateBridge({
+    ...symlinkOptions,
+    outputDirectory: path.join(symlinkRepo, '.codex', 'bridge'),
   }), /symlink|physical output/);
   assert(!fs.existsSync(path.join(trackedPublic, 'bridge')), 'a .codex symlink cannot redirect writes into tracked public files');
 
@@ -143,12 +170,8 @@ try {
   try {
     fs.symlinkSync(trackedPublic, path.join(outsideRoot, 'linked-public'));
     assert.throws(() => generateBridge({
-      repoRoot: symlinkRepo,
-      sitemapPath: symlinkSitemap,
+      ...symlinkOptions,
       outputDirectory: path.join(outsideRoot, 'linked-public', 'bridge'),
-      currentBase: current,
-      legacyBase: legacy,
-      expectedRoutes: 4,
     }), /physical output resolves inside the repository/);
     assert(!fs.existsSync(path.join(trackedPublic, 'bridge')));
   } finally {
@@ -158,28 +181,22 @@ try {
   const sentinelDirectory = path.join(path.dirname(outputOne), `.${path.basename(outputOne)}.${process.pid}.sentinel`);
   fs.mkdirSync(sentinelDirectory);
   fs.writeFileSync(path.join(sentinelDirectory, 'KEEP'), 'owned by another process', 'utf8');
-  const outputThree = path.join(fixtureRoot, '.codex', 'bridge-three');
-  generateBridge({
-    repoRoot: fixtureRoot,
-    sitemapPath,
-    outputDirectory: outputThree,
-    currentBase: current,
-    legacyBase: legacy,
-    expectedRoutes: 4,
-  });
+  generateBridge(bridgeOptions(path.join(fixtureRoot, '.codex', 'bridge-three')));
   assert.strictEqual(fs.readFileSync(path.join(sentinelDirectory, 'KEEP'), 'utf8'), 'owned by another process');
 
   const cliOutput = path.join(fixtureRoot, '.codex', 'cli');
   const cli = spawnSync(process.execPath, [
     scriptPath,
     '--sitemap', sitemapPath,
+    '--skills-index', skillsIndexPath,
     '--output', cliOutput,
     '--current-base', current,
     '--legacy-base', legacy,
     '--expected-routes', '4',
+    '--expected-skills', '2',
   ], { encoding: 'utf8' });
   assert.strictEqual(cli.status, 0, cli.stderr);
-  assert.match(cli.stdout, /Generated 4 redirect pages/);
+  assert.match(cli.stdout, /Generated 5 redirect pages/);
 
   const missingOutput = spawnSync(process.execPath, [scriptPath, '--sitemap', sitemapPath], { encoding: 'utf8' });
   assert.strictEqual(missingOutput.status, 1);
@@ -187,18 +204,20 @@ try {
 
   const productionOutputRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'pages-redirect-production-'));
   try {
-    const productionSitemapPath = path.join(productionOutputRoot, 'sitemap.xml');
-    const productionBase = 'https://sickn33.github.io/agentic-awesome-skills/';
-    const productionUrls = [
-      productionBase,
-      ...Array.from({ length: 186 }, (_, index) => `${productionBase}skill/production-${index + 1}/`),
-    ];
-    fs.writeFileSync(productionSitemapPath, sitemap(productionUrls), 'utf8');
-    const productionManifest = generateBridge({
-      sitemapPath: productionSitemapPath,
-      outputDirectory: path.join(productionOutputRoot, 'bridge'),
-    });
-    assert.strictEqual(productionManifest.route_count, 187);
+    const productionOutput = path.join(productionOutputRoot, 'bridge');
+    const productionManifest = generateBridge({ outputDirectory: productionOutput });
+    assert.strictEqual(productionManifest.source_sitemap_route_count, 187);
+    assert.strictEqual(productionManifest.current_skill_route_count, 1965);
+    assert.strictEqual(productionManifest.route_count, 1972);
+    assert.strictEqual(productionManifest.legacy_sitemap_route_count, 187);
+    const productionSkills = JSON.parse(fs.readFileSync(path.resolve(__dirname, '..', '..', '..', 'skills_index.json'), 'utf8'));
+    const expectedSkillUrls = new Set(productionSkills.map(({ id }) => `https://sickn33.github.io/agentic-awesome-skills/skill/${id}/`));
+    const actualSkillUrls = new Set(productionManifest.redirects.map(({ to }) => to).filter((url) => url.includes('/skill/')));
+    assert.deepStrictEqual(actualSkillUrls, expectedSkillUrls, 'production bridge must cover exactly every current skill id');
+    assert(!productionManifest.redirects.some(({ to }) => to.endsWith('/skill/goldrush-api/')));
+    assert(!productionManifest.redirects.some(({ to }) => to.endsWith('/skill/merge-batch-e2e-test/')));
+    const productionLegacySitemap = fs.readFileSync(path.join(productionOutput, 'antigravity-awesome-skills/sitemap.xml'), 'utf8');
+    assert.strictEqual((productionLegacySitemap.match(/<loc>/g) || []).length, 187);
   } finally {
     fs.rmSync(productionOutputRoot, { recursive: true, force: true });
   }


### PR DESCRIPTION
# Pull Request Description

Expands the separate legacy GitHub Pages bridge from the curated 187-route sitemap subset to exact one-to-one coverage for every current catalog skill. The generator now combines all 1,965 current skill IDs with the seven structural sitemap routes, producing 1,972 redirect pages while deliberately keeping the legacy sitemap limited to the same 187 curated discovery URLs.

The migration-readiness audit now enforces that exact catalog-plus-structure set. Removed IDs remain excluded because `skills_index.json` is the only skill source of truth.

## Change Classification

- [ ] Skill PR
- [ ] Docs PR
- [x] Infra PR

## Issue Link (Optional)

N/A

## Quality Bar Checklist ✅

- [x] **Standards**: I have read `docs/contributors/quality-bar.md` and `docs/contributors/security-guardrails.md`.
- [x] **Metadata**: Not applicable; no `SKILL.md` files changed. `npm run validate` passes for all 1,965 skills.
- [x] **Risk Label**: Not applicable; no skill content changed.
- [x] **Triggers**: Not applicable; no skill content changed.
- [x] **Limitations**: Not applicable; no skill content changed.
- [x] **Security**: Not applicable; no offensive skill content changed.
- [x] **Safety scan**: `npm run security:docs` passes.
- [x] **Automated Skill Review**: Not applicable; no `SKILL.md` files changed.
- [x] **Manual Logic Review**: Exact route membership, removed-ID exclusion, path safety, URL normalization, sitemap policy, hashes, and atomic output were manually reviewed.
- [x] **Local Test**: Root suite, 140 app tests, app build/prerender, generator production proof, and migration-readiness regressions pass.
- [x] **Repo Checks**: `npm run validate:references`, `npm run check:warning-budget`, and `npm run lint:workflows` pass.
- [x] **Source-Only PR**: No generated registry, sitemap, or redirect deployment artifact is included.
- [x] **Credits**: Not applicable; no external content added.
- [x] **License provenance**: Not applicable; no external source imported.
- [x] **Maintainer Edits**: Enabled.

## Screenshots (if applicable)

Not applicable; this changes a maintainer generator and readiness audit, not the current-site UI.

## Verification

- `npm run validate`
- `npm run test`
- `npm run security:docs`
- `npm run validate:references`
- `npm run check:warning-budget`
- `npm run lint:workflows`
- `npm audit --audit-level=high`
- `npm run app:test` (19 files, 140 tests)
- `npm run app:build`
- `npm run pages:redirect-bridge -- --output .codex/full-legacy-route-bridge-final`

Generated proof: 1,972 redirect pages = 1,965 exact current skill routes + 7 structural routes; legacy sitemap remains 187 URLs; removed IDs `goldrush-api` and `merge-batch-e2e-test` are absent.