### PR TITLE
fix: harden legacy redirect infrastructure

### DIFF
--- a/docs/maintainers/legacy-redirect-bridge.md
+++ b/docs/maintainers/legacy-redirect-bridge.md
@@ -1,0 +1,44 @@
+# Legacy Redirect Bridge
+
+The compatibility site at `https://sickn33.github.io/antigravity-awesome-skills/` is published from the separate `sickn33/sickn33.github.io` repository. It preserves old indexed URLs while the canonical site lives at `https://sickn33.github.io/agentic-awesome-skills/`.
+
+## Managed deployment surface
+
+Only these paths belong to the redirect generator:
+
+- `.nojekyll`
+- `redirect-manifest.json`
+- `antigravity-awesome-skills/**`
+
+The target repository's `README.md` and `.github/**` automation are deliberately outside that managed set.
+
+Generate a fresh bridge from the current catalog:
+
+```bash
+npm run pages:redirect-bridge -- --output /new/output/directory
+```
+
+The generator keeps the curated sitemap route count locked while deriving the skill count from `skills_index.json`. It also preserves the legacy Google verification file and the Bing verification meta tag on the legacy root page.
+
+Verify a checked-out target repository byte-for-byte:
+
+```bash
+npm run pages:redirect-verify -- --deployment-root /path/to/sickn33.github.io
+```
+
+Add a bounded live probe after deployment:
+
+```bash
+npm run pages:redirect-verify -- \
+  --deployment-root /path/to/sickn33.github.io \
+  --live-root https://sickn33.github.io/ \
+  --live-mode sample
+```
+
+Use `--live-mode all` for a complete route-pair audit.
+
+## Publication contract
+
+The target repository owns the scheduled synchronization workflow. It checks out this repository at `main`, regenerates only the managed deployment surface, opens a fixed-branch PR when drift exists, dispatches the exact-head verifier, and merges only after the protected check succeeds. The same run explicitly requests and verifies the legacy Pages build so automation is not dependent on GitHub events suppressed for `GITHUB_TOKEN`-authored changes.
+
+Target `main` must remain protected with strict `legacy-bridge-verify`, administrator enforcement, pull requests required, and force pushes/deletions disabled.

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "check:stale-claims": "node tools/scripts/run-python.js tools/scripts/check_stale_claims.py",
     "check:live-seo": "node tools/scripts/check-live-seo-geo.js",
     "pages:redirect-bridge": "node tools/scripts/generate-pages-redirect-bridge.js",
+    "pages:redirect-verify": "node tools/scripts/verify-pages-redirect-bridge.js",
     "traffic:normalize": "node tools/scripts/normalize_traffic_snapshots.js",
     "traffic:migration-readiness": "node tools/scripts/audit_search_migration_readiness.js",
     "check:warning-budget": "node tools/scripts/run-python.js tools/scripts/check_validation_warning_budget.py",

--- a/tools/scripts/generate-pages-redirect-bridge.js
+++ b/tools/scripts/generate-pages-redirect-bridge.js
@@ -8,10 +8,12 @@ const path = require('path');
 const REPO_ROOT = path.resolve(__dirname, '..', '..');
 const DEFAULT_SITEMAP = path.join(REPO_ROOT, 'apps', 'web-app', 'public', 'sitemap.xml');
 const DEFAULT_SKILLS_INDEX = path.join(REPO_ROOT, 'skills_index.json');
+const GOOGLE_VERIFICATION_FILENAME = 'google5815fd8827d2319c.html';
+const DEFAULT_GOOGLE_VERIFICATION = path.join(REPO_ROOT, 'apps', 'web-app', 'public', GOOGLE_VERIFICATION_FILENAME);
+const BING_VERIFICATION_TOKEN = 'CAC904EB0D2DD1B22B5F2BC540CAD654';
 const DEFAULT_CURRENT_BASE = 'https://sickn33.github.io/agentic-awesome-skills/';
 const DEFAULT_LEGACY_BASE = 'https://sickn33.github.io/antigravity-awesome-skills/';
 const DEFAULT_EXPECTED_ROUTES = 187;
-const DEFAULT_EXPECTED_SKILLS = 1965;
 const SAFE_SEGMENT = /^[A-Za-z0-9._~-]+$/;
 
 function isSafeSegment(value) {
@@ -113,13 +115,16 @@ function outputRelativePath(legacyBase, relativeRoute) {
   return path.posix.join(...baseSegments, relativeRoute, 'index.html');
 }
 
-function redirectHtml(destination) {
+function redirectHtml(destination, options = {}) {
   const escaped = htmlEscape(destination);
+  const bingVerification = options.bingVerificationToken
+    ? `\n    <meta name="msvalidate.01" content="${htmlEscape(options.bingVerificationToken)}">`
+    : '';
   return `<!doctype html>
 <html lang="en">
   <head>
     <meta charset="utf-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta name="viewport" content="width=device-width, initial-scale=1">${bingVerification}
     <meta http-equiv="refresh" content="0; url=${escaped}">
     <link rel="canonical" href="${escaped}">
     <title>Agentic Awesome Skills has moved</title>
@@ -190,15 +195,19 @@ function assertSafeOutput(outputDirectory, repoRoot) {
   }
 }
 
-function writeBridge(stagingDirectory, redirects, sitemapRedirects, manifest, legacyBase) {
+function writeBridge(stagingDirectory, redirects, sitemapRedirects, manifest, legacyBase, googleVerificationSource) {
   for (const redirect of redirects) {
     const filePath = path.join(stagingDirectory, ...redirect.output_file.split('/'));
     fs.mkdirSync(path.dirname(filePath), { recursive: true });
-    fs.writeFileSync(filePath, redirectHtml(redirect.to), 'utf8');
+    const isLegacyRoot = redirect.from === legacyBase.toString();
+    fs.writeFileSync(filePath, redirectHtml(redirect.to, {
+      bingVerificationToken: isLegacyRoot ? BING_VERIFICATION_TOKEN : null,
+    }), 'utf8');
   }
   const legacyDirectory = path.join(stagingDirectory, ...legacyBase.pathname.split('/').filter(Boolean));
   fs.mkdirSync(legacyDirectory, { recursive: true });
   fs.writeFileSync(path.join(legacyDirectory, 'sitemap.xml'), legacySitemap(sitemapRedirects), 'utf8');
+  fs.writeFileSync(path.join(legacyDirectory, GOOGLE_VERIFICATION_FILENAME), googleVerificationSource);
   fs.writeFileSync(path.join(stagingDirectory, 'redirect-manifest.json'), `${JSON.stringify(manifest, null, 2)}\n`, 'utf8');
   fs.writeFileSync(path.join(stagingDirectory, '.nojekyll'), '', 'utf8');
 }
@@ -207,6 +216,7 @@ function generateBridge(options) {
   const repoRoot = path.resolve(options.repoRoot || REPO_ROOT);
   const sitemapPath = path.resolve(options.sitemapPath || DEFAULT_SITEMAP);
   const skillsIndexPath = path.resolve(options.skillsIndexPath || DEFAULT_SKILLS_INDEX);
+  const googleVerificationPath = path.resolve(options.googleVerificationPath || DEFAULT_GOOGLE_VERIFICATION);
   if (!options.outputDirectory) throw new Error('--output is required');
   const outputDirectory = path.resolve(options.outputDirectory);
   const currentBase = canonicalBase(options.currentBase || DEFAULT_CURRENT_BASE, 'current base');
@@ -214,18 +224,25 @@ function generateBridge(options) {
   if (currentBase.toString() === legacyBase.toString()) throw new Error('current and legacy bases must be distinct');
   const expectedRoutes = Number(options.expectedRoutes ?? DEFAULT_EXPECTED_ROUTES);
   if (!Number.isSafeInteger(expectedRoutes) || expectedRoutes <= 0) throw new Error('expected route count must be a positive integer');
-  const expectedSkills = Number(options.expectedSkills ?? DEFAULT_EXPECTED_SKILLS);
-  if (!Number.isSafeInteger(expectedSkills) || expectedSkills <= 0) throw new Error('expected skill count must be a positive integer');
+  const expectedSkills = options.expectedSkills == null ? null : Number(options.expectedSkills);
+  if (expectedSkills != null && (!Number.isSafeInteger(expectedSkills) || expectedSkills <= 0)) {
+    throw new Error('expected skill count must be a positive integer');
+  }
   assertSafeOutput(outputDirectory, repoRoot);
 
   const sitemapSource = fs.readFileSync(sitemapPath, 'utf8');
   const skillsIndexSource = fs.readFileSync(skillsIndexPath, 'utf8');
+  const googleVerificationSource = fs.readFileSync(googleVerificationPath);
+  const expectedGoogleVerification = `google-site-verification: ${GOOGLE_VERIFICATION_FILENAME}`;
+  if (googleVerificationSource.toString('utf8').trim() !== expectedGoogleVerification) {
+    throw new Error(`Google verification file must contain exactly: ${expectedGoogleVerification}`);
+  }
   const locations = parseSitemap(sitemapSource);
   const skillIds = parseSkillIds(skillsIndexSource);
   if (locations.length !== expectedRoutes) {
     throw new Error(`sitemap route count ${locations.length} does not match locked expectation ${expectedRoutes}`);
   }
-  if (skillIds.length !== expectedSkills) {
+  if (expectedSkills != null && skillIds.length !== expectedSkills) {
     throw new Error(`skills index count ${skillIds.length} does not match locked expectation ${expectedSkills}`);
   }
 
@@ -269,6 +286,13 @@ function generateBridge(options) {
   if (redirects.some(({ output_file }) => output_file.startsWith(`${legacySitemapPath}/`))) {
     throw new Error(`generated route collides with reserved legacy sitemap path: ${legacySitemapPath}`);
   }
+  const googleVerificationOutputPath = path.posix.join(
+    ...legacyBase.pathname.split('/').filter(Boolean),
+    GOOGLE_VERIFICATION_FILENAME,
+  );
+  if (redirects.some(({ output_file }) => output_file.startsWith(`${googleVerificationOutputPath}/`))) {
+    throw new Error(`generated route collides with reserved Google verification path: ${googleVerificationOutputPath}`);
+  }
 
   const manifest = {
     schema_version: 2,
@@ -284,6 +308,17 @@ function generateBridge(options) {
     legacy_sitemap_route_count: sitemapRedirects.length,
     legacy_sitemap_policy: 'curated current sitemap routes only',
     legacy_sitemap: legacySitemapPath,
+    webmaster_verification: {
+      google: {
+        legacy_file: googleVerificationOutputPath,
+        sha256: sha256(googleVerificationSource),
+      },
+      bing: {
+        legacy_page: outputRelativePath(legacyBase, ''),
+        meta_name: 'msvalidate.01',
+        token: BING_VERIFICATION_TOKEN,
+      },
+    },
     redirects,
   };
 
@@ -291,7 +326,7 @@ function generateBridge(options) {
   let stagingDirectory = null;
   try {
     stagingDirectory = fs.mkdtempSync(path.join(path.dirname(outputDirectory), `.${path.basename(outputDirectory)}.${process.pid}.`));
-    writeBridge(stagingDirectory, redirects, sitemapRedirects, manifest, legacyBase);
+    writeBridge(stagingDirectory, redirects, sitemapRedirects, manifest, legacyBase, googleVerificationSource);
     fs.renameSync(stagingDirectory, outputDirectory);
   } finally {
     if (stagingDirectory && fs.existsSync(stagingDirectory)) fs.rmSync(stagingDirectory, { recursive: true, force: true });
@@ -305,6 +340,7 @@ function parseArgs(argv) {
     '--output': 'outputDirectory',
     '--sitemap': 'sitemapPath',
     '--skills-index': 'skillsIndexPath',
+    '--google-verification': 'googleVerificationPath',
     '--current-base': 'currentBase',
     '--legacy-base': 'legacyBase',
     '--expected-routes': 'expectedRoutes',
@@ -328,7 +364,7 @@ function parseArgs(argv) {
 function main() {
   const options = parseArgs(process.argv.slice(2));
   if (options.help) {
-    process.stdout.write('Usage: node tools/scripts/generate-pages-redirect-bridge.js --output NEW_DIR [--sitemap FILE] [--skills-index FILE] [--expected-routes N] [--expected-skills N]\n');
+    process.stdout.write('Usage: node tools/scripts/generate-pages-redirect-bridge.js --output NEW_DIR [--sitemap FILE] [--skills-index FILE] [--google-verification FILE] [--expected-routes N] [--expected-skills N]\n');
     return;
   }
   const manifest = generateBridge(options);
@@ -351,4 +387,6 @@ module.exports = {
   parseSkillIds,
   parseSitemap,
   redirectHtml,
+  BING_VERIFICATION_TOKEN,
+  GOOGLE_VERIFICATION_FILENAME,
 };

--- a/tools/scripts/tests/generate_pages_redirect_bridge.test.js
+++ b/tools/scripts/tests/generate_pages_redirect_bridge.test.js
@@ -10,6 +10,8 @@ const { generateBridge } = require(scriptPath);
 const fixtureRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'pages-redirect-bridge-'));
 const sitemapPath = path.join(fixtureRoot, 'sitemap.xml');
 const skillsIndexPath = path.join(fixtureRoot, 'skills_index.json');
+const googleVerificationPath = path.join(fixtureRoot, 'google5815fd8827d2319c.html');
+const googleVerificationBody = 'google-site-verification: google5815fd8827d2319c.html';
 const current = 'https://example.github.io/agentic-awesome-skills/';
 const legacy = 'https://example.github.io/antigravity-awesome-skills/';
 
@@ -26,6 +28,7 @@ function bridgeOptions(outputDirectory, overrides = {}) {
     repoRoot: fixtureRoot,
     sitemapPath,
     skillsIndexPath,
+    googleVerificationPath,
     outputDirectory,
     currentBase: current,
     legacyBase: legacy,
@@ -52,6 +55,7 @@ try {
   const locations = [current, `${current}plugins/`, `${current}topics/github-ai-skills-repository/`, `${current}skill/brainstorming/`];
   fs.writeFileSync(sitemapPath, sitemap(locations), 'utf8');
   writeSkills(skillsIndexPath, ['brainstorming', 'catalog-only']);
+  fs.writeFileSync(googleVerificationPath, googleVerificationBody, 'utf8');
 
   const outputOne = path.join(fixtureRoot, '.codex', 'bridge-one');
   const manifest = generateBridge(bridgeOptions(outputOne));
@@ -60,6 +64,9 @@ try {
   assert.strictEqual(manifest.current_skill_route_count, 2);
   assert.strictEqual(manifest.route_count, 5);
   assert.strictEqual(manifest.legacy_sitemap_route_count, 4);
+  assert.strictEqual(manifest.webmaster_verification.google.legacy_file, 'antigravity-awesome-skills/google5815fd8827d2319c.html');
+  assert.strictEqual(manifest.webmaster_verification.bing.meta_name, 'msvalidate.01');
+  assert.strictEqual(manifest.webmaster_verification.bing.token, 'CAC904EB0D2DD1B22B5F2BC540CAD654');
   assert.strictEqual(manifest.redirects.length, 5);
   assert.strictEqual(new Set(manifest.redirects.map((redirect) => redirect.from)).size, 5);
   assert.strictEqual(new Set(manifest.redirects.map((redirect) => redirect.output_file)).size, 5);
@@ -76,10 +83,24 @@ try {
   assert(!fs.existsSync(path.join(outputOne, 'antigravity-awesome-skills/skill/removed-skill/index.html')));
   assert(!manifest.redirects.some(({ from }) => from === `${legacy}skill/removed-skill/`));
 
+  const legacyRootHtml = fs.readFileSync(path.join(outputOne, 'antigravity-awesome-skills/index.html'), 'utf8');
+  assert.strictEqual((legacyRootHtml.match(/name="msvalidate\.01"/g) || []).length, 1);
+  assert.match(legacyRootHtml, /name="msvalidate\.01" content="CAC904EB0D2DD1B22B5F2BC540CAD654"/);
+  assert(
+    legacyRootHtml.indexOf('name="msvalidate.01"') < legacyRootHtml.indexOf('http-equiv="refresh"'),
+    'Bing verification must appear before the redirect refresh',
+  );
+
   const pluginHtml = fs.readFileSync(path.join(outputOne, 'antigravity-awesome-skills/plugins/index.html'), 'utf8');
   assert.match(pluginHtml, /http-equiv="refresh" content="0; url=https:\/\/example\.github\.io\/agentic-awesome-skills\/plugins\/"/);
   assert.match(pluginHtml, /rel="canonical" href="https:\/\/example\.github\.io\/agentic-awesome-skills\/plugins\/"/);
   assert.match(pluginHtml, /<a href="https:\/\/example\.github\.io\/agentic-awesome-skills\/plugins\/">/);
+  assert(!pluginHtml.includes('msvalidate.01'), 'Bing verification belongs only on the legacy root');
+  const copiedGoogleVerification = fs.readFileSync(
+    path.join(outputOne, 'antigravity-awesome-skills/google5815fd8827d2319c.html'),
+    'utf8',
+  );
+  assert.strictEqual(copiedGoogleVerification, googleVerificationBody, 'Google verification must be copied byte-for-byte');
   const legacySitemapSource = fs.readFileSync(path.join(outputOne, 'antigravity-awesome-skills/sitemap.xml'), 'utf8');
   assert.strictEqual((legacySitemapSource.match(/<loc>/g) || []).length, 4, 'legacy sitemap stays on the curated source sitemap');
   assert(!legacySitemapSource.includes('/skill/catalog-only/'), 'catalog-only redirects must not expand crawler discovery');
@@ -142,6 +163,23 @@ try {
     expectedSkills: 3,
   })), /skills index count 2 does not match locked expectation 3/);
 
+  const dynamicSkillCountOutput = path.join(fixtureRoot, '.codex', 'dynamic-skill-count');
+  const dynamicSkillCountManifest = generateBridge(bridgeOptions(dynamicSkillCountOutput, { expectedSkills: null }));
+  assert.strictEqual(dynamicSkillCountManifest.current_skill_route_count, 2, 'omitting the skill-count lock follows the current index');
+
+  const invalidGoogleVerification = path.join(fixtureRoot, 'invalid-google.html');
+  fs.writeFileSync(invalidGoogleVerification, 'stale verification token', 'utf8');
+  assert.throws(() => generateBridge(bridgeOptions(path.join(fixtureRoot, '.codex', 'invalid-google'), {
+    googleVerificationPath: invalidGoogleVerification,
+  })), /Google verification file must contain exactly/);
+
+  const collidingSitemap = path.join(fixtureRoot, 'google-collision.xml');
+  fs.writeFileSync(collidingSitemap, sitemap([current, `${current}google5815fd8827d2319c.html/`]), 'utf8');
+  assert.throws(() => generateBridge(bridgeOptions(path.join(fixtureRoot, '.codex', 'google-collision'), {
+    sitemapPath: collidingSitemap,
+    expectedRoutes: 2,
+  })), /reserved Google verification path/);
+
   const trackedOutput = path.join(fixtureRoot, 'apps', 'web-app', 'public', 'bridge');
   assert.throws(() => generateBridge(bridgeOptions(trackedOutput)), /only under ignored \.codex/);
 
@@ -189,6 +227,7 @@ try {
     scriptPath,
     '--sitemap', sitemapPath,
     '--skills-index', skillsIndexPath,
+    '--google-verification', googleVerificationPath,
     '--output', cliOutput,
     '--current-base', current,
     '--legacy-base', legacy,
@@ -206,11 +245,11 @@ try {
   try {
     const productionOutput = path.join(productionOutputRoot, 'bridge');
     const productionManifest = generateBridge({ outputDirectory: productionOutput });
-    assert.strictEqual(productionManifest.source_sitemap_route_count, 187);
-    assert.strictEqual(productionManifest.current_skill_route_count, 1965);
-    assert.strictEqual(productionManifest.route_count, 1972);
-    assert.strictEqual(productionManifest.legacy_sitemap_route_count, 187);
     const productionSkills = JSON.parse(fs.readFileSync(path.resolve(__dirname, '..', '..', '..', 'skills_index.json'), 'utf8'));
+    assert.strictEqual(productionManifest.source_sitemap_route_count, 187);
+    assert.strictEqual(productionManifest.current_skill_route_count, productionSkills.length);
+    assert.strictEqual(productionManifest.route_count, productionSkills.length + 7);
+    assert.strictEqual(productionManifest.legacy_sitemap_route_count, 187);
     const expectedSkillUrls = new Set(productionSkills.map(({ id }) => `https://sickn33.github.io/agentic-awesome-skills/skill/${id}/`));
     const actualSkillUrls = new Set(productionManifest.redirects.map(({ to }) => to).filter((url) => url.includes('/skill/')));
     assert.deepStrictEqual(actualSkillUrls, expectedSkillUrls, 'production bridge must cover exactly every current skill id');
@@ -218,6 +257,12 @@ try {
     assert(!productionManifest.redirects.some(({ to }) => to.endsWith('/skill/merge-batch-e2e-test/')));
     const productionLegacySitemap = fs.readFileSync(path.join(productionOutput, 'antigravity-awesome-skills/sitemap.xml'), 'utf8');
     assert.strictEqual((productionLegacySitemap.match(/<loc>/g) || []).length, 187);
+    assert.strictEqual(
+      fs.readFileSync(path.join(productionOutput, 'antigravity-awesome-skills/google5815fd8827d2319c.html'), 'utf8'),
+      fs.readFileSync(path.resolve(__dirname, '..', '..', '..', 'apps/web-app/public/google5815fd8827d2319c.html'), 'utf8'),
+    );
+    const productionRootHtml = fs.readFileSync(path.join(productionOutput, 'antigravity-awesome-skills/index.html'), 'utf8');
+    assert.match(productionRootHtml, /name="msvalidate\.01" content="CAC904EB0D2DD1B22B5F2BC540CAD654"/);
   } finally {
     fs.rmSync(productionOutputRoot, { recursive: true, force: true });
   }

--- a/tools/scripts/tests/verify_pages_redirect_bridge.test.js
+++ b/tools/scripts/tests/verify_pages_redirect_bridge.test.js
@@ -1,0 +1,97 @@
+const assert = require('assert');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const { generateBridge } = require('../generate-pages-redirect-bridge');
+const { verifyLiveDeployment, verifyLocalDeployment } = require('../verify-pages-redirect-bridge');
+
+const root = fs.mkdtempSync(path.join(os.tmpdir(), 'verify-pages-redirect-'));
+const current = 'https://example.github.io/agentic-awesome-skills/';
+const legacy = 'https://example.github.io/antigravity-awesome-skills/';
+
+async function run() {
+  const sitemapPath = path.join(root, 'sitemap.xml');
+  const skillsIndexPath = path.join(root, 'skills.json');
+  const googleVerificationPath = path.join(root, 'google5815fd8827d2319c.html');
+  const deploymentRoot = path.join(root, 'deployment');
+  fs.writeFileSync(sitemapPath, `<?xml version="1.0"?><urlset><url><loc>${current}</loc></urlset>`);
+  fs.writeFileSync(skillsIndexPath, JSON.stringify([{ id: 'alpha' }, { id: 'beta' }]));
+  fs.writeFileSync(googleVerificationPath, 'google-site-verification: google5815fd8827d2319c.html');
+  const generatorOptions = {
+    sitemapPath,
+    skillsIndexPath,
+    googleVerificationPath,
+    currentBase: current,
+    legacyBase: legacy,
+    expectedRoutes: 1,
+    expectedSkills: 2,
+  };
+  const manifest = generateBridge({ ...generatorOptions, outputDirectory: deploymentRoot });
+  const verified = verifyLocalDeployment({ ...generatorOptions, deploymentRoot });
+  assert.strictEqual(verified.manifest.route_count, manifest.route_count);
+
+  const rootHtmlPath = path.join(deploymentRoot, 'antigravity-awesome-skills/index.html');
+  const originalRoot = fs.readFileSync(rootHtmlPath);
+  fs.appendFileSync(rootHtmlPath, '\ndrift');
+  assert.throws(() => verifyLocalDeployment({ ...generatorOptions, deploymentRoot }), /mismatched=/);
+  fs.writeFileSync(rootHtmlPath, originalRoot);
+
+  const stalePath = path.join(deploymentRoot, 'antigravity-awesome-skills/stale.txt');
+  fs.writeFileSync(stalePath, 'stale');
+  assert.throws(() => verifyLocalDeployment({ ...generatorOptions, deploymentRoot }), /unexpected=.*stale\.txt/);
+  fs.unlinkSync(stalePath);
+
+  const fetchImpl = async (url) => {
+    const parsed = new URL(url);
+    if (parsed.pathname.startsWith('/agentic-awesome-skills/')) return new Response('current destination', { status: 200 });
+    const relative = parsed.pathname.replace(/^\//, '');
+    let filePath = path.join(deploymentRoot, relative);
+    if (parsed.pathname.endsWith('/')) filePath = path.join(filePath, 'index.html');
+    if (!fs.existsSync(filePath)) return new Response('missing', { status: 404 });
+    return new Response(fs.readFileSync(filePath), { status: 200 });
+  };
+  const live = await verifyLiveDeployment({
+    deploymentRoot,
+    liveRoot: 'https://example.github.io/',
+    liveMode: 'all',
+    fetchImpl,
+  });
+  assert.strictEqual(live.checked_redirects, manifest.route_count);
+
+  await assert.rejects(() => verifyLiveDeployment({
+    deploymentRoot,
+    liveRoot: 'https://example.github.io/',
+    concurrency: 0,
+    fetchImpl,
+  }), /concurrency must be an integer from 1 to 64/);
+
+  const missingBingFetch = async (url, init) => {
+    if (new URL(url).pathname === '/antigravity-awesome-skills/') {
+      return new Response(fs.readFileSync(rootHtmlPath, 'utf8').replace('msvalidate.01', 'missing-bing'), { status: 200 });
+    }
+    return fetchImpl(url, init);
+  };
+  await assert.rejects(() => verifyLiveDeployment({
+    deploymentRoot,
+    liveRoot: 'https://example.github.io/',
+    fetchImpl: missingBingFetch,
+  }), /exact Bing verification meta tag/);
+
+  const mismatchedFetch = async (url, init) => {
+    if (new URL(url).pathname === '/redirect-manifest.json') return new Response('{}\n', { status: 200 });
+    return fetchImpl(url, init);
+  };
+  await assert.rejects(() => verifyLiveDeployment({
+    deploymentRoot,
+    liveRoot: 'https://example.github.io/',
+    fetchImpl: mismatchedFetch,
+  }), /live redirect manifest differs/);
+}
+
+run()
+  .then(() => console.log('verify_pages_redirect_bridge tests passed'))
+  .catch((error) => {
+    console.error(error);
+    process.exitCode = 1;
+  })
+  .finally(() => fs.rmSync(root, { recursive: true, force: true }));

--- a/tools/scripts/verify-pages-redirect-bridge.js
+++ b/tools/scripts/verify-pages-redirect-bridge.js
@@ -1,0 +1,201 @@
+#!/usr/bin/env node
+'use strict';
+
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const { generateBridge } = require('./generate-pages-redirect-bridge');
+
+function listFiles(root) {
+  const files = [];
+  function visit(directory) {
+    for (const entry of fs.readdirSync(directory, { withFileTypes: true }).sort((a, b) => a.name.localeCompare(b.name))) {
+      const filePath = path.join(directory, entry.name);
+      if (entry.isDirectory()) visit(filePath);
+      else if (entry.isFile()) files.push(path.relative(root, filePath));
+      else throw new Error(`managed bridge contains a non-file entry: ${path.relative(root, filePath)}`);
+    }
+  }
+  visit(root);
+  return files;
+}
+
+function managedFiles(root, legacyBase) {
+  const required = ['.nojekyll', 'redirect-manifest.json'];
+  const legacyDirectory = path.join(root, ...new URL(legacyBase).pathname.split('/').filter(Boolean));
+  if (!fs.existsSync(legacyDirectory) || !fs.statSync(legacyDirectory).isDirectory()) {
+    throw new Error(`missing managed legacy directory: ${legacyDirectory}`);
+  }
+  return [...required, ...listFiles(legacyDirectory).map((file) => path.join(path.relative(root, legacyDirectory), file))]
+    .map((file) => file.split(path.sep).join('/'))
+    .sort();
+}
+
+function compareManagedTrees(expectedRoot, actualRoot, legacyBase) {
+  const expectedFiles = managedFiles(expectedRoot, legacyBase);
+  const actualFiles = managedFiles(actualRoot, legacyBase);
+  const expectedSet = new Set(expectedFiles);
+  const actualSet = new Set(actualFiles);
+  const missing = expectedFiles.filter((file) => !actualSet.has(file));
+  const unexpected = actualFiles.filter((file) => !expectedSet.has(file));
+  const mismatched = expectedFiles.filter((file) => actualSet.has(file)
+    && !fs.readFileSync(path.join(expectedRoot, file)).equals(fs.readFileSync(path.join(actualRoot, file))));
+  if (missing.length || unexpected.length || mismatched.length) {
+    throw new Error(`managed bridge drift detected: missing=${missing.join(',') || '-'} unexpected=${unexpected.join(',') || '-'} mismatched=${mismatched.join(',') || '-'}`);
+  }
+  return { file_count: expectedFiles.length };
+}
+
+function generateExpected(options) {
+  const temporaryRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'pages-redirect-verify-'));
+  const outputDirectory = path.join(temporaryRoot, 'bridge');
+  try {
+    const manifest = generateBridge({ ...options, outputDirectory });
+    return { temporaryRoot, outputDirectory, manifest };
+  } catch (error) {
+    fs.rmSync(temporaryRoot, { recursive: true, force: true });
+    throw error;
+  }
+}
+
+function verifyLocalDeployment(options) {
+  if (!options.deploymentRoot) throw new Error('--deployment-root is required');
+  const deploymentRoot = path.resolve(options.deploymentRoot);
+  const generated = generateExpected(options);
+  try {
+    const result = compareManagedTrees(generated.outputDirectory, deploymentRoot, generated.manifest.legacy_base);
+    return { ...result, manifest: generated.manifest };
+  } finally {
+    fs.rmSync(generated.temporaryRoot, { recursive: true, force: true });
+  }
+}
+
+function selectRedirects(redirects, mode) {
+  if (mode === 'all') return redirects;
+  if (mode !== 'sample') throw new Error('--live-mode must be sample or all');
+  const indexes = new Set([0, redirects.length - 1]);
+  const sampleSize = Math.min(25, redirects.length);
+  for (let index = 0; index < sampleSize; index += 1) {
+    indexes.add(Math.floor((index * (redirects.length - 1)) / Math.max(1, sampleSize - 1)));
+  }
+  return [...indexes].sort((left, right) => left - right).map((index) => redirects[index]);
+}
+
+async function fetchText(url, fetchImpl, timeoutMs) {
+  const response = await fetchImpl(url, { redirect: 'follow', signal: AbortSignal.timeout(timeoutMs) });
+  const body = await response.text();
+  if (response.status !== 200) throw new Error(`live probe failed: ${url} returned ${response.status}`);
+  return body;
+}
+
+async function runPool(items, concurrency, worker) {
+  let cursor = 0;
+  const runners = Array.from({ length: Math.min(concurrency, items.length) }, async () => {
+    while (cursor < items.length) {
+      const item = items[cursor];
+      cursor += 1;
+      await worker(item);
+    }
+  });
+  await Promise.all(runners);
+}
+
+async function verifyLiveDeployment(options) {
+  const deploymentRoot = path.resolve(options.deploymentRoot);
+  const liveRoot = new URL(options.liveRoot);
+  if (liveRoot.protocol !== 'https:' || !liveRoot.pathname.endsWith('/')) {
+    throw new Error('--live-root must be an HTTPS URL ending with a slash');
+  }
+  const fetchImpl = options.fetchImpl || global.fetch;
+  const timeoutMs = Number(options.timeoutMs ?? 15000);
+  const concurrency = Number(options.concurrency ?? 16);
+  if (!Number.isSafeInteger(timeoutMs) || timeoutMs < 1 || timeoutMs > 60000) {
+    throw new Error('--timeout-ms must be an integer from 1 to 60000');
+  }
+  if (!Number.isSafeInteger(concurrency) || concurrency < 1 || concurrency > 64) {
+    throw new Error('--concurrency must be an integer from 1 to 64');
+  }
+  const manifestSource = fs.readFileSync(path.join(deploymentRoot, 'redirect-manifest.json'), 'utf8');
+  const manifest = JSON.parse(manifestSource);
+  const liveManifest = await fetchText(new URL('redirect-manifest.json', liveRoot), fetchImpl, timeoutMs);
+  if (liveManifest !== manifestSource) throw new Error('live redirect manifest differs from the protected deployment');
+
+  const googlePath = manifest.webmaster_verification.google.legacy_file;
+  const expectedGoogle = fs.readFileSync(path.join(deploymentRoot, googlePath), 'utf8');
+  const liveGoogle = await fetchText(new URL(googlePath, liveRoot), fetchImpl, timeoutMs);
+  if (liveGoogle !== expectedGoogle) throw new Error('live Google verification file differs from the protected deployment');
+
+  const expectedSitemap = fs.readFileSync(path.join(deploymentRoot, manifest.legacy_sitemap), 'utf8');
+  const liveSitemap = await fetchText(new URL(manifest.legacy_sitemap, liveRoot), fetchImpl, timeoutMs);
+  if (liveSitemap !== expectedSitemap) throw new Error('live legacy sitemap differs from the protected deployment');
+
+  const bing = manifest.webmaster_verification.bing;
+  const liveLegacyRoot = await fetchText(manifest.legacy_base, fetchImpl, timeoutMs);
+  const bingMeta = `name="${bing.meta_name}" content="${bing.token}"`;
+  if ((liveLegacyRoot.match(new RegExp(bingMeta.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'), 'g')) || []).length !== 1) {
+    throw new Error('live legacy root does not expose the exact Bing verification meta tag');
+  }
+
+  const redirects = selectRedirects(manifest.redirects, options.liveMode || 'sample');
+  await runPool(redirects, concurrency, async (redirect) => {
+    const legacyHtml = await fetchText(redirect.from, fetchImpl, timeoutMs);
+    if (!legacyHtml.includes(`http-equiv="refresh" content="0; url=${redirect.to}"`)
+      || !legacyHtml.includes(`rel="canonical" href="${redirect.to}"`)) {
+      throw new Error(`live redirect markup mismatch: ${redirect.from}`);
+    }
+    await fetchText(redirect.to, fetchImpl, timeoutMs);
+  });
+  return { checked_redirects: redirects.length, route_count: manifest.route_count };
+}
+
+function parseArgs(argv) {
+  const options = {};
+  const aliases = {
+    '--deployment-root': 'deploymentRoot',
+    '--sitemap': 'sitemapPath',
+    '--skills-index': 'skillsIndexPath',
+    '--google-verification': 'googleVerificationPath',
+    '--current-base': 'currentBase',
+    '--legacy-base': 'legacyBase',
+    '--expected-routes': 'expectedRoutes',
+    '--expected-skills': 'expectedSkills',
+    '--live-root': 'liveRoot',
+    '--live-mode': 'liveMode',
+    '--concurrency': 'concurrency',
+    '--timeout-ms': 'timeoutMs',
+  };
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    const key = aliases[arg];
+    const value = argv[index + 1];
+    if (!key || !value || value.startsWith('--')) throw new Error(`unknown option or missing value: ${arg}`);
+    options[key] = value;
+    index += 1;
+  }
+  return options;
+}
+
+async function main() {
+  const options = parseArgs(process.argv.slice(2));
+  const local = verifyLocalDeployment(options);
+  process.stdout.write(`Verified ${local.file_count} managed bridge files for ${local.manifest.route_count} routes\n`);
+  if (options.liveRoot) {
+    const live = await verifyLiveDeployment(options);
+    process.stdout.write(`Verified ${live.checked_redirects}/${live.route_count} live redirect pairs\n`);
+  }
+}
+
+if (require.main === module) {
+  main().catch((error) => {
+    process.stderr.write(`redirect bridge verification failed: ${error.message}\n`);
+    process.exitCode = 1;
+  });
+}
+
+module.exports = {
+  compareManagedTrees,
+  parseArgs,
+  selectRedirects,
+  verifyLiveDeployment,
+  verifyLocalDeployment,
+};

--- a/walkthrough.md
+++ b/walkthrough.md
@@ -277,3 +277,10 @@
 - Reuse a previously successful review for identical content, avoiding Tessl setup and another charged review after unrelated PR pushes or base refreshes.
 - Route an explicit Tessl credit/quota failure to `manual-review-required` with exact-head attestation; unrelated Tessl failures still fail closed.
 - Added regression coverage for fingerprint invalidation, GitHub Actions cache wiring, quota classification, and truthful review outcomes.
+# Maintenance Walkthrough - 2026-07-17 Legacy Redirect Infrastructure
+
+- Preserved the Google Search Console HTML verification file on the legacy Pages path and the Bing Webmaster Tools meta token on the legacy root redirect.
+- Made redirect generation follow the current `skills_index.json` count while retaining the curated sitemap-count lock and exact route-set validation.
+- Added `pages:redirect-verify` for byte-exact managed-tree validation plus bounded or full live route probing.
+- Documented the protected cross-repository synchronization contract for `sickn33/sickn33.github.io`.
+- Added regression coverage for webmaster tokens, reserved-path collisions, dynamic skill counts, local drift, stale files, and live manifest/route verification.


### PR DESCRIPTION
## Summary

- preserve the legacy Google and Bing webmaster verification surfaces
- make skill-route generation follow the current catalog while retaining the curated sitemap lock
- add byte-exact local validation and bounded/full live redirect verification
- document the protected cross-repository deployment contract

## Change Classification

- [ ] Skill PR
- [x] Docs PR
- [x] Infra PR

## Quality Bar Checklist ✅

- [x] **Standards**: I have read `docs/contributors/quality-bar.md` and `docs/contributors/security-guardrails.md`.
- [x] **Metadata**: Not applicable; no `SKILL.md` changed.
- [x] **Risk Label**: Not applicable; no skill changed.
- [x] **Triggers**: Not applicable; no skill changed.
- [x] **Limitations**: The maintainer guide documents managed scope and deployment boundaries.
- [x] **Security**: Not applicable; no offensive skill changed.
- [x] **Safety scan**: `npm run security:docs` passed.
- [x] **Automated Skill Review**: Not applicable; no `SKILL.md` changed.
- [x] **Manual Logic Review**: Generator, verifier, failure modes, and cross-repository trust boundaries were manually reviewed.
- [x] **Local Test**: Targeted generator/verifier tests and the full local test suite passed.
- [x] **Repo Checks**: `npm run validate:references`, `npm run validate`, `npm run lint:workflows`, and `npm audit --audit-level=high` passed.
- [x] **Source-Only PR**: No generated registry artifacts are included.
- [x] **Credits**: Not applicable; no external source content was added.
- [x] **License provenance**: Not applicable; no external skill content was imported.
- [x] **Maintainer Edits**: Same-repository maintainer branch.

## Evidence

- `npm run validate`
- `npm_config_cache=/tmp/aas-infra.TuxpG8/npm-cache npm test`
- `npm run security:docs`
- `npm run validate:references`
- `npm run lint:workflows`
- `npm audit --audit-level=high`
- `node tools/scripts/tests/generate_pages_redirect_bridge.test.js`
- `node tools/scripts/tests/verify_pages_redirect_bridge.test.js`
