### PR TITLE
chore: version redirect manifest contract

### DIFF
--- a/docs/maintainers/legacy-redirect-bridge.md
+++ b/docs/maintainers/legacy-redirect-bridge.md
@@ -20,6 +20,8 @@ npm run pages:redirect-bridge -- --output /new/output/directory
 
 The generator keeps the curated sitemap route count locked while deriving the skill count from `skills_index.json`. It also preserves the legacy Google verification file and the Bing verification meta tag on the legacy root page.
 
+Manifest schema version `3` records both redirect coverage and webmaster-verification evidence for automation consumers.
+
 Verify a checked-out target repository byte-for-byte:
 
 ```bash

--- a/tools/scripts/generate-pages-redirect-bridge.js
+++ b/tools/scripts/generate-pages-redirect-bridge.js
@@ -295,7 +295,7 @@ function generateBridge(options) {
   }
 
   const manifest = {
-    schema_version: 2,
+    schema_version: 3,
     deployment_scope: 'separate GitHub Pages user-site subdirectory',
     not_for_current_project_pages: true,
     source_sitemap_sha256: sha256(sitemapSource),

--- a/tools/scripts/tests/generate_pages_redirect_bridge.test.js
+++ b/tools/scripts/tests/generate_pages_redirect_bridge.test.js
@@ -59,7 +59,7 @@ try {
 
   const outputOne = path.join(fixtureRoot, '.codex', 'bridge-one');
   const manifest = generateBridge(bridgeOptions(outputOne));
-  assert.strictEqual(manifest.schema_version, 2);
+  assert.strictEqual(manifest.schema_version, 3);
   assert.strictEqual(manifest.source_sitemap_route_count, 4);
   assert.strictEqual(manifest.current_skill_route_count, 2);
   assert.strictEqual(manifest.route_count, 5);

--- a/walkthrough.md
+++ b/walkthrough.md
@@ -282,5 +282,6 @@
 - Preserved the Google Search Console HTML verification file on the legacy Pages path and the Bing Webmaster Tools meta token on the legacy root redirect.
 - Made redirect generation follow the current `skills_index.json` count while retaining the curated sitemap-count lock and exact route-set validation.
 - Added `pages:redirect-verify` for byte-exact managed-tree validation plus bounded or full live route probing.
+- Versioned the redirect manifest contract as schema `3`, including webmaster-verification evidence consumed by the protected sync.
 - Documented the protected cross-repository synchronization contract for `sickn33/sickn33.github.io`.
 - Added regression coverage for webmaster tokens, reserved-path collisions, dynamic skill counts, local drift, stale files, and live manifest/route verification.


### PR DESCRIPTION
## Summary

- bump the redirect manifest contract to schema version 3
- document that schema 3 includes webmaster-verification evidence
- use the versioned output as the final end-to-end drift/sync acceptance test

## Change Classification

- [ ] Skill PR
- [x] Docs PR
- [x] Infra PR

## Quality Bar Checklist ✅

- [x] **Standards**: Maintainer and security guidance reviewed.
- [x] **Metadata**: Not applicable; no skill changed.
- [x] **Risk Label**: Not applicable.
- [x] **Triggers**: Not applicable.
- [x] **Limitations**: Deployment contract remains documented.
- [x] **Security**: Not applicable.
- [x] **Safety scan**: No command guidance changed.
- [x] **Automated Skill Review**: Not applicable.
- [x] **Manual Logic Review**: Manifest compatibility and consumers reviewed.
- [x] **Local Test**: Generator and verifier regression suites passed.
- [x] **Repo Checks**: Reference validation and diff checks passed.
- [x] **Source-Only PR**: No generated registry artifacts included.
- [x] **Credits**: Not applicable.
- [x] **License provenance**: Not applicable.
- [x] **Maintainer Edits**: Same-repository maintainer branch.

## Evidence

- `node tools/scripts/tests/generate_pages_redirect_bridge.test.js`
- `node tools/scripts/tests/verify_pages_redirect_bridge.test.js`
- `npm run validate:references`
- `git diff --check`
