### PR TITLE
ci: update Pages actions to Node 24

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -94,10 +94,10 @@ jobs:
           test -f 404.html
 
       - name: Configure GitHub Pages
-        uses: actions/configure-pages@983d7736d9b0ae728b81ab479565c72886d7745b # v5
+        uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d # v6.0.0
 
       - name: Upload Pages artifact
-        uses: actions/upload-pages-artifact@7b1f4a764d45c48632c6b24a0339c27f5614fb0b # v4
+        uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0
         with:
           path: apps/web-app/dist
 


### PR DESCRIPTION
## Summary

Update the two Pages build actions responsible for the Node 20 deprecation warning to their official Node 24 releases, pinned to full commit SHAs.

## Change Classification

- [ ] Skill PR
- [ ] Docs PR
- [x] Infra PR

## Quality Bar Checklist ✅

- [x] Standards reviewed
- [x] Metadata not applicable; no SKILL.md changed
- [x] Risk label not applicable; no skill content changed
- [x] Triggers not applicable
- [x] Limitations not applicable
- [x] Security disclaimer not applicable
- [x] Safety scan passed with npm run security:docs
- [x] Automated skill review not applicable
- [x] Manual logic review completed for workflow compatibility and failure modes
- [x] Local tests passed: npm run validate, npm test, npm run lint:workflows
- [x] Repo checks passed: npm run validate:references
- [x] Source-only PR; no generated registry artifacts
- [x] Credits not applicable
- [x] License provenance not applicable
- [x] Maintainer edits enabled

## Verification

The official release tags resolve to configure-pages v6.0.0 at 45bfe0192ca1faeb007ade9deae92b16b8254a0d and upload-pages-artifact v5.0.0 at fc324d3547104276b827a68afc52ff2a11cc49c9.