### PR TITLE
fix: allow canonical sync without Pages

### DIFF
--- a/.github/MAINTENANCE.md
+++ b/.github/MAINTENANCE.md
@@ -283,6 +283,7 @@ We used this flow for PRs [#220](https://github.com/sickn33/agentic-awesome-skil
 **Maintainer shortcut for batched PRs:**
 
 - Use `npm run merge:batch -- --prs 450,449,446,451` to automate the ordered maintainer flow for multiple PRs. See [docs/maintainers/merge-batch.md](../docs/maintainers/merge-batch.md) for the short usage guide.
+- When a canonical-sync PR must be merged without publishing Pages, invoke `tools/scripts/merge_canonical_sync_pr.cjs` with `--skip-pages`. Required CI and CodeQL are still dispatched; Pages remains an explicit later action.
 - The script keeps the GitHub-only squash merge rule, handles fork-run approvals and stale PR metadata refresh, waits only on fresh required checks, retries `Base branch was modified`, and runs the mandatory post-merge `sync:contributors` follow-up on `main`. The fork content allowlist applies only to external PRs; same-repository maintainer PRs may change repository-wide source while remaining subject to protected checks, trusted changed-skill evidence, exact-head review, and immutable PR identity.
 - It is intentionally not a conflict resolver. If a PR is conflicting, stop and follow the manual conflict playbook.
 

--- a/tools/scripts/merge_canonical_sync_pr.cjs
+++ b/tools/scripts/merge_canonical_sync_pr.cjs
@@ -8,9 +8,13 @@ const BOT_BRANCH = "automation/canonical-repo-state";
 const CI_WORKFLOW_PATH = ".github/workflows/ci.yml";
 
 function parseArgs(argv) {
-  const options = { pollSeconds: 10, maxAttempts: 180 };
+  const options = { pollSeconds: 10, maxAttempts: 180, skipPages: false };
   for (let index = 0; index < argv.length; index += 1) {
     const argument = argv[index];
+    if (argument === "--skip-pages") {
+      options.skipPages = true;
+      continue;
+    }
     if (["--repo", "--pr", "--head", "--poll-seconds", "--max-attempts"].includes(argument)) {
       const value = argv[index + 1];
       if (!value || value.startsWith("--")) throw new Error(`${argument} requires a value.`);
@@ -27,6 +31,10 @@ function parseArgs(argv) {
   if (!Number.isInteger(options.pollSeconds) || options.pollSeconds <= 0) throw new Error("--poll-seconds must be positive.");
   if (!Number.isInteger(options.maxAttempts) || options.maxAttempts <= 0) throw new Error("--max-attempts must be positive.");
   return options;
+}
+
+function verificationWorkflows(options = {}) {
+  return options.skipPages ? ["ci.yml", "codeql.yml"] : ["ci.yml", "pages.yml", "codeql.yml"];
 }
 
 function runGh(args, options = {}) {
@@ -213,7 +221,7 @@ async function main() {
   ));
   if (merged?.merged !== true) throw new Error(`Canonical-sync merge failed: ${merged?.message || "merged=false"}`);
 
-  for (const workflow of ["ci.yml", "pages.yml", "codeql.yml"]) {
+  for (const workflow of verificationWorkflows(options)) {
     runGh([
       "api",
       `repos/${options.repo}/actions/workflows/${workflow}/dispatches`,
@@ -223,7 +231,8 @@ async function main() {
       "ref=main",
     ]);
   }
-  process.stdout.write(`[canonical-sync] merged PR #${options.pr} at ${options.head} and dispatched main verification.\n`);
+  const pages = options.skipPages ? " without Pages publication" : " including Pages verification";
+  process.stdout.write(`[canonical-sync] merged PR #${options.pr} at ${options.head} and dispatched main verification${pages}.\n`);
 }
 
 if (require.main === module) {
@@ -241,5 +250,6 @@ module.exports = {
   summarizeChecks,
   validateProtectedMain,
   validatePullRequest,
+  verificationWorkflows,
   waitForChecks,
 };

--- a/tools/scripts/tests/merge_canonical_sync_pr.test.js
+++ b/tools/scripts/tests/merge_canonical_sync_pr.test.js
@@ -5,6 +5,11 @@ const canonicalMerge = require("../merge_canonical_sync_pr.cjs");
 const HEAD = "a".repeat(40);
 const options = canonicalMerge.parseArgs(["--repo", "owner/repo", "--pr", "42", "--head", HEAD]);
 assert.strictEqual(options.pollSeconds, 10);
+assert.strictEqual(options.skipPages, false);
+const noPages = canonicalMerge.parseArgs(["--repo", "owner/repo", "--pr", "42", "--head", HEAD, "--skip-pages"]);
+assert.strictEqual(noPages.skipPages, true);
+assert.deepStrictEqual(canonicalMerge.verificationWorkflows(options), ["ci.yml", "pages.yml", "codeql.yml"]);
+assert.deepStrictEqual(canonicalMerge.verificationWorkflows(noPages), ["ci.yml", "codeql.yml"]);
 assert.throws(() => canonicalMerge.parseArgs(["--repo", "owner/repo", "--pr", "42", "--head", "short"]), /full SHA-1/);
 
 const CHECK_SUITE_ID = 777;


### PR DESCRIPTION
## Summary

- add an explicit `--skip-pages` mode to the protected canonical-sync merger
- keep CI and CodeQL dispatches mandatory
- document and test the non-publishing path

## Quality Bar Checklist

- [x] Targeted canonical-sync merger tests pass
- [x] Repository validation passes
- [x] Documentation security checks pass
- [x] No generated registry artifacts changed
- [x] No Pages deployment is performed by this PR