### PR TITLE
fix: guard canonical sync Pages deploys

### DIFF
--- a/.github/MAINTENANCE.md
+++ b/.github/MAINTENANCE.md
@@ -283,7 +283,7 @@ We used this flow for PRs [#220](https://github.com/sickn33/agentic-awesome-skil
 **Maintainer shortcut for batched PRs:**
 
 - Use `npm run merge:batch -- --prs 450,449,446,451` to automate the ordered maintainer flow for multiple PRs. See [docs/maintainers/merge-batch.md](../docs/maintainers/merge-batch.md) for the short usage guide.
-- When a canonical-sync PR must be merged without publishing Pages, invoke `tools/scripts/merge_canonical_sync_pr.cjs` with `--skip-pages`. Required CI and CodeQL are still dispatched; Pages remains an explicit later action.
+- When a canonical-sync PR must be merged without publishing Pages, invoke `tools/scripts/merge_canonical_sync_pr.cjs` with `--skip-pages`. The merge commit carries `[skip pages]`, required CI, the frozen AAS baseline, and CodeQL remain enforced, and Pages remains an explicit later action.
 - The script keeps the GitHub-only squash merge rule, handles fork-run approvals and stale PR metadata refresh, waits only on fresh required checks, retries `Base branch was modified`, and runs the mandatory post-merge `sync:contributors` follow-up on `main`. The fork content allowlist applies only to external PRs; same-repository maintainer PRs may change repository-wide source while remaining subject to protected checks, trusted changed-skill evidence, exact-head review, and immutable PR identity.
 - It is intentionally not a conflict resolver. If a PR is conflicting, stop and follow the manual conflict playbook.
 

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -23,6 +23,7 @@ env:
 
 jobs:
   build:
+    if: github.event_name == 'workflow_dispatch' || !contains(github.event.head_commit.message, '[skip pages]')
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/tools/scripts/merge_canonical_sync_pr.cjs
+++ b/tools/scripts/merge_canonical_sync_pr.cjs
@@ -6,6 +6,7 @@ const REQUIRED_CHECKS = ["pr-policy", "pr-evidence", "source-validation", "artif
 const GITHUB_ACTIONS_APP_ID = 15368;
 const BOT_BRANCH = "automation/canonical-repo-state";
 const CI_WORKFLOW_PATH = ".github/workflows/ci.yml";
+const BASELINE_WORKFLOW_PATH = ".github/workflows/aas-v1-baseline-check.yml";
 
 function parseArgs(argv) {
   const options = { pollSeconds: 10, maxAttempts: 180, skipPages: false };
@@ -48,13 +49,13 @@ function runGh(args, options = {}) {
   return result.stdout.trim();
 }
 
-function latestRequiredChecks(checkRuns, expectedCheckSuiteId) {
+function latestRequiredChecks(checkRuns, expectedCheckSuiteId, requiredChecks = REQUIRED_CHECKS) {
   const result = new Map();
   for (const run of checkRuns || []) {
     if (
       Number(run?.app?.id) !== GITHUB_ACTIONS_APP_ID ||
       Number(run?.check_suite?.id) !== Number(expectedCheckSuiteId) ||
-      !REQUIRED_CHECKS.includes(String(run?.name || ""))
+      !requiredChecks.includes(String(run?.name || ""))
     ) {
       continue;
     }
@@ -68,9 +69,9 @@ function latestRequiredChecks(checkRuns, expectedCheckSuiteId) {
   return result;
 }
 
-function summarizeChecks(checkRuns, expectedCheckSuiteId) {
-  const latest = latestRequiredChecks(checkRuns, expectedCheckSuiteId);
-  return REQUIRED_CHECKS.map((name) => {
+function summarizeChecks(checkRuns, expectedCheckSuiteId, requiredChecks = REQUIRED_CHECKS) {
+  const latest = latestRequiredChecks(checkRuns, expectedCheckSuiteId, requiredChecks);
+  return requiredChecks.map((name) => {
     const run = latest.get(name);
     if (!run) return { name, state: "pending", conclusion: "missing" };
     if (String(run.status).toLowerCase() !== "completed") return { name, state: "pending", conclusion: "in_progress" };
@@ -102,9 +103,9 @@ function validateProtectedMain(branch) {
   return true;
 }
 
-function selectCanonicalPullRequestRun(runs, options, expectedBaseSha) {
+function selectCanonicalPullRequestRun(runs, options, expectedBaseSha, workflowPath = CI_WORKFLOW_PATH) {
   const matches = (runs || []).filter((run) => (
-    run?.path === CI_WORKFLOW_PATH &&
+    run?.path === workflowPath &&
     run?.event === "pull_request" &&
     run?.head_branch === BOT_BRANCH &&
     run?.head_sha === options.head &&
@@ -132,7 +133,7 @@ function wait(milliseconds) {
   return new Promise((resolve) => setTimeout(resolve, milliseconds));
 }
 
-async function waitForChecks(options, expectedCheckSuiteId, dependencies = {}) {
+async function waitForChecks(options, expectedCheckSuiteId, dependencies = {}, requiredChecks = REQUIRED_CHECKS) {
   if (!Number.isInteger(Number(expectedCheckSuiteId)) || Number(expectedCheckSuiteId) <= 0) {
     throw new Error("Canonical-sync PR CI did not expose a valid check-suite ID.");
   }
@@ -146,7 +147,7 @@ async function waitForChecks(options, expectedCheckSuiteId, dependencies = {}) {
   const pause = dependencies.wait || wait;
 
   for (let attempt = 1; attempt <= options.maxAttempts; attempt += 1) {
-    const summaries = summarizeChecks(load(), expectedCheckSuiteId);
+    const summaries = summarizeChecks(load(), expectedCheckSuiteId, requiredChecks);
     process.stdout.write(`[canonical-sync] ${summaries.map((item) => `${item.name}:${item.conclusion}`).join(" ")}\n`);
     const failed = summaries.filter((item) => item.state === "failed");
     if (failed.length) throw new Error(`Canonical-sync required checks failed: ${failed.map((item) => item.name).join(", ")}`);
@@ -156,7 +157,7 @@ async function waitForChecks(options, expectedCheckSuiteId, dependencies = {}) {
   throw new Error("Timed out waiting for canonical-sync required checks.");
 }
 
-async function ensurePullRequestChecksStarted(options, expectedBaseSha, dependencies = {}) {
+async function ensurePullRequestChecksStarted(options, expectedBaseSha, dependencies = {}, workflowPath = CI_WORKFLOW_PATH) {
   const load = dependencies.loadWorkflowRuns || (() => {
     const payload = JSON.parse(runGh([
       "api",
@@ -173,7 +174,7 @@ async function ensurePullRequestChecksStarted(options, expectedBaseSha, dependen
   const pause = dependencies.wait || wait;
 
   for (let attempt = 1; attempt <= options.maxAttempts; attempt += 1) {
-    const run = selectCanonicalPullRequestRun(load(), options, expectedBaseSha);
+    const run = selectCanonicalPullRequestRun(load(), options, expectedBaseSha, workflowPath);
     if (!run) {
       await pause(options.pollSeconds * 1000);
       continue;
@@ -202,6 +203,8 @@ async function main() {
   validatePullRequest(initialPr, options, initialBaseSha);
   const pullRequestRun = await ensurePullRequestChecksStarted(options, initialBaseSha);
   await waitForChecks(options, pullRequestRun.check_suite_id);
+  const baselineRun = await ensurePullRequestChecksStarted(options, initialBaseSha, {}, BASELINE_WORKFLOW_PATH);
+  await waitForChecks(options, baselineRun.check_suite_id, {}, ["aas-v1-baseline"]);
   const pr = JSON.parse(runGh(["api", `repos/${options.repo}/pulls/${options.pr}`]));
   const finalBranch = JSON.parse(runGh(["api", `repos/${options.repo}/branches/main`]));
   validateProtectedMain(finalBranch);
@@ -212,7 +215,9 @@ async function main() {
   const payload = JSON.stringify({
     merge_method: "squash",
     sha: options.head,
-    commit_title: "chore: synchronize canonical repository state",
+    commit_title: options.skipPages
+      ? "[skip pages] chore: synchronize canonical repository state"
+      : "chore: synchronize canonical repository state",
     commit_message: "Generated artifacts reproduced and merged through protected required checks.",
   });
   const merged = JSON.parse(runGh(

--- a/tools/scripts/tests/merge_canonical_sync_pr.test.js
+++ b/tools/scripts/tests/merge_canonical_sync_pr.test.js
@@ -72,6 +72,11 @@ const canonicalRun = {
   }],
 };
 assert.strictEqual(canonicalMerge.selectCanonicalPullRequestRun([canonicalRun], options, "b".repeat(40)), canonicalRun);
+const baselineRun = { ...canonicalRun, id: 125, path: ".github/workflows/aas-v1-baseline-check.yml", check_suite_id: 778 };
+assert.strictEqual(
+  canonicalMerge.selectCanonicalPullRequestRun([baselineRun], options, "b".repeat(40), ".github/workflows/aas-v1-baseline-check.yml"),
+  baselineRun,
+);
 assert.strictEqual(canonicalMerge.selectCanonicalPullRequestRun([
   { ...canonicalRun, actor: { login: "attacker" } },
 ], options, "b".repeat(40)), null);
@@ -130,6 +135,11 @@ assert.throws(
     wait: async () => {},
   });
   assert.strictEqual(calls, 2);
+
+  await canonicalMerge.waitForChecks({ ...options, pollSeconds: 1, maxAttempts: 1 }, 778, {
+    loadCheckRuns: () => [run("aas-v1-baseline", "success", 30, 15368, 778)],
+    wait: async () => {},
+  }, ["aas-v1-baseline"]);
   console.log("Canonical sync merge tests passed.");
 })().catch((error) => {
   console.error(error);


### PR DESCRIPTION
## Summary
- make `--skip-pages` durable by tagging the canonical-sync merge commit
- skip the Pages build/deploy job for tagged push events while preserving explicit dispatch
- enforce the frozen AAS baseline before canonical-sync merges

## Validation
- `node tools/scripts/tests/merge_canonical_sync_pr.test.js`
- `npm run lint:workflows`
- `npm run validate`
- `npm run security:docs`
- `git diff --check`

## Quality Bar Checklist
- [x] Change is scoped to canonical-sync/Pages maintenance behavior
- [x] Tests cover the new baseline and skip behavior
- [x] No canonical skill content changed
- [x] No public Pages deployment was performed