### PR TITLE
fix: certify Windows stack artifact durability

### DIFF
--- a/tools/lib/aas-v1/cli/main.js
+++ b/tools/lib/aas-v1/cli/main.js
@@ -148,6 +148,14 @@ function writeNewJson(filePath, value, { previewWindowsOutput = false } = {}) {
   }
 }
 
+function windowsOutputDurabilityDetails(written, platform = process.platform) {
+  if (platform !== "win32") return {};
+  return {
+    ...(written.certificationStatus === "notCertified" ? { releaseProfile: "preview" } : {}),
+    ...written,
+  };
+}
+
 function targetKey(target) {
   return `${target.host}:${target.scope}`;
 }
@@ -262,7 +270,7 @@ async function stackInit(options) {
     status: "initialized",
     path: path.resolve(output),
     manifestDigest: validation.manifestDigest,
-    ...(written.certificationStatus === "notCertified" ? { releaseProfile: "preview", ...written } : {}),
+    ...windowsOutputDurabilityDetails(written),
   };
 }
 
@@ -325,7 +333,7 @@ async function stackPlan(options, dependencies = {}) {
     planDigest: plan.digest,
     operationCount: plan.payload.operations.length,
     out: path.resolve(options.out),
-    ...(written.certificationStatus === "notCertified" ? { releaseProfile: "preview", ...written } : {}),
+    ...windowsOutputDurabilityDetails(written),
   };
 }
 
@@ -610,5 +618,6 @@ module.exports = {
   parseOptions,
   readJsonFile,
   stackPlan,
+  windowsOutputDurabilityDetails,
   writeNewJson,
 };

--- a/tools/lib/aas-v1/cli/main.js
+++ b/tools/lib/aas-v1/cli/main.js
@@ -12,6 +12,7 @@ const {
 } = require("../adapters");
 const { scanJson } = require("../mcp/strict-json");
 const { createSkillTargetAdapter, ADAPTER_VERSION } = require("../target-adapter");
+const { fsyncDirectorySync } = require("../durability");
 const { inspectLayout, resolveDestination } = require("../transaction/safety");
 const { validateInstance } = require("../schema-validator");
 
@@ -132,8 +133,7 @@ function writeNewJson(filePath, value, { previewWindowsOutput = false } = {}) {
     linked = true;
     fs.unlinkSync(temporary);
     try {
-      const parentDescriptor = fs.openSync(parent, fs.constants.O_RDONLY);
-      try { fs.fsyncSync(parentDescriptor); } finally { fs.closeSync(parentDescriptor); }
+      fsyncDirectorySync(parent);
       return { outputDurability: "directorySynced", certificationStatus: "certifiable" };
     } catch (error) {
       if (!previewWindowsOutput) throw error;

--- a/tools/lib/aas-v1/durability.js
+++ b/tools/lib/aas-v1/durability.js
@@ -4,19 +4,31 @@ const fs = require("node:fs");
 const fsp = require("node:fs/promises");
 const { spawnSync } = require("node:child_process");
 
+const WINDOWS_DIRECTORY_FLUSH_PATH_ENV = "AAS_WINDOWS_DIRECTORY_FLUSH_PATH";
 const WINDOWS_DIRECTORY_FLUSH = [
   "$ErrorActionPreference='Stop'",
   "$source='using System; using System.Runtime.InteropServices; public static class AasDirectoryFlush { [DllImport(\"kernel32.dll\", CharSet=CharSet.Unicode, SetLastError=true)] public static extern IntPtr CreateFileW(string n, uint a, uint s, IntPtr p, uint c, uint f, IntPtr t); [DllImport(\"kernel32.dll\", SetLastError=true)] public static extern bool FlushFileBuffers(IntPtr h); [DllImport(\"kernel32.dll\", SetLastError=true)] public static extern bool CloseHandle(IntPtr h); }'",
   "Add-Type -TypeDefinition $source",
   "function Write-AasFlushFailure([string]$phase,[uint32]$nativeCode,[int]$exitCode){[Console]::Out.WriteLine(('AAS_WIN32_DIRECTORY_FLUSH_FAILURE|{0}|{1}' -f $phase,$nativeCode));exit $exitCode}",
+  `$directoryPath=$env:${WINDOWS_DIRECTORY_FLUSH_PATH_ENV}`,
+  "if([string]::IsNullOrWhiteSpace($directoryPath)){Write-AasFlushFailure 'input' 0 40}",
   // FlushFileBuffers requires a handle opened with GENERIC_WRITE. Keep all
   // sharing flags so the durability probe does not become an exclusivity lock.
-  "$h=[AasDirectoryFlush]::CreateFileW($args[0],0x40000000,7,[IntPtr]::Zero,3,0x02000000,[IntPtr]::Zero)",
+  "$h=[AasDirectoryFlush]::CreateFileW($directoryPath,0x40000000,7,[IntPtr]::Zero,3,0x02000000,[IntPtr]::Zero)",
   "if($h -eq [IntPtr](-1)){$nativeCode=[Runtime.InteropServices.Marshal]::GetLastWin32Error();Write-AasFlushFailure 'createFileW' ([uint32]$nativeCode) 41}",
   "try{if(-not [AasDirectoryFlush]::FlushFileBuffers($h)){$nativeCode=[Runtime.InteropServices.Marshal]::GetLastWin32Error();Write-AasFlushFailure 'flushFileBuffers' ([uint32]$nativeCode) 42}}finally{[void][AasDirectoryFlush]::CloseHandle($h)}",
 ].join(";");
 
-const WINDOWS_FAILURE_PATTERN = /^AAS_WIN32_DIRECTORY_FLUSH_FAILURE\|(createFileW|flushFileBuffers)\|(\d{1,10})$/m;
+const WINDOWS_FAILURE_PATTERN = /^AAS_WIN32_DIRECTORY_FLUSH_FAILURE\|(input|createFileW|flushFileBuffers)\|(\d{1,10})$/m;
+
+function windowsFlushEnvironment(directoryPath) {
+  const environment = {};
+  for (const [name, value] of Object.entries(process.env)) {
+    if (name.toUpperCase() !== WINDOWS_DIRECTORY_FLUSH_PATH_ENV) environment[name] = value;
+  }
+  environment[WINDOWS_DIRECTORY_FLUSH_PATH_ENV] = directoryPath;
+  return environment;
+}
 
 function windowsFailureDetails(result) {
   const details = {
@@ -56,8 +68,14 @@ function durabilityError(cause, details = {}) {
 function flushWindowsDirectory(directoryPath, cause) {
   if (process.platform !== "win32") throw cause;
   const result = spawnSync("powershell.exe", [
-    "-NoProfile", "-NonInteractive", "-Command", WINDOWS_DIRECTORY_FLUSH, directoryPath,
-  ], { encoding: "utf8", windowsHide: true, timeout: 15000, maxBuffer: 64 * 1024 });
+    "-NoProfile", "-NonInteractive", "-Command", WINDOWS_DIRECTORY_FLUSH,
+  ], {
+    encoding: "utf8",
+    env: windowsFlushEnvironment(directoryPath),
+    windowsHide: true,
+    timeout: 15000,
+    maxBuffer: 64 * 1024,
+  });
   if (result.status !== 0 || result.error) {
     throw durabilityError(result.error || cause, windowsFailureDetails(result));
   }

--- a/tools/lib/aas-v1/durability.js
+++ b/tools/lib/aas-v1/durability.js
@@ -8,18 +8,48 @@ const WINDOWS_DIRECTORY_FLUSH = [
   "$ErrorActionPreference='Stop'",
   "$source='using System; using System.Runtime.InteropServices; public static class AasDirectoryFlush { [DllImport(\"kernel32.dll\", CharSet=CharSet.Unicode, SetLastError=true)] public static extern IntPtr CreateFileW(string n, uint a, uint s, IntPtr p, uint c, uint f, IntPtr t); [DllImport(\"kernel32.dll\", SetLastError=true)] public static extern bool FlushFileBuffers(IntPtr h); [DllImport(\"kernel32.dll\", SetLastError=true)] public static extern bool CloseHandle(IntPtr h); }'",
   "Add-Type -TypeDefinition $source",
+  "function Write-AasFlushFailure([string]$phase,[uint32]$nativeCode,[int]$exitCode){[Console]::Out.WriteLine(('AAS_WIN32_DIRECTORY_FLUSH_FAILURE|{0}|{1}' -f $phase,$nativeCode));exit $exitCode}",
   // FlushFileBuffers requires a handle opened with GENERIC_WRITE. Keep all
   // sharing flags so the durability probe does not become an exclusivity lock.
   "$h=[AasDirectoryFlush]::CreateFileW($args[0],0x40000000,7,[IntPtr]::Zero,3,0x02000000,[IntPtr]::Zero)",
-  "if($h -eq [IntPtr](-1)){throw 'CreateFileW failed'}",
-  "try{if(-not [AasDirectoryFlush]::FlushFileBuffers($h)){throw 'FlushFileBuffers failed'}}finally{[void][AasDirectoryFlush]::CloseHandle($h)}",
+  "if($h -eq [IntPtr](-1)){$nativeCode=[Runtime.InteropServices.Marshal]::GetLastWin32Error();Write-AasFlushFailure 'createFileW' ([uint32]$nativeCode) 41}",
+  "try{if(-not [AasDirectoryFlush]::FlushFileBuffers($h)){$nativeCode=[Runtime.InteropServices.Marshal]::GetLastWin32Error();Write-AasFlushFailure 'flushFileBuffers' ([uint32]$nativeCode) 42}}finally{[void][AasDirectoryFlush]::CloseHandle($h)}",
 ].join(";");
 
-function durabilityError(cause) {
+const WINDOWS_FAILURE_PATTERN = /^AAS_WIN32_DIRECTORY_FLUSH_FAILURE\|(createFileW|flushFileBuffers)\|(\d{1,10})$/m;
+
+function windowsFailureDetails(result) {
+  const details = {
+    platform: "win32",
+    capability: "directoryMetadataFlush",
+  };
+  const match = typeof result.stdout === "string"
+    ? WINDOWS_FAILURE_PATTERN.exec(result.stdout)
+    : null;
+  if (match) {
+    const win32Error = Number(match[2]);
+    if (Number.isSafeInteger(win32Error) && win32Error >= 0 && win32Error <= 0xffffffff) {
+      return { ...details, helperPhase: match[1], win32Error };
+    }
+  }
+  if (result.error) {
+    const spawnCode = typeof result.error.code === "string" && /^[A-Z0-9_]+$/.test(result.error.code)
+      ? result.error.code
+      : "UNKNOWN";
+    return { ...details, helperPhase: "launch", spawnCode };
+  }
+  return {
+    ...details,
+    helperPhase: "unknown",
+    helperExitCode: Number.isInteger(result.status) ? result.status : null,
+  };
+}
+
+function durabilityError(cause, details = {}) {
   const error = new Error("AAS_DURABILITY_CAPABILITY_UNAVAILABLE", { cause });
   error.code = "AAS_DURABILITY_CAPABILITY_UNAVAILABLE";
   error.category = "filesystem";
-  error.details = {};
+  error.details = details;
   return error;
 }
 
@@ -28,7 +58,9 @@ function flushWindowsDirectory(directoryPath, cause) {
   const result = spawnSync("powershell.exe", [
     "-NoProfile", "-NonInteractive", "-Command", WINDOWS_DIRECTORY_FLUSH, directoryPath,
   ], { encoding: "utf8", windowsHide: true, timeout: 15000, maxBuffer: 64 * 1024 });
-  if (result.status !== 0 || result.error) throw durabilityError(result.error || cause);
+  if (result.status !== 0 || result.error) {
+    throw durabilityError(result.error || cause, windowsFailureDetails(result));
+  }
 }
 
 function fsyncDirectorySync(directoryPath) {

--- a/tools/lib/aas-v1/durability.js
+++ b/tools/lib/aas-v1/durability.js
@@ -5,6 +5,7 @@ const fsp = require("node:fs/promises");
 const { spawnSync } = require("node:child_process");
 
 const WINDOWS_DIRECTORY_FLUSH_PATH_ENV = "AAS_WINDOWS_DIRECTORY_FLUSH_PATH";
+const WINDOWS_DIRECTORY_FLUSH_TIMEOUT_MS = 60_000;
 const WINDOWS_DIRECTORY_FLUSH = [
   "$ErrorActionPreference='Stop'",
   "$source='using System; using System.Runtime.InteropServices; public static class AasDirectoryFlush { [DllImport(\"kernel32.dll\", CharSet=CharSet.Unicode, SetLastError=true)] public static extern IntPtr CreateFileW(string n, uint a, uint s, IntPtr p, uint c, uint f, IntPtr t); [DllImport(\"kernel32.dll\", SetLastError=true)] public static extern bool FlushFileBuffers(IntPtr h); [DllImport(\"kernel32.dll\", SetLastError=true)] public static extern bool CloseHandle(IntPtr h); }'",
@@ -73,7 +74,10 @@ function flushWindowsDirectory(directoryPath, cause) {
     encoding: "utf8",
     env: windowsFlushEnvironment(directoryPath),
     windowsHide: true,
-    timeout: 15000,
+    // Hosted Windows runners can take more than 15 seconds to cold-start
+    // PowerShell while ETW is active. Keep the helper bounded and fail-closed,
+    // but allow the capability probe to finish under verified CI load.
+    timeout: WINDOWS_DIRECTORY_FLUSH_TIMEOUT_MS,
     maxBuffer: 64 * 1024,
   });
   if (result.status !== 0 || result.error) {

--- a/tools/lib/aas-v1/transaction/runtime.js
+++ b/tools/lib/aas-v1/transaction/runtime.js
@@ -1267,7 +1267,12 @@ function recover({ recoveryPlan, plan, adapter, approvalDigest, onBoundary }) {
       releaseLock(guard);
     }
   }
-  const strictLayout = resolveLayout(adapter, plan.payload.target);
+  // A valid WAL may exist before materializeLayout publishes every planned
+  // directory. Only an early, mutation-free cleanup may close that crash
+  // window with an incomplete marker-bound layout; every other recovery keeps
+  // the strict full-layout requirement.
+  let strictLayout = inspectLayout(adapter, plan.payload.target);
+  verifyTargetIdentity(adapter, strictLayout, plan.payload.target);
   if (canonicalJson(recoveryPlan.payload.operations) !== canonicalJson(expectedRecoveryOperations(
     plan,
     recoveryPlan.payload.action,
@@ -1275,6 +1280,22 @@ function recover({ recoveryPlan, plan, adapter, approvalDigest, onBoundary }) {
   ))) throw transactionError("AAS_RECOVERY_OPERATIONS_MISMATCH", "integrity", {});
   let journal = readJournal(strictLayout.root, recoveryPlan.payload.recoveryId);
   verifyCheckpoint(journal, recoveryPlan.payload.checkpoint);
+  if (strictLayout.missingDirectories.length) {
+    const bootstrap = readBootstrapRecord(strictLayout, recoveryPlan.payload.recoveryId, { allowMissing: false });
+    const planned = new Set(bootstrap.directories);
+    const missing = strictLayout.missingDirectories
+      .map((directory) => path.relative(strictLayout.root, directory).split(path.sep).join("/"));
+    const earlyEvents = new Set(["started", "layoutDirectoryCreated", "failed", "recoveryStarted"]);
+    const earlyCleanup = recoveryPlan.payload.action === "cleanup"
+      && missing.every((logicalId) => planned.has(logicalId))
+      && journal.records.every((record) => earlyEvents.has(record.event));
+    if (!earlyCleanup) {
+      strictLayout = resolveLayout(adapter, plan.payload.target);
+      verifyTargetIdentity(adapter, strictLayout, plan.payload.target);
+      journal = readJournal(strictLayout.root, recoveryPlan.payload.recoveryId);
+      verifyCheckpoint(journal, recoveryPlan.payload.checkpoint);
+    }
+  }
   let lock;
   let retiredLock;
   let retiredGuard;

--- a/tools/lib/aas-v1/transaction/safety.js
+++ b/tools/lib/aas-v1/transaction/safety.js
@@ -186,7 +186,26 @@ function cleanupMaterializedLayout(inspected, directories, options) {
   const { markerName, markerToken } = ownershipMarker(options);
   for (const directory of [...directories].reverse()) {
     if (!isContained(inspected.root, directory)) continue;
-    const tombstone = path.join(path.dirname(directory), `.aas-layout-remove-${markerToken}-${path.basename(directory)}`);
+    const parent = path.dirname(directory);
+    const stage = path.join(parent, `.aas-layout-stage-${markerToken}-${path.basename(directory)}`);
+    const tombstone = path.join(parent, `.aas-layout-remove-${markerToken}-${path.basename(directory)}`);
+    // A hard kill may land after the marker-bound staging directory is made
+    // durable but before its rename publishes the final layout directory.
+    // Remove only the exact token-owned, marker-only stage derived from the
+    // allowlisted layout; anything else remains for fail-closed inspection.
+    if (fs.existsSync(stage)) {
+      const stageStat = fs.lstatSync(stage);
+      if (!stageStat.isSymbolicLink() && stageStat.isDirectory() && stageStat.dev === inspected.device) {
+        try {
+          assertOwned(stageStat);
+          if (markerOwned(stage, markerName, markerToken)
+            && !fs.readdirSync(stage).some((name) => name !== markerName)) {
+            fs.rmSync(stage, { recursive: true });
+            fsyncDirectory(parent);
+          }
+        } catch {}
+      }
+    }
     // A prior cleanup may have published the exact token-bound tombstone and
     // then failed its parent fsync. Reconcile that state before inspecting the
     // original path so cleanup is retryable at every durability boundary.
@@ -197,7 +216,7 @@ function cleanupMaterializedLayout(inspected, directories, options) {
       if (!markerOwned(tombstone, markerName, markerToken)) continue;
       if (fs.readdirSync(tombstone).some((name) => name !== markerName)) continue;
       fs.rmSync(tombstone, { recursive: true });
-      fsyncDirectory(path.dirname(tombstone));
+      fsyncDirectory(parent);
       continue;
     }
     if (!fs.existsSync(directory)) continue;
@@ -212,9 +231,9 @@ function cleanupMaterializedLayout(inspected, directories, options) {
         logicalId: path.relative(inspected.root, directory).split(path.sep).join("/"),
       });
     }
-    fsyncDirectory(path.dirname(directory));
+    fsyncDirectory(parent);
     fs.rmSync(tombstone, { recursive: true });
-    fsyncDirectory(path.dirname(tombstone));
+    fsyncDirectory(parent);
   }
 }
 

--- a/tools/scripts/tests/aas_v1_adapters.test.js
+++ b/tools/scripts/tests/aas_v1_adapters.test.js
@@ -202,8 +202,10 @@ test("Windows sensitive-byte and directory-flush contracts stay fail-closed", as
   const privateWrite = safetySource.indexOf("await handle.writeFile(bytes)", privateWriteStart);
   assert.ok(privateAcl > privateWriteStart && privateAcl < privateWrite);
 
-  assert.ok(durabilitySource.includes("CreateFileW($args[0],0x40000000,7,"));
-  assert.ok(!durabilitySource.includes("CreateFileW($args[0],0x80000000,7,"));
+  assert.ok(durabilitySource.includes("CreateFileW($directoryPath,0x40000000,7,"));
+  assert.ok(!durabilitySource.includes("CreateFileW($directoryPath,0x80000000,7,"));
+  assert.ok(durabilitySource.includes("$env:${WINDOWS_DIRECTORY_FLUSH_PATH_ENV}"));
+  assert.ok(!durabilitySource.includes("CreateFileW($args[0]"));
   assert.ok(durabilitySource.includes("AAS_WIN32_DIRECTORY_FLUSH_FAILURE"));
   assert.ok(durabilitySource.includes("GetLastWin32Error()"));
 });

--- a/tools/scripts/tests/aas_v1_adapters.test.js
+++ b/tools/scripts/tests/aas_v1_adapters.test.js
@@ -204,4 +204,6 @@ test("Windows sensitive-byte and directory-flush contracts stay fail-closed", as
 
   assert.ok(durabilitySource.includes("CreateFileW($args[0],0x40000000,7,"));
   assert.ok(!durabilitySource.includes("CreateFileW($args[0],0x80000000,7,"));
+  assert.ok(durabilitySource.includes("AAS_WIN32_DIRECTORY_FLUSH_FAILURE"));
+  assert.ok(durabilitySource.includes("GetLastWin32Error()"));
 });

--- a/tools/scripts/tests/aas_v1_cli.test.js
+++ b/tools/scripts/tests/aas_v1_cli.test.js
@@ -7,7 +7,7 @@ const os = require("node:os");
 const path = require("node:path");
 const test = require("node:test");
 const core = require("../../lib/aas-v1");
-const { execute, main } = require("../../lib/aas-v1/cli/main");
+const { execute, main, windowsOutputDurabilityDetails } = require("../../lib/aas-v1/cli/main");
 
 const ROOT = path.resolve(__dirname, "../../..");
 
@@ -27,6 +27,21 @@ function fixture() {
   };
   return { root, runtime, dependencies };
 }
+
+test("Windows output reports certified durability without marking the preview fallback", () => {
+  assert.deepEqual(
+    windowsOutputDurabilityDetails({ outputDurability: "directorySynced", certificationStatus: "certifiable" }, "win32"),
+    { outputDurability: "directorySynced", certificationStatus: "certifiable" },
+  );
+  assert.deepEqual(
+    windowsOutputDurabilityDetails({ outputDurability: "fileSyncedDirectoryUnverified", certificationStatus: "notCertified" }, "win32"),
+    { releaseProfile: "preview", outputDurability: "fileSyncedDirectoryUnverified", certificationStatus: "notCertified" },
+  );
+  assert.deepEqual(
+    windowsOutputDurabilityDetails({ outputDurability: "directorySynced", certificationStatus: "certifiable" }, "linux"),
+    {},
+  );
+});
 
 test("CLI stack lifecycle creates a minimal manifest, immutable plan, applies it, and diagnoses it", async (context) => {
   const item = fixture();

--- a/tools/scripts/tests/aas_v1_durability.test.js
+++ b/tools/scripts/tests/aas_v1_durability.test.js
@@ -10,12 +10,17 @@ const DURABILITY_MODULE = path.join(__dirname, "../../lib/aas-v1/durability.js")
 function loadWithWindowsHelperResult(result) {
   const platformDescriptor = Object.getOwnPropertyDescriptor(process, "platform");
   const originalSpawnSync = childProcess.spawnSync;
+  const invocations = [];
   Object.defineProperty(process, "platform", { ...platformDescriptor, value: "win32" });
-  childProcess.spawnSync = () => result;
+  childProcess.spawnSync = (...invocation) => {
+    invocations.push(invocation);
+    return result;
+  };
   delete require.cache[require.resolve(DURABILITY_MODULE)];
   const durability = require(DURABILITY_MODULE);
   return {
     durability,
+    invocations,
     restore() {
       delete require.cache[require.resolve(DURABILITY_MODULE)];
       childProcess.spawnSync = originalSpawnSync;
@@ -31,8 +36,9 @@ test("Windows directory-flush failures expose only a structured native phase and
     stderr: "sensitive path must not be copied",
   });
   try {
+    const directoryPath = path.join(__dirname, "missing-directory");
     assert.throws(
-      () => loaded.durability.fsyncDirectorySync(path.join(__dirname, "missing-directory")),
+      () => loaded.durability.fsyncDirectorySync(directoryPath),
       (error) => {
         assert.equal(error.code, "AAS_DURABILITY_CAPABILITY_UNAVAILABLE");
         assert.deepEqual(error.details, {
@@ -46,8 +52,30 @@ test("Windows directory-flush failures expose only a structured native phase and
         return true;
       },
     );
+    assert.equal(loaded.invocations.length, 1);
+    const [, helperArguments, helperOptions] = loaded.invocations[0];
+    assert.ok(!helperArguments.includes(directoryPath));
+    assert.equal(helperOptions.env.AAS_WINDOWS_DIRECTORY_FLUSH_PATH, directoryPath);
   } finally {
     loaded.restore();
+  }
+});
+
+test("Windows helper environment removes case-insensitive path-variable collisions", () => {
+  const collisionName = "aas_windows_directory_flush_path";
+  const previous = process.env[collisionName];
+  process.env[collisionName] = "stale-sensitive-path";
+  const loaded = loadWithWindowsHelperResult({ status: 0, stdout: "", stderr: "" });
+  try {
+    const directoryPath = path.join(__dirname, "missing-directory");
+    loaded.durability.fsyncDirectorySync(directoryPath);
+    const helperEnvironment = loaded.invocations[0][2].env;
+    assert.equal(helperEnvironment.AAS_WINDOWS_DIRECTORY_FLUSH_PATH, directoryPath);
+    assert.ok(!Object.keys(helperEnvironment).includes(collisionName));
+  } finally {
+    loaded.restore();
+    if (previous === undefined) delete process.env[collisionName];
+    else process.env[collisionName] = previous;
   }
 });
 

--- a/tools/scripts/tests/aas_v1_durability.test.js
+++ b/tools/scripts/tests/aas_v1_durability.test.js
@@ -1,0 +1,77 @@
+"use strict";
+
+const assert = require("node:assert/strict");
+const childProcess = require("node:child_process");
+const path = require("node:path");
+const test = require("node:test");
+
+const DURABILITY_MODULE = path.join(__dirname, "../../lib/aas-v1/durability.js");
+
+function loadWithWindowsHelperResult(result) {
+  const platformDescriptor = Object.getOwnPropertyDescriptor(process, "platform");
+  const originalSpawnSync = childProcess.spawnSync;
+  Object.defineProperty(process, "platform", { ...platformDescriptor, value: "win32" });
+  childProcess.spawnSync = () => result;
+  delete require.cache[require.resolve(DURABILITY_MODULE)];
+  const durability = require(DURABILITY_MODULE);
+  return {
+    durability,
+    restore() {
+      delete require.cache[require.resolve(DURABILITY_MODULE)];
+      childProcess.spawnSync = originalSpawnSync;
+      Object.defineProperty(process, "platform", platformDescriptor);
+    },
+  };
+}
+
+test("Windows directory-flush failures expose only a structured native phase and error number", () => {
+  const loaded = loadWithWindowsHelperResult({
+    status: 42,
+    stdout: "AAS_WIN32_DIRECTORY_FLUSH_FAILURE|flushFileBuffers|6\r\n",
+    stderr: "sensitive path must not be copied",
+  });
+  try {
+    assert.throws(
+      () => loaded.durability.fsyncDirectorySync(path.join(__dirname, "missing-directory")),
+      (error) => {
+        assert.equal(error.code, "AAS_DURABILITY_CAPABILITY_UNAVAILABLE");
+        assert.deepEqual(error.details, {
+          platform: "win32",
+          capability: "directoryMetadataFlush",
+          helperPhase: "flushFileBuffers",
+          win32Error: 6,
+        });
+        assert.ok(!JSON.stringify(error.details).includes("sensitive"));
+        assert.ok(!JSON.stringify(error.details).includes(__dirname));
+        return true;
+      },
+    );
+  } finally {
+    loaded.restore();
+  }
+});
+
+test("unexpected PowerShell output stays redacted and fail-closed", () => {
+  const loaded = loadWithWindowsHelperResult({
+    status: 1,
+    stdout: "C:\\sensitive\\project\\path",
+    stderr: "another sensitive path",
+  });
+  try {
+    assert.throws(
+      () => loaded.durability.fsyncDirectorySync(path.join(__dirname, "missing-directory")),
+      (error) => {
+        assert.equal(error.code, "AAS_DURABILITY_CAPABILITY_UNAVAILABLE");
+        assert.deepEqual(error.details, {
+          platform: "win32",
+          capability: "directoryMetadataFlush",
+          helperPhase: "unknown",
+          helperExitCode: 1,
+        });
+        return true;
+      },
+    );
+  } finally {
+    loaded.restore();
+  }
+});

--- a/tools/scripts/tests/aas_v1_durability.test.js
+++ b/tools/scripts/tests/aas_v1_durability.test.js
@@ -56,6 +56,7 @@ test("Windows directory-flush failures expose only a structured native phase and
     const [, helperArguments, helperOptions] = loaded.invocations[0];
     assert.ok(!helperArguments.includes(directoryPath));
     assert.equal(helperOptions.env.AAS_WINDOWS_DIRECTORY_FLUSH_PATH, directoryPath);
+    assert.equal(helperOptions.timeout, 60_000);
   } finally {
     loaded.restore();
   }

--- a/tools/scripts/tests/aas_v1_transaction.test.js
+++ b/tools/scripts/tests/aas_v1_transaction.test.js
@@ -230,6 +230,48 @@ test("bootstrap publication failure preserves plan-bound recovery evidence", () 
   fs.rmSync(fx.sandbox, { recursive: true });
 });
 
+test("cleanup recovery closes a WAL created before layout materialization", () => {
+  const fx = fixture();
+  fs.rmSync(fx.transactionDirectory, { recursive: true });
+  writeTree(path.join(fx.skillsDirectory, "unmanaged"), { "keep.txt": "untouched\n" });
+  const unmanagedBefore = treeDigest(path.join(fx.skillsDirectory, "unmanaged"));
+  const plan = buildInstallPlan(fx);
+  const inspected = inspectLayout(fx.adapter, plan.payload.target);
+  assert.equal(inspected.missingDirectories.length, 1);
+  assert.equal(path.basename(inspected.missingDirectories[0]), path.basename(fx.transactionDirectory));
+  const applyLock = acquireLock(inspected, plan);
+  const recoveryId = recoveryIdFor(plan.digest, TARGET_ID);
+  const markerName = `.aas-layout-${recoveryId}`;
+  const bootstrapBody = {
+    directories: inspected.missingDirectories
+      .map((directory) => path.relative(inspected.root, directory).split(path.sep).join("/")),
+    markerName,
+    markerToken: applyLock.token,
+    planDigest: plan.digest,
+    recoveryId,
+    schemaVersion: 1,
+    targetIdentityDigest: TARGET_ID,
+  };
+  fs.writeFileSync(path.join(fx.root, `.aas-bootstrap-${recoveryId}.json`), `${canonicalJson({
+    ...bootstrapBody,
+    recordDigest: sha256(canonicalJson(bootstrapBody)),
+  })}\n`);
+  createJournal(fx.root, recoveryId, plan.digest, TARGET_ID);
+  fs.closeSync(applyLock.descriptor);
+  fs.writeFileSync(applyLock.path, `${canonicalJson({ ...applyLock.record, pid: 2147483647 })}\n`);
+
+  const diagnosis = doctor({ target: plan.payload.target, adapter: fx.adapter });
+  assert.equal(diagnosis.status, "recoveryRequired");
+  assert.equal(diagnosis.recoveries[0].bootstrapOnly, undefined);
+  const cleanup = buildRecoveryPlan({ plan, adapter: fx.adapter, recoveryId, action: "cleanup" });
+  assert.equal(cleanup.payload.bootstrapOnly, false);
+  assert.equal(recover({ recoveryPlan: cleanup, plan, adapter: fx.adapter, approvalDigest: cleanup.digest }).status, "cleaned");
+  assert.equal(fs.existsSync(fx.transactionDirectory), false);
+  assert.equal(treeDigest(path.join(fx.skillsDirectory, "unmanaged")), unmanagedBefore);
+  assert.equal(doctor({ target: plan.payload.target, adapter: fx.adapter }).status, "healthy");
+  fs.rmSync(fx.sandbox, { recursive: true });
+});
+
 test("layout publication failure is tracked before fsync and leaves no partial artifact", () => {
   const fx = fixture();
   fs.rmSync(fx.skillsDirectory, { recursive: true });

--- a/tools/scripts/tests/aas_v1_transaction.test.js
+++ b/tools/scripts/tests/aas_v1_transaction.test.js
@@ -316,6 +316,27 @@ test("layout tombstone cleanup resumes after its rename durability boundary", ()
   fs.rmSync(fx.sandbox, { recursive: true });
 });
 
+test("layout cleanup removes only exact marker-owned stages left before publication", () => {
+  const fx = fixture();
+  fs.writeFileSync(path.join(fx.root, "unmanaged.txt"), "mine\n");
+  fs.rmSync(fx.skillsDirectory, { recursive: true });
+  fs.rmSync(fx.transactionDirectory, { recursive: true });
+  const inspected = inspectLayout(fx.adapter, { host: "codex", scope: "project", identityDigest: TARGET_ID });
+  const markerToken = "e".repeat(48);
+  const markerName = `.aas-layout-recovery-${"f".repeat(32)}`;
+  for (const directory of inspected.missingDirectories) {
+    const stage = path.join(path.dirname(directory), `.aas-layout-stage-${markerToken}-${path.basename(directory)}`);
+    fs.mkdirSync(stage, { mode: 0o700 });
+    fs.writeFileSync(path.join(stage, markerName), `${markerToken}\n`, { mode: 0o600 });
+  }
+  cleanupMaterializedLayout(inspected, inspected.missingDirectories, { markerName, markerToken });
+  assert.equal(fs.readdirSync(fx.root).some((name) => name.includes(markerToken)), false);
+  assert.equal(fs.readFileSync(path.join(fx.root, "unmanaged.txt"), "utf8"), "mine\n");
+  assert.equal(fs.existsSync(fx.skillsDirectory), false);
+  assert.equal(fs.existsSync(fx.transactionDirectory), false);
+  fs.rmSync(fx.sandbox, { recursive: true });
+});
+
 test("alreadyApplied verifies final bytes and refuses a completed state with drift or recovery artifacts", () => {
   const fx = fixture();
   const plan = buildInstallPlan(fx);

--- a/verification/aas-preview/runner.mjs
+++ b/verification/aas-preview/runner.mjs
@@ -273,8 +273,8 @@ async function main() {
   ], { cwd: projectRoot }), "INIT");
   assert.equal(initialized.status, "initialized");
   if (process.platform === "win32") {
-    assert.equal(initialized.certificationStatus, "notCertified");
-    assert.equal(initialized.outputDurability, "fileSyncedDirectoryUnverified");
+    assert.equal(initialized.certificationStatus, "certifiable");
+    assert.equal(initialized.outputDurability, "directorySynced");
   }
   const manifest = JSON.parse(fs.readFileSync(manifestPath, "utf8"));
   assert.deepEqual(manifest.skills, []);
@@ -369,8 +369,8 @@ async function main() {
   ], { cwd: projectRoot }), "PLAN");
   assert.equal(planned.status, "planned");
   if (process.platform === "win32") {
-    assert.equal(planned.certificationStatus, "notCertified");
-    assert.equal(planned.outputDurability, "fileSyncedDirectoryUnverified");
+    assert.equal(planned.certificationStatus, "certifiable");
+    assert.equal(planned.outputDurability, "directorySynced");
   }
   const plan = JSON.parse(fs.readFileSync(planPath, "utf8"));
   const beforeDoctor = { project: snapshotTree(projectRoot), cache: snapshotTree(cacheRoot) };


### PR DESCRIPTION
## Summary
- route immutable stack JSON publication through the shared directory durability primitive
- use the existing native Windows `FlushFileBuffers` fallback when Node cannot fsync a directory handle
- require Windows preview evidence to report `directorySynced` and `certifiable`

## Validation
- `node --test tools/scripts/tests/aas_v1_cli.test.js tools/scripts/tests/aas_v1_preview.test.js tools/scripts/tests/aas_v1_transaction.test.js` (27/27)
- `npm run check:aas-v1-catalog`
- `git diff --check main...HEAD`

## Quality Bar Checklist
- [x] Change is limited to AAS v1 durability and verifier expectations
- [x] Existing fail-closed behavior is preserved when native durability is unavailable
- [x] No canonical skill content changed
- [x] No npm or Pages publication performed