### PR TITLE
ci: require explicit Pages release dispatch

### DIFF
--- a/.github/MAINTENANCE.md
+++ b/.github/MAINTENANCE.md
@@ -283,7 +283,7 @@ We used this flow for PRs [#220](https://github.com/sickn33/agentic-awesome-skil
 **Maintainer shortcut for batched PRs:**
 
 - Use `npm run merge:batch -- --prs 450,449,446,451` to automate the ordered maintainer flow for multiple PRs. See [docs/maintainers/merge-batch.md](../docs/maintainers/merge-batch.md) for the short usage guide.
-- When a canonical-sync PR must be merged without publishing Pages, invoke `tools/scripts/merge_canonical_sync_pr.cjs` with `--skip-pages`. The merge commit carries `[skip pages]`, required CI, the frozen AAS baseline, and CodeQL remain enforced, and Pages remains an explicit later action.
+- Pages is release-only: ordinary pushes to `main` never deploy it. Dispatch `.github/workflows/pages.yml` explicitly only at an approved publication gate. Canonical-sync merges still use `--skip-pages` and carry `[skip pages]` as a durable audit marker; required CI, the frozen AAS baseline, and CodeQL remain enforced.
 - The script keeps the GitHub-only squash merge rule, handles fork-run approvals and stale PR metadata refresh, waits only on fresh required checks, retries `Base branch was modified`, and runs the mandatory post-merge `sync:contributors` follow-up on `main`. The fork content allowlist applies only to external PRs; same-repository maintainer PRs may change repository-wide source while remaining subject to protected checks, trusted changed-skill evidence, exact-head review, and immutable PR identity.
 - It is intentionally not a conflict resolver. If a PR is conflicting, stop and follow the manual conflict playbook.
 

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,12 +1,10 @@
-# Build and deploy the web app to GitHub Pages.
+# Build and deploy the web app to GitHub Pages only after an explicit release dispatch.
 # Enable in repo: Settings → Pages → Source: GitHub Actions.
 # Site URL: https://<owner>.github.io/<repo>/
 
 name: Deploy Web App to GitHub Pages
 
 on:
-  push:
-    branches: ["main", "master"]
   workflow_dispatch:
 
 permissions:
@@ -23,7 +21,6 @@ env:
 
 jobs:
   build:
-    if: github.event_name == 'workflow_dispatch' || !contains(github.event.head_commit.message, '[skip pages]')
     runs-on: ubuntu-latest
     steps:
       - name: Checkout


### PR DESCRIPTION
## Summary
- stop deploying GitHub Pages on every push to `main`
- keep the Pages workflow available only through explicit release dispatch
- document the publication gate and retain canonical-sync audit markers

## Validation
- `npm run lint:workflows`
- `npm run validate`
- `npm run security:docs`
- `git diff --check`

## Quality Bar Checklist
- [x] Prevents unapproved public publication during AAS v1 development
- [x] Explicit approved Pages releases remain available
- [x] No canonical skill content changed
- [x] No Pages deployment performed