### PR TITLE
test: freeze explicit Pages release trigger

### DIFF
--- a/tools/scripts/tests/workflow_contracts.test.js
+++ b/tools/scripts/tests/workflow_contracts.test.js
@@ -76,6 +76,8 @@ const pagesWorkflow = fs.readFileSync(
   path.resolve(__dirname, "..", "..", "..", ".github", "workflows", "pages.yml"),
   "utf8",
 );
+assert.match(pagesWorkflow, /^on:\s*\n\s+workflow_dispatch:/m);
+assert.doesNotMatch(pagesWorkflow, /^\s+push:/m);
 for (const command of [
   "npm run validate:strict",
   "npm run validate:glossary",


### PR DESCRIPTION
## Summary
- freeze the release-only Pages workflow contract
- fail if a push trigger is reintroduced

## Validation
- `node tools/scripts/tests/workflow_contracts.test.js`
- `npm run lint:workflows`
- `git diff --check`

## Quality Bar Checklist
- [x] Test-only contract guard
- [x] No canonical skill content changed
- [x] No Pages deployment performed