### PR TITLE
test: add black-box transaction evidence controller

### DIFF
--- a/.github/workflows/aas-v1-product-verifier.yml
+++ b/.github/workflows/aas-v1-product-verifier.yml
@@ -63,6 +63,7 @@ jobs:
         working-directory: candidate
         shell: bash
         run: |
+          npm ci --ignore-scripts --no-audit --no-fund
           mkdir -p "$RUNNER_TEMP/aas-candidate"
           npm pack --ignore-scripts --json --pack-destination "$RUNNER_TEMP/aas-candidate" > "$RUNNER_TEMP/aas-pack.json"
           test "$(find "$RUNNER_TEMP/aas-candidate" -maxdepth 1 -name '*.tgz' -type f | wc -l | tr -d ' ')" = 1
@@ -139,6 +140,18 @@ jobs:
       - name: Verify protected freeze before candidate execution
         working-directory: trusted/verification/aas-v1/verifier
         run: npm run freeze:check
+      - name: Generate external transaction evidence
+        shell: bash
+        env:
+          AAS_VERIFIER_RUNNER_LABEL: ${{ matrix.os }}
+          AAS_VERIFIER_FILESYSTEM_TYPE: ${{ matrix.fs_type }}
+          AAS_VERIFIER_FILESYSTEM_CASE: ${{ matrix.fs_case }}
+        run: |
+          tarball="$(find "$RUNNER_TEMP/candidate" -maxdepth 1 -name '*.tgz' -type f -print -quit)"
+          node trusted/verification/aas-v1/verifier/bin/generate-transaction-evidence.mjs \
+            --tarball "$tarball" \
+            --work-root "$RUNNER_TEMP/aas-v1-transaction-work" \
+            --out "$RUNNER_TEMP/aas-transaction-evidence.json"
       - name: Run black-box verifier
         shell: bash
         env:

--- a/verification/aas-v1/baseline/v1/freeze-manifest.json
+++ b/verification/aas-v1/baseline/v1/freeze-manifest.json
@@ -8,7 +8,7 @@
     "verifier/node_modules/",
     "baseline/v1/legacy/14.6.0/_work/"
   ],
-  "rootDigest": "sha256-8d3ccce4357964d469eb1f2e11ca379f6df3669c2c9c6dbb9e25ab33a623c131",
+  "rootDigest": "sha256-4cd3efdb824f2ab5b3546c7c05973549b936cc5fcea2007a56d43ef87db6f1e8",
   "fileCount": 764,
   "files": [
     {
@@ -3723,8 +3723,8 @@
     },
     {
       "path": "verifier/lib/observer.mjs",
-      "bytes": 28053,
-      "sha256": "142d79bdd7c4f449ac4c2b8b9452ede26764a2237fd2482e8aa0ee00283c7740"
+      "bytes": 29472,
+      "sha256": "6e06406954eccb37202410e301b8c50cece0904fdd0e0da5b04ecfe612abcefe"
     },
     {
       "path": "verifier/lib/prng.mjs",
@@ -3808,8 +3808,8 @@
     },
     {
       "path": "verifier/tests/observer.test.mjs",
-      "bytes": 4876,
-      "sha256": "127f4ed7d315abb911b8a3a8b1a7d105f8f78056703d9d86aaf0a5ea70ac9f4d"
+      "bytes": 5730,
+      "sha256": "3c8111741f33dc100ffc752d456c29264d970e38823a5ab1d137573e011f0c77"
     },
     {
       "path": "verifier/tests/runtime.test.mjs",

--- a/verification/aas-v1/baseline/v1/freeze-manifest.json
+++ b/verification/aas-v1/baseline/v1/freeze-manifest.json
@@ -8,7 +8,7 @@
     "verifier/node_modules/",
     "baseline/v1/legacy/14.6.0/_work/"
   ],
-  "rootDigest": "sha256-4cd3efdb824f2ab5b3546c7c05973549b936cc5fcea2007a56d43ef87db6f1e8",
+  "rootDigest": "sha256-eb032a1527a0d5eb2432a09dfbb812b2b39f40f73f4464288718bd46201213a5",
   "fileCount": 764,
   "files": [
     {
@@ -3758,8 +3758,8 @@
     },
     {
       "path": "verifier/lib/transaction-controller.mjs",
-      "bytes": 38780,
-      "sha256": "61afc801bde261ec40d9031479dc001fb50a5c039f6e7fe7960c4e42e21560fb"
+      "bytes": 39299,
+      "sha256": "06ed63f503d3c3a59c34b1cf5c6a0086eceb8a304557dfb02b8dbcd3eeea4a50"
     },
     {
       "path": "verifier/lib/transaction-evidence.mjs",

--- a/verification/aas-v1/baseline/v1/freeze-manifest.json
+++ b/verification/aas-v1/baseline/v1/freeze-manifest.json
@@ -8,7 +8,7 @@
     "verifier/node_modules/",
     "baseline/v1/legacy/14.6.0/_work/"
   ],
-  "rootDigest": "sha256-9d86796560f5a6fca8169259d820ca7c2895419e98bba428332dba4936f8eb09",
+  "rootDigest": "sha256-2bb92ca8893dc7fcd2348decb2d69b41a6229f62826a094848cfec1e2bf7e330",
   "fileCount": 764,
   "files": [
     {
@@ -3723,8 +3723,8 @@
     },
     {
       "path": "verifier/lib/observer.mjs",
-      "bytes": 26123,
-      "sha256": "c8ff0f1aad94c06ddb089078f0e6b06c33e68b74c52319115adc33b3ea63ccd4"
+      "bytes": 26895,
+      "sha256": "ef93b4684cf0643c09271f061febbeb5933164e19e92b510a54597a1f5ab5264"
     },
     {
       "path": "verifier/lib/prng.mjs",
@@ -3808,8 +3808,8 @@
     },
     {
       "path": "verifier/tests/observer.test.mjs",
-      "bytes": 3424,
-      "sha256": "a4b6effd1be8b7a65da764fd46d783cb037a4016245bbe838e14e6b942fae687"
+      "bytes": 4062,
+      "sha256": "990f6e4c4b68d15057d951948249b4e79ae2f44cf5577c37430bce74fafd83ee"
     },
     {
       "path": "verifier/tests/runtime.test.mjs",

--- a/verification/aas-v1/baseline/v1/freeze-manifest.json
+++ b/verification/aas-v1/baseline/v1/freeze-manifest.json
@@ -8,7 +8,7 @@
     "verifier/node_modules/",
     "baseline/v1/legacy/14.6.0/_work/"
   ],
-  "rootDigest": "sha256-686fa2220b4ee6067707a176561cda63c132d1eb94b225d8fe7515d3b39805c2",
+  "rootDigest": "sha256-fbefc073730b9cc6db0fd5b2088bd2f2c05d8fae675497dc45c1f54607af9ed6",
   "fileCount": 764,
   "files": [
     {
@@ -3723,8 +3723,8 @@
     },
     {
       "path": "verifier/lib/observer.mjs",
-      "bytes": 26895,
-      "sha256": "ef93b4684cf0643c09271f061febbeb5933164e19e92b510a54597a1f5ab5264"
+      "bytes": 26950,
+      "sha256": "9b370965342b1c90a686e09e0ccc08a78c89d113164bf006f0ffc9161af9530a"
     },
     {
       "path": "verifier/lib/prng.mjs",
@@ -3808,8 +3808,8 @@
     },
     {
       "path": "verifier/tests/observer.test.mjs",
-      "bytes": 4062,
-      "sha256": "990f6e4c4b68d15057d951948249b4e79ae2f44cf5577c37430bce74fafd83ee"
+      "bytes": 4105,
+      "sha256": "56acbfa7e8d53c8ded15ce1a08da8311efb0ad5d4856058f5c7be87815fc9682"
     },
     {
       "path": "verifier/tests/runtime.test.mjs",

--- a/verification/aas-v1/baseline/v1/freeze-manifest.json
+++ b/verification/aas-v1/baseline/v1/freeze-manifest.json
@@ -8,7 +8,7 @@
     "verifier/node_modules/",
     "baseline/v1/legacy/14.6.0/_work/"
   ],
-  "rootDigest": "sha256-88fb7eb49c534ab30bcda2d8d3421dc47ad91ea7817dc797e05d51ffed3d7d17",
+  "rootDigest": "sha256-7ec1fbced81201aaf6b498bf470a6a7f554df2bd0144ff34b8e6ecefd4f2c00e",
   "fileCount": 764,
   "files": [
     {
@@ -3758,8 +3758,8 @@
     },
     {
       "path": "verifier/lib/transaction-controller.mjs",
-      "bytes": 36054,
-      "sha256": "7c917ba70e96a8931fcce8141277744e1c44a5a03da4fc3c26ddc30fd6c518a8"
+      "bytes": 36559,
+      "sha256": "2d875ff11f7022d314d21365f76de6cc91ad3a72a6b3784f2f8717c7829dddeb"
     },
     {
       "path": "verifier/lib/transaction-evidence.mjs",
@@ -3823,8 +3823,8 @@
     },
     {
       "path": "verifier/tests/transaction-evidence.test.mjs",
-      "bytes": 6014,
-      "sha256": "201a03fd1126b68bb781ffa6d6de14ab33f5c0941cc9b033be9942d786dc9653"
+      "bytes": 6951,
+      "sha256": "09c1ac6381c0c464a56c9b977c1d039e131b90112b11b742b896b8ad3cbd0043"
     },
     {
       "path": "verifier/tests/tuning-gold-equivalence-audit.test.mjs",

--- a/verification/aas-v1/baseline/v1/freeze-manifest.json
+++ b/verification/aas-v1/baseline/v1/freeze-manifest.json
@@ -8,7 +8,7 @@
     "verifier/node_modules/",
     "baseline/v1/legacy/14.6.0/_work/"
   ],
-  "rootDigest": "sha256-fbf3428ddaca3bb183c0051ae042eecfa408bf733102f5369c3cab449dfd8c16",
+  "rootDigest": "sha256-cc72f086a29179fe8e8aab6eeabeac6494981e80041cca5bc153d993ab933ac6",
   "fileCount": 764,
   "files": [
     {
@@ -3678,8 +3678,8 @@
     },
     {
       "path": "verifier/drivers/transaction-fault.mjs",
-      "bytes": 7373,
-      "sha256": "c296efd606e6da5008dcda4df2b1ea2f6742968d5c93a400bfefb75074d126c5"
+      "bytes": 7396,
+      "sha256": "37d5d27d13448e5b9c8c8e956a9483c1d5b3405529c30143a7611fa2085cd6a6"
     },
     {
       "path": "verifier/drivers/transaction-race.mjs",
@@ -3758,8 +3758,8 @@
     },
     {
       "path": "verifier/lib/transaction-controller.mjs",
-      "bytes": 33225,
-      "sha256": "45c90e4d6d1e7d58e9b75c6ef6aa2982daa01846f2cbee6c3b4ae8c9e69cccf2"
+      "bytes": 34011,
+      "sha256": "013ffdf6329e4b40c4615b9f2e6c9dbfef5ed6b0b797a8f7bd6eb178e05c3b5e"
     },
     {
       "path": "verifier/lib/transaction-evidence.mjs",

--- a/verification/aas-v1/baseline/v1/freeze-manifest.json
+++ b/verification/aas-v1/baseline/v1/freeze-manifest.json
@@ -8,7 +8,7 @@
     "verifier/node_modules/",
     "baseline/v1/legacy/14.6.0/_work/"
   ],
-  "rootDigest": "sha256-f4f289f8a2cb6b94497895fa84751ef89187d86af3cd3fd43b3ae3ed7492848a",
+  "rootDigest": "sha256-39202f4bdc19e942cc47eef8e2f09ae45de88ed7176f460919e91f3d422597b4",
   "fileCount": 764,
   "files": [
     {
@@ -3678,8 +3678,8 @@
     },
     {
       "path": "verifier/drivers/transaction-fault.mjs",
-      "bytes": 8519,
-      "sha256": "e45850b3c113a69295aa745d5b527a23b738df388fb195e73c0b53e89d401647"
+      "bytes": 8781,
+      "sha256": "593c351bc63ee324d6ba3f00b7773d5be97c6f0a57ff36c9ea946377a8e020b8"
     },
     {
       "path": "verifier/drivers/transaction-race.mjs",

--- a/verification/aas-v1/baseline/v1/freeze-manifest.json
+++ b/verification/aas-v1/baseline/v1/freeze-manifest.json
@@ -8,7 +8,7 @@
     "verifier/node_modules/",
     "baseline/v1/legacy/14.6.0/_work/"
   ],
-  "rootDigest": "sha256-c47e52dc37d17768a3be3fe238fb73dacc1f4559e295c289c663d88bacf8cfb0",
+  "rootDigest": "sha256-6b72552f28432af9270b1e59df4c025599e3af02f71a92061a582c9348997c07",
   "fileCount": 764,
   "files": [
     {
@@ -3758,8 +3758,8 @@
     },
     {
       "path": "verifier/lib/transaction-controller.mjs",
-      "bytes": 36738,
-      "sha256": "3b06eb93c8248da936e184a3da9456c82fc30ac3c5305169c0de66212a9e672e"
+      "bytes": 37223,
+      "sha256": "c4101fc54fc9671ca26aefaccee5d1e668fafa799475da758cab2807f404434b"
     },
     {
       "path": "verifier/lib/transaction-evidence.mjs",
@@ -3823,8 +3823,8 @@
     },
     {
       "path": "verifier/tests/transaction-evidence.test.mjs",
-      "bytes": 7854,
-      "sha256": "cde10a86c2c40385a4cee31dc33f1df19a75cb836672175dded8ab2509e89917"
+      "bytes": 8422,
+      "sha256": "266864f035a0f67bcea001dcf548557b108419983cc167bf9f7a356458e10717"
     },
     {
       "path": "verifier/tests/tuning-gold-equivalence-audit.test.mjs",

--- a/verification/aas-v1/baseline/v1/freeze-manifest.json
+++ b/verification/aas-v1/baseline/v1/freeze-manifest.json
@@ -8,7 +8,7 @@
     "verifier/node_modules/",
     "baseline/v1/legacy/14.6.0/_work/"
   ],
-  "rootDigest": "sha256-fbefc073730b9cc6db0fd5b2088bd2f2c05d8fae675497dc45c1f54607af9ed6",
+  "rootDigest": "sha256-fbf3428ddaca3bb183c0051ae042eecfa408bf733102f5369c3cab449dfd8c16",
   "fileCount": 764,
   "files": [
     {
@@ -3758,8 +3758,8 @@
     },
     {
       "path": "verifier/lib/transaction-controller.mjs",
-      "bytes": 32774,
-      "sha256": "ec27139f3b532bc996ae5ebe0268420ced7b057cb616b3f4c18465808d450146"
+      "bytes": 33225,
+      "sha256": "45c90e4d6d1e7d58e9b75c6ef6aa2982daa01846f2cbee6c3b4ae8c9e69cccf2"
     },
     {
       "path": "verifier/lib/transaction-evidence.mjs",

--- a/verification/aas-v1/baseline/v1/freeze-manifest.json
+++ b/verification/aas-v1/baseline/v1/freeze-manifest.json
@@ -8,7 +8,7 @@
     "verifier/node_modules/",
     "baseline/v1/legacy/14.6.0/_work/"
   ],
-  "rootDigest": "sha256-b111b32296a0a5495ba70b97959890c8c35bde81f11a6d334f44806f8be862f7",
+  "rootDigest": "sha256-9d48466f195f5156a4a95c6e25e067afe840734cd08a0980bef1ddc36882a187",
   "fileCount": 764,
   "files": [
     {
@@ -3758,8 +3758,8 @@
     },
     {
       "path": "verifier/lib/transaction-controller.mjs",
-      "bytes": 37976,
-      "sha256": "a546f661f34265bb20fb2fb678918775afd3d025dbacaeeae4500c5849d46d3a"
+      "bytes": 38454,
+      "sha256": "38988f7de7051fdbfb0b0d30ac288d2940fdc8e00063fa4153c6579d33561a23"
     },
     {
       "path": "verifier/lib/transaction-evidence.mjs",
@@ -3823,8 +3823,8 @@
     },
     {
       "path": "verifier/tests/transaction-evidence.test.mjs",
-      "bytes": 9170,
-      "sha256": "009440aaefcd04aa82c810cd04fab818823d575ecc6bc38846dc062a154f9e73"
+      "bytes": 9946,
+      "sha256": "d914259b0dcfbb85bbd2111f01039349277468f8ce086371f4f888bf199796d5"
     },
     {
       "path": "verifier/tests/tuning-gold-equivalence-audit.test.mjs",

--- a/verification/aas-v1/baseline/v1/freeze-manifest.json
+++ b/verification/aas-v1/baseline/v1/freeze-manifest.json
@@ -8,7 +8,7 @@
     "verifier/node_modules/",
     "baseline/v1/legacy/14.6.0/_work/"
   ],
-  "rootDigest": "sha256-eb032a1527a0d5eb2432a09dfbb812b2b39f40f73f4464288718bd46201213a5",
+  "rootDigest": "sha256-a7b09f915cc3879a97d477dac9f38022ca8d9496aff70bc5ca5a182b452b27d9",
   "fileCount": 764,
   "files": [
     {
@@ -3758,8 +3758,8 @@
     },
     {
       "path": "verifier/lib/transaction-controller.mjs",
-      "bytes": 39299,
-      "sha256": "06ed63f503d3c3a59c34b1cf5c6a0086eceb8a304557dfb02b8dbcd3eeea4a50"
+      "bytes": 39925,
+      "sha256": "2eb3b2bd8711677eedfefaca7f3289faaa1c9ce4dacc2743552890719c46da92"
     },
     {
       "path": "verifier/lib/transaction-evidence.mjs",
@@ -3823,8 +3823,8 @@
     },
     {
       "path": "verifier/tests/transaction-evidence.test.mjs",
-      "bytes": 10483,
-      "sha256": "896c342ba089414dee86ccbddeb49aa99e5703d196d2e58dc045aceda7a558bb"
+      "bytes": 10899,
+      "sha256": "cfe5bb814b7e2d0db2d825adfa95d86891454ebe5774ed3ccbbd7f749ee8094e"
     },
     {
       "path": "verifier/tests/tuning-gold-equivalence-audit.test.mjs",

--- a/verification/aas-v1/baseline/v1/freeze-manifest.json
+++ b/verification/aas-v1/baseline/v1/freeze-manifest.json
@@ -8,8 +8,8 @@
     "verifier/node_modules/",
     "baseline/v1/legacy/14.6.0/_work/"
   ],
-  "rootDigest": "sha256-8413fa955c4926a041237f815356853ecee6cf6aee9825697724d06beabd0a81",
-  "fileCount": 757,
+  "rootDigest": "sha256-a234fcab5b987a8c444c4c9e65bf06775a6a6ec0ac4ff0baf04a2035e8ab802e",
+  "fileCount": 763,
   "files": [
     {
       "path": "README.md",
@@ -3573,8 +3573,8 @@
     },
     {
       "path": "schemas/product-transaction-evidence.schema.json",
-      "bytes": 2902,
-      "sha256": "806b390497ca7789749cdec15030c23e13d8c373fae1ead968b75de104dde2b5"
+      "bytes": 5217,
+      "sha256": "eb1c566215580c3b0598d0200727e16d3290bfc2700e0fc5a5eabaaead1fe94c"
     },
     {
       "path": "schemas/product-verifier-manifest.schema.json",
@@ -3617,6 +3617,11 @@
       "sha256": "0fd74f758fd76956656c46cfd2825ff2716d8c0127bb2624e7d5d2a390930bb6"
     },
     {
+      "path": "verifier/bin/generate-transaction-evidence.mjs",
+      "bytes": 1389,
+      "sha256": "e6cb7931302824264ee6b3a037f673e194187b3f75f5ce673ed70de1e91efb5a"
+    },
+    {
       "path": "verifier/bin/merge-product-evidence.mjs",
       "bytes": 1174,
       "sha256": "62a9bfca49c008c5ef11156d42c5b02a66c9722099a9d9e8f3ba31a9fa5f188f"
@@ -3648,8 +3653,8 @@
     },
     {
       "path": "verifier/bin/verify-product.mjs",
-      "bytes": 8811,
-      "sha256": "3b9e5ef4d0803b5ccda12c14bd2b5e00bf4e072f50dcc09bef7596c6d6316cd7"
+      "bytes": 8475,
+      "sha256": "2707179f492c4fd98f429f820142683b9cfb4f6583f1c9e6a47f1274b5b7056c"
     },
     {
       "path": "verifier/drivers/fuzz.cjs",
@@ -3670,6 +3675,16 @@
       "path": "verifier/drivers/property.cjs",
       "bytes": 10358,
       "sha256": "ec35432454c5867cff1ea265cf1a6a2c889afc36689a8e521186f658e08e67f5"
+    },
+    {
+      "path": "verifier/drivers/transaction-fault.mjs",
+      "bytes": 7373,
+      "sha256": "c296efd606e6da5008dcda4df2b1ea2f6742968d5c93a400bfefb75074d126c5"
+    },
+    {
+      "path": "verifier/drivers/transaction-race.mjs",
+      "bytes": 4615,
+      "sha256": "9706d0b170bdfbd37db40f65fd819043fd3fb61fbadba51f28147d6c27ecfb2a"
     },
     {
       "path": "verifier/drivers/windows-tree-child.ps1",
@@ -3742,6 +3757,16 @@
       "sha256": "b0092b585006a581e127408f3a560d1b5a77cbb9c7a1c8b9f7e74a0514e5c949"
     },
     {
+      "path": "verifier/lib/transaction-controller.mjs",
+      "bytes": 32618,
+      "sha256": "6cdd56163238a830471fd186310e2d0cc4b4633b839edbb52e5cc428d6c36cd7"
+    },
+    {
+      "path": "verifier/lib/transaction-evidence.mjs",
+      "bytes": 11460,
+      "sha256": "2fff15ff8ae040c602848653502b341a7014fe1ab7571c2bfe667e3f114c7c00"
+    },
+    {
       "path": "verifier/observers/windows-etw.ps1",
       "bytes": 9245,
       "sha256": "7e7da41a8334e66c1f4b19ce4ec9a74c461708f4c333c55b861f2746511f8f53"
@@ -3754,12 +3779,12 @@
     {
       "path": "verifier/package-lock.json",
       "bytes": 2953,
-      "sha256": "036646405be913db4dcb90b3fa8131988c295b3783d57bd079320539a80be782"
+      "sha256": "1dab9aa6bd27350ccd90950b79109862c2a2c4363e9f691b3490602560e38203"
     },
     {
       "path": "verifier/package.json",
-      "bytes": 1205,
-      "sha256": "d5add74f94d14ac6d0b8566eeda47b98360d0995af5efed1fe51a060694b68d7"
+      "bytes": 1277,
+      "sha256": "a19c6096414c03e0472d8fa945293c8be3ba624e25017988a97ee1723d10e30a"
     },
     {
       "path": "verifier/tests/aggregate.test.mjs",
@@ -3787,9 +3812,14 @@
       "sha256": "a4b6effd1be8b7a65da764fd46d783cb037a4016245bbe838e14e6b942fae687"
     },
     {
+      "path": "verifier/tests/transaction-evidence-semantics.test.mjs",
+      "bytes": 10033,
+      "sha256": "572dd378f4d66a0a1591bc4bf0faf5f64d5e68e1ff6f2bf68ffaaddf58779d5d"
+    },
+    {
       "path": "verifier/tests/transaction-evidence.test.mjs",
-      "bytes": 1804,
-      "sha256": "8fb73620c3ea46b5d7f918a6d429257164518465edaf9b2415514c4f574bb78a"
+      "bytes": 3091,
+      "sha256": "ee06b8f5a4c8eba4c3771ed24cd412cc30c456ff64b970c271cea13d653f6d18"
     },
     {
       "path": "verifier/tests/tuning-gold-equivalence-audit.test.mjs",

--- a/verification/aas-v1/baseline/v1/freeze-manifest.json
+++ b/verification/aas-v1/baseline/v1/freeze-manifest.json
@@ -8,7 +8,7 @@
     "verifier/node_modules/",
     "baseline/v1/legacy/14.6.0/_work/"
   ],
-  "rootDigest": "sha256-7ec1fbced81201aaf6b498bf470a6a7f554df2bd0144ff34b8e6ecefd4f2c00e",
+  "rootDigest": "sha256-c47e52dc37d17768a3be3fe238fb73dacc1f4559e295c289c663d88bacf8cfb0",
   "fileCount": 764,
   "files": [
     {
@@ -3758,8 +3758,8 @@
     },
     {
       "path": "verifier/lib/transaction-controller.mjs",
-      "bytes": 36559,
-      "sha256": "2d875ff11f7022d314d21365f76de6cc91ad3a72a6b3784f2f8717c7829dddeb"
+      "bytes": 36738,
+      "sha256": "3b06eb93c8248da936e184a3da9456c82fc30ac3c5305169c0de66212a9e672e"
     },
     {
       "path": "verifier/lib/transaction-evidence.mjs",
@@ -3823,8 +3823,8 @@
     },
     {
       "path": "verifier/tests/transaction-evidence.test.mjs",
-      "bytes": 6951,
-      "sha256": "09c1ac6381c0c464a56c9b977c1d039e131b90112b11b742b896b8ad3cbd0043"
+      "bytes": 7854,
+      "sha256": "cde10a86c2c40385a4cee31dc33f1df19a75cb836672175dded8ab2509e89917"
     },
     {
       "path": "verifier/tests/tuning-gold-equivalence-audit.test.mjs",

--- a/verification/aas-v1/baseline/v1/freeze-manifest.json
+++ b/verification/aas-v1/baseline/v1/freeze-manifest.json
@@ -8,8 +8,8 @@
     "verifier/node_modules/",
     "baseline/v1/legacy/14.6.0/_work/"
   ],
-  "rootDigest": "sha256-a234fcab5b987a8c444c4c9e65bf06775a6a6ec0ac4ff0baf04a2035e8ab802e",
-  "fileCount": 763,
+  "rootDigest": "sha256-9d86796560f5a6fca8169259d820ca7c2895419e98bba428332dba4936f8eb09",
+  "fileCount": 764,
   "files": [
     {
       "path": "README.md",
@@ -3743,8 +3743,8 @@
     },
     {
       "path": "verifier/lib/runtime.mjs",
-      "bytes": 3325,
-      "sha256": "c64560584c9a379c92b26606c04d1ff8855d58a4018658cc704d7a873927080c"
+      "bytes": 4213,
+      "sha256": "65c658f07226d2e2d28b6a27f1c2df03213f6ae85b6370dcdd1ca5fdd50f5641"
     },
     {
       "path": "verifier/lib/suites.mjs",
@@ -3758,8 +3758,8 @@
     },
     {
       "path": "verifier/lib/transaction-controller.mjs",
-      "bytes": 32618,
-      "sha256": "6cdd56163238a830471fd186310e2d0cc4b4633b839edbb52e5cc428d6c36cd7"
+      "bytes": 32774,
+      "sha256": "ec27139f3b532bc996ae5ebe0268420ced7b057cb616b3f4c18465808d450146"
     },
     {
       "path": "verifier/lib/transaction-evidence.mjs",
@@ -3810,6 +3810,11 @@
       "path": "verifier/tests/observer.test.mjs",
       "bytes": 3424,
       "sha256": "a4b6effd1be8b7a65da764fd46d783cb037a4016245bbe838e14e6b942fae687"
+    },
+    {
+      "path": "verifier/tests/runtime.test.mjs",
+      "bytes": 1191,
+      "sha256": "daed89d3add8b5c8d0870200ef734455f5c7042ef124ec741fcbd3c8b6677415"
     },
     {
       "path": "verifier/tests/transaction-evidence-semantics.test.mjs",

--- a/verification/aas-v1/baseline/v1/freeze-manifest.json
+++ b/verification/aas-v1/baseline/v1/freeze-manifest.json
@@ -8,7 +8,7 @@
     "verifier/node_modules/",
     "baseline/v1/legacy/14.6.0/_work/"
   ],
-  "rootDigest": "sha256-2bb92ca8893dc7fcd2348decb2d69b41a6229f62826a094848cfec1e2bf7e330",
+  "rootDigest": "sha256-686fa2220b4ee6067707a176561cda63c132d1eb94b225d8fe7515d3b39805c2",
   "fileCount": 764,
   "files": [
     {
@@ -3743,8 +3743,8 @@
     },
     {
       "path": "verifier/lib/runtime.mjs",
-      "bytes": 4213,
-      "sha256": "65c658f07226d2e2d28b6a27f1c2df03213f6ae85b6370dcdd1ca5fdd50f5641"
+      "bytes": 3891,
+      "sha256": "3a559b1c95d06724dd42aa893c83ed46135a4b385a8fdc8e53de64acf1c50b89"
     },
     {
       "path": "verifier/lib/suites.mjs",
@@ -3813,8 +3813,8 @@
     },
     {
       "path": "verifier/tests/runtime.test.mjs",
-      "bytes": 1191,
-      "sha256": "daed89d3add8b5c8d0870200ef734455f5c7042ef124ec741fcbd3c8b6677415"
+      "bytes": 940,
+      "sha256": "ff56819f43eb72bf222a50faa0d1d1f748dc5ed0a19ae72215b3366c02de46e0"
     },
     {
       "path": "verifier/tests/transaction-evidence-semantics.test.mjs",

--- a/verification/aas-v1/baseline/v1/freeze-manifest.json
+++ b/verification/aas-v1/baseline/v1/freeze-manifest.json
@@ -8,7 +8,7 @@
     "verifier/node_modules/",
     "baseline/v1/legacy/14.6.0/_work/"
   ],
-  "rootDigest": "sha256-888ba577fe37369ec37b6733fb1b06a4b27aedeb9d5f46f4963b622863c496d5",
+  "rootDigest": "sha256-f98ffcf31b5f0ef25853a59094db499af77441f98caebf1f74ac75257b96a1b6",
   "fileCount": 764,
   "files": [
     {
@@ -3758,8 +3758,8 @@
     },
     {
       "path": "verifier/lib/transaction-controller.mjs",
-      "bytes": 37728,
-      "sha256": "c730d1465c6a1bc8bc5210c06f9a1c5a1d61d70de08e5631fc4328c7892a7c0d"
+      "bytes": 37893,
+      "sha256": "123e43318d3ede8ae44b4a91bb8dfbe6a14ecce8675abb8af40a20b27796b9a4"
     },
     {
       "path": "verifier/lib/transaction-evidence.mjs",
@@ -3823,8 +3823,8 @@
     },
     {
       "path": "verifier/tests/transaction-evidence.test.mjs",
-      "bytes": 8749,
-      "sha256": "81ffcb1656e18faea193de01c247de7e74630d773fde2a17e750b9848d176abd"
+      "bytes": 9033,
+      "sha256": "b7a3baf75f29104ad0b55182362e07e83149f9667ba3d986c8dc93a72ffaced3"
     },
     {
       "path": "verifier/tests/tuning-gold-equivalence-audit.test.mjs",

--- a/verification/aas-v1/baseline/v1/freeze-manifest.json
+++ b/verification/aas-v1/baseline/v1/freeze-manifest.json
@@ -8,7 +8,7 @@
     "verifier/node_modules/",
     "baseline/v1/legacy/14.6.0/_work/"
   ],
-  "rootDigest": "sha256-e84ea18fa31b01a85d8e985da315217de4335c07b144609c1079d08c2aa71ded",
+  "rootDigest": "sha256-88fb7eb49c534ab30bcda2d8d3421dc47ad91ea7817dc797e05d51ffed3d7d17",
   "fileCount": 764,
   "files": [
     {
@@ -3758,8 +3758,8 @@
     },
     {
       "path": "verifier/lib/transaction-controller.mjs",
-      "bytes": 35840,
-      "sha256": "8df3cb0fdae5c96535faf10597bf5c7b226697dba30f4f7b8fc5ec8e8415b959"
+      "bytes": 36054,
+      "sha256": "7c917ba70e96a8931fcce8141277744e1c44a5a03da4fc3c26ddc30fd6c518a8"
     },
     {
       "path": "verifier/lib/transaction-evidence.mjs",
@@ -3823,8 +3823,8 @@
     },
     {
       "path": "verifier/tests/transaction-evidence.test.mjs",
-      "bytes": 5227,
-      "sha256": "60f41b18929d229c696400219b78f7a72143b4f1ad356e0f902e98fe175185a8"
+      "bytes": 6014,
+      "sha256": "201a03fd1126b68bb781ffa6d6de14ab33f5c0941cc9b033be9942d786dc9653"
     },
     {
       "path": "verifier/tests/tuning-gold-equivalence-audit.test.mjs",

--- a/verification/aas-v1/baseline/v1/freeze-manifest.json
+++ b/verification/aas-v1/baseline/v1/freeze-manifest.json
@@ -8,7 +8,7 @@
     "verifier/node_modules/",
     "baseline/v1/legacy/14.6.0/_work/"
   ],
-  "rootDigest": "sha256-340b25c11055376c38ba2344ad4db7fff4127ddaaac6145f81cd0aec0fa40210",
+  "rootDigest": "sha256-888ba577fe37369ec37b6733fb1b06a4b27aedeb9d5f46f4963b622863c496d5",
   "fileCount": 764,
   "files": [
     {
@@ -3758,8 +3758,8 @@
     },
     {
       "path": "verifier/lib/transaction-controller.mjs",
-      "bytes": 37223,
-      "sha256": "c4101fc54fc9671ca26aefaccee5d1e668fafa799475da758cab2807f404434b"
+      "bytes": 37728,
+      "sha256": "c730d1465c6a1bc8bc5210c06f9a1c5a1d61d70de08e5631fc4328c7892a7c0d"
     },
     {
       "path": "verifier/lib/transaction-evidence.mjs",
@@ -3823,8 +3823,8 @@
     },
     {
       "path": "verifier/tests/transaction-evidence.test.mjs",
-      "bytes": 8422,
-      "sha256": "266864f035a0f67bcea001dcf548557b108419983cc167bf9f7a356458e10717"
+      "bytes": 8749,
+      "sha256": "81ffcb1656e18faea193de01c247de7e74630d773fde2a17e750b9848d176abd"
     },
     {
       "path": "verifier/tests/tuning-gold-equivalence-audit.test.mjs",

--- a/verification/aas-v1/baseline/v1/freeze-manifest.json
+++ b/verification/aas-v1/baseline/v1/freeze-manifest.json
@@ -8,7 +8,7 @@
     "verifier/node_modules/",
     "baseline/v1/legacy/14.6.0/_work/"
   ],
-  "rootDigest": "sha256-cc72f086a29179fe8e8aab6eeabeac6494981e80041cca5bc153d993ab933ac6",
+  "rootDigest": "sha256-0ad63abe549ddf8619549f0ce9dd633fd8ed21d05d30bc0a61b26fcc59aee011",
   "fileCount": 764,
   "files": [
     {
@@ -3758,8 +3758,8 @@
     },
     {
       "path": "verifier/lib/transaction-controller.mjs",
-      "bytes": 34011,
-      "sha256": "013ffdf6329e4b40c4615b9f2e6c9dbfef5ed6b0b797a8f7bd6eb178e05c3b5e"
+      "bytes": 34054,
+      "sha256": "45d80d544d735197d923c50e9aadbc30e5c6629b79a42848ede19e9544b22002"
     },
     {
       "path": "verifier/lib/transaction-evidence.mjs",

--- a/verification/aas-v1/baseline/v1/freeze-manifest.json
+++ b/verification/aas-v1/baseline/v1/freeze-manifest.json
@@ -8,7 +8,7 @@
     "verifier/node_modules/",
     "baseline/v1/legacy/14.6.0/_work/"
   ],
-  "rootDigest": "sha256-39202f4bdc19e942cc47eef8e2f09ae45de88ed7176f460919e91f3d422597b4",
+  "rootDigest": "sha256-e84ea18fa31b01a85d8e985da315217de4335c07b144609c1079d08c2aa71ded",
   "fileCount": 764,
   "files": [
     {
@@ -3758,8 +3758,8 @@
     },
     {
       "path": "verifier/lib/transaction-controller.mjs",
-      "bytes": 35786,
-      "sha256": "2e8fcf80cc717fb1fce29458a3e77cb375d4d436ed3692e5ba364c978038db3b"
+      "bytes": 35840,
+      "sha256": "8df3cb0fdae5c96535faf10597bf5c7b226697dba30f4f7b8fc5ec8e8415b959"
     },
     {
       "path": "verifier/lib/transaction-evidence.mjs",

--- a/verification/aas-v1/baseline/v1/freeze-manifest.json
+++ b/verification/aas-v1/baseline/v1/freeze-manifest.json
@@ -8,7 +8,7 @@
     "verifier/node_modules/",
     "baseline/v1/legacy/14.6.0/_work/"
   ],
-  "rootDigest": "sha256-9738cca2bdcb120f3b7024a4261874b10b64ae919516fc42021c7208b6adbf1a",
+  "rootDigest": "sha256-f4f289f8a2cb6b94497895fa84751ef89187d86af3cd3fd43b3ae3ed7492848a",
   "fileCount": 764,
   "files": [
     {
@@ -3678,8 +3678,8 @@
     },
     {
       "path": "verifier/drivers/transaction-fault.mjs",
-      "bytes": 7396,
-      "sha256": "37d5d27d13448e5b9c8c8e956a9483c1d5b3405529c30143a7611fa2085cd6a6"
+      "bytes": 8519,
+      "sha256": "e45850b3c113a69295aa745d5b527a23b738df388fb195e73c0b53e89d401647"
     },
     {
       "path": "verifier/drivers/transaction-race.mjs",
@@ -3733,8 +3733,8 @@
     },
     {
       "path": "verifier/lib/process.mjs",
-      "bytes": 1861,
-      "sha256": "7b155892ea76a6998c0d63751938b60568192f801affd516d02cd5d53b3374bb"
+      "bytes": 1917,
+      "sha256": "eb1c6835f1a4d43044b092b54ed5479c59a6821d70365c903c6c8ebcbacedea8"
     },
     {
       "path": "verifier/lib/receipt.mjs",
@@ -3808,8 +3808,8 @@
     },
     {
       "path": "verifier/tests/observer.test.mjs",
-      "bytes": 4105,
-      "sha256": "56acbfa7e8d53c8ded15ce1a08da8311efb0ad5d4856058f5c7be87815fc9682"
+      "bytes": 4747,
+      "sha256": "a3025145e7db963729894641e7a5d02be9f34b42b2eeac7aebb3b390d26dd22b"
     },
     {
       "path": "verifier/tests/runtime.test.mjs",

--- a/verification/aas-v1/baseline/v1/freeze-manifest.json
+++ b/verification/aas-v1/baseline/v1/freeze-manifest.json
@@ -8,7 +8,7 @@
     "verifier/node_modules/",
     "baseline/v1/legacy/14.6.0/_work/"
   ],
-  "rootDigest": "sha256-0ad63abe549ddf8619549f0ce9dd633fd8ed21d05d30bc0a61b26fcc59aee011",
+  "rootDigest": "sha256-9738cca2bdcb120f3b7024a4261874b10b64ae919516fc42021c7208b6adbf1a",
   "fileCount": 764,
   "files": [
     {
@@ -3758,8 +3758,8 @@
     },
     {
       "path": "verifier/lib/transaction-controller.mjs",
-      "bytes": 34054,
-      "sha256": "45d80d544d735197d923c50e9aadbc30e5c6629b79a42848ede19e9544b22002"
+      "bytes": 35786,
+      "sha256": "2e8fcf80cc717fb1fce29458a3e77cb375d4d436ed3692e5ba364c978038db3b"
     },
     {
       "path": "verifier/lib/transaction-evidence.mjs",
@@ -3823,8 +3823,8 @@
     },
     {
       "path": "verifier/tests/transaction-evidence.test.mjs",
-      "bytes": 3091,
-      "sha256": "ee06b8f5a4c8eba4c3771ed24cd412cc30c456ff64b970c271cea13d653f6d18"
+      "bytes": 5227,
+      "sha256": "60f41b18929d229c696400219b78f7a72143b4f1ad356e0f902e98fe175185a8"
     },
     {
       "path": "verifier/tests/tuning-gold-equivalence-audit.test.mjs",

--- a/verification/aas-v1/baseline/v1/freeze-manifest.json
+++ b/verification/aas-v1/baseline/v1/freeze-manifest.json
@@ -8,7 +8,7 @@
     "verifier/node_modules/",
     "baseline/v1/legacy/14.6.0/_work/"
   ],
-  "rootDigest": "sha256-6b72552f28432af9270b1e59df4c025599e3af02f71a92061a582c9348997c07",
+  "rootDigest": "sha256-340b25c11055376c38ba2344ad4db7fff4127ddaaac6145f81cd0aec0fa40210",
   "fileCount": 764,
   "files": [
     {
@@ -3723,8 +3723,8 @@
     },
     {
       "path": "verifier/lib/observer.mjs",
-      "bytes": 26950,
-      "sha256": "9b370965342b1c90a686e09e0ccc08a78c89d113164bf006f0ffc9161af9530a"
+      "bytes": 27250,
+      "sha256": "03b7ac87b6b08737ba3422ab2a65c08c0b92189c42af3788939e53f08d540c19"
     },
     {
       "path": "verifier/lib/prng.mjs",
@@ -3809,7 +3809,7 @@
     {
       "path": "verifier/tests/observer.test.mjs",
       "bytes": 4747,
-      "sha256": "a3025145e7db963729894641e7a5d02be9f34b42b2eeac7aebb3b390d26dd22b"
+      "sha256": "0cc1e53664eac7276acc8d8a748d9416b715b73aea7170c1031aff7a969cc77d"
     },
     {
       "path": "verifier/tests/runtime.test.mjs",

--- a/verification/aas-v1/baseline/v1/freeze-manifest.json
+++ b/verification/aas-v1/baseline/v1/freeze-manifest.json
@@ -8,7 +8,7 @@
     "verifier/node_modules/",
     "baseline/v1/legacy/14.6.0/_work/"
   ],
-  "rootDigest": "sha256-9d48466f195f5156a4a95c6e25e067afe840734cd08a0980bef1ddc36882a187",
+  "rootDigest": "sha256-efab3b87770cef2f4bda104002b22ce8733d9bd8daf39d4b1ff81ca5bb4045bc",
   "fileCount": 764,
   "files": [
     {
@@ -3678,8 +3678,8 @@
     },
     {
       "path": "verifier/drivers/transaction-fault.mjs",
-      "bytes": 8781,
-      "sha256": "593c351bc63ee324d6ba3f00b7773d5be97c6f0a57ff36c9ea946377a8e020b8"
+      "bytes": 9151,
+      "sha256": "f7ea5ab2e24ef47c34a134862516a40f33c7910da0f2ce5e83b9f8d5eec47ef8"
     },
     {
       "path": "verifier/drivers/transaction-race.mjs",
@@ -3723,8 +3723,8 @@
     },
     {
       "path": "verifier/lib/observer.mjs",
-      "bytes": 27250,
-      "sha256": "03b7ac87b6b08737ba3422ab2a65c08c0b92189c42af3788939e53f08d540c19"
+      "bytes": 27608,
+      "sha256": "0e177d4d8cbd781691e1d35c987176181bce9c8f6010630db834850e22e78b76"
     },
     {
       "path": "verifier/lib/prng.mjs",
@@ -3758,8 +3758,8 @@
     },
     {
       "path": "verifier/lib/transaction-controller.mjs",
-      "bytes": 38454,
-      "sha256": "38988f7de7051fdbfb0b0d30ac288d2940fdc8e00063fa4153c6579d33561a23"
+      "bytes": 38780,
+      "sha256": "61afc801bde261ec40d9031479dc001fb50a5c039f6e7fe7960c4e42e21560fb"
     },
     {
       "path": "verifier/lib/transaction-evidence.mjs",
@@ -3823,8 +3823,8 @@
     },
     {
       "path": "verifier/tests/transaction-evidence.test.mjs",
-      "bytes": 9946,
-      "sha256": "d914259b0dcfbb85bbd2111f01039349277468f8ce086371f4f888bf199796d5"
+      "bytes": 10483,
+      "sha256": "896c342ba089414dee86ccbddeb49aa99e5703d196d2e58dc045aceda7a558bb"
     },
     {
       "path": "verifier/tests/tuning-gold-equivalence-audit.test.mjs",

--- a/verification/aas-v1/baseline/v1/freeze-manifest.json
+++ b/verification/aas-v1/baseline/v1/freeze-manifest.json
@@ -8,7 +8,7 @@
     "verifier/node_modules/",
     "baseline/v1/legacy/14.6.0/_work/"
   ],
-  "rootDigest": "sha256-f98ffcf31b5f0ef25853a59094db499af77441f98caebf1f74ac75257b96a1b6",
+  "rootDigest": "sha256-b111b32296a0a5495ba70b97959890c8c35bde81f11a6d334f44806f8be862f7",
   "fileCount": 764,
   "files": [
     {
@@ -3758,8 +3758,8 @@
     },
     {
       "path": "verifier/lib/transaction-controller.mjs",
-      "bytes": 37893,
-      "sha256": "123e43318d3ede8ae44b4a91bb8dfbe6a14ecce8675abb8af40a20b27796b9a4"
+      "bytes": 37976,
+      "sha256": "a546f661f34265bb20fb2fb678918775afd3d025dbacaeeae4500c5849d46d3a"
     },
     {
       "path": "verifier/lib/transaction-evidence.mjs",
@@ -3823,8 +3823,8 @@
     },
     {
       "path": "verifier/tests/transaction-evidence.test.mjs",
-      "bytes": 9033,
-      "sha256": "b7a3baf75f29104ad0b55182362e07e83149f9667ba3d986c8dc93a72ffaced3"
+      "bytes": 9170,
+      "sha256": "009440aaefcd04aa82c810cd04fab818823d575ecc6bc38846dc062a154f9e73"
     },
     {
       "path": "verifier/tests/tuning-gold-equivalence-audit.test.mjs",

--- a/verification/aas-v1/baseline/v1/freeze-manifest.json
+++ b/verification/aas-v1/baseline/v1/freeze-manifest.json
@@ -8,7 +8,7 @@
     "verifier/node_modules/",
     "baseline/v1/legacy/14.6.0/_work/"
   ],
-  "rootDigest": "sha256-efab3b87770cef2f4bda104002b22ce8733d9bd8daf39d4b1ff81ca5bb4045bc",
+  "rootDigest": "sha256-8d3ccce4357964d469eb1f2e11ca379f6df3669c2c9c6dbb9e25ab33a623c131",
   "fileCount": 764,
   "files": [
     {
@@ -3723,8 +3723,8 @@
     },
     {
       "path": "verifier/lib/observer.mjs",
-      "bytes": 27608,
-      "sha256": "0e177d4d8cbd781691e1d35c987176181bce9c8f6010630db834850e22e78b76"
+      "bytes": 28053,
+      "sha256": "142d79bdd7c4f449ac4c2b8b9452ede26764a2237fd2482e8aa0ee00283c7740"
     },
     {
       "path": "verifier/lib/prng.mjs",
@@ -3808,8 +3808,8 @@
     },
     {
       "path": "verifier/tests/observer.test.mjs",
-      "bytes": 4747,
-      "sha256": "0cc1e53664eac7276acc8d8a748d9416b715b73aea7170c1031aff7a969cc77d"
+      "bytes": 4876,
+      "sha256": "127f4ed7d315abb911b8a3a8b1a7d105f8f78056703d9d86aaf0a5ea70ac9f4d"
     },
     {
       "path": "verifier/tests/runtime.test.mjs",

--- a/verification/aas-v1/schemas/product-transaction-evidence.schema.json
+++ b/verification/aas-v1/schemas/product-transaction-evidence.schema.json
@@ -3,19 +3,41 @@
   "$id": "https://aas.example/schemas/v1/product-transaction-evidence.schema.json",
   "title": "AAS v1 external production transaction evidence",
   "type": "object",
-  "required": ["schemaVersion", "status", "productionBinary", "testMode", "mocked", "observer", "faultBoundaryClasses", "raceClasses", "executions", "killExecutions", "swapExecutions", "recoveryExecutions", "partialStates", "unmanagedMutations", "hardPolicyViolations", "boundaryEvidence"],
+  "required": ["schemaVersion", "status", "productionBinary", "testMode", "mocked", "candidate", "controller", "observer", "faultBoundaryClasses", "raceClasses", "executions", "killExecutions", "swapExecutions", "recoveryExecutions", "partialStates", "unmanagedMutations", "hardPolicyViolations", "boundaryEvidence"],
   "properties": {
     "schemaVersion": { "const": 1 },
     "status": { "const": "passed" },
     "productionBinary": { "const": true },
     "testMode": { "const": false },
     "mocked": { "const": false },
+    "candidate": {
+      "type": "object",
+      "required": ["package", "version", "tarballSha512", "installedTreeSha256", "aasEntrypointSha256"],
+      "properties": {
+        "package": { "const": "agentic-awesome-skills" },
+        "version": { "type": "string", "pattern": "^(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)(?:[-+][0-9A-Za-z.-]+)?$" },
+        "tarballSha512": { "type": "string", "pattern": "^sha512-[A-Za-z0-9+/]+={0,2}$" },
+        "installedTreeSha256": { "type": "string", "pattern": "^sha256-[a-f0-9]{64}$" },
+        "aasEntrypointSha256": { "type": "string", "pattern": "^sha256-[a-f0-9]{64}$" }
+      },
+      "additionalProperties": false
+    },
+    "controller": {
+      "type": "object",
+      "required": ["version", "digest"],
+      "properties": {
+        "version": { "type": "string", "pattern": "^[0-9]+\\.[0-9]+\\.[0-9]+$" },
+        "digest": { "type": "string", "pattern": "^sha256-[a-f0-9]{64}$" }
+      },
+      "additionalProperties": false
+    },
     "observer": {
       "type": "object",
-      "required": ["backend", "eventDigest", "overflow", "ambiguousLineage"],
+      "required": ["backend", "eventDigest", "eventCount", "overflow", "ambiguousLineage"],
       "properties": {
         "backend": { "enum": ["linux-strace-process-tree", "macos-fs_usage-process", "windows-etw-kernel-process-tree"] },
         "eventDigest": { "type": "string", "pattern": "^sha256-[a-f0-9]{64}$" },
+        "eventCount": { "type": "integer", "minimum": 13 },
         "overflow": { "const": false },
         "ambiguousLineage": { "const": false }
       },
@@ -40,13 +62,25 @@
       "type": "array", "minItems": 13,
       "items": {
         "type": "object",
-        "required": ["class", "observedOperation", "injectionAction", "beforeDigest", "afterDigest", "finalState", "noPartialState"],
+        "required": ["executionId", "class", "kind", "observedOperation", "injectionAction", "planDigest", "commandDigest", "observerEventDigest", "beforeDigest", "afterDigest", "unmanagedBeforeDigest", "unmanagedAfterDigest", "exitCode", "exitSignal", "recoveryAction", "recoveryStatus", "recoveryPlanDigest", "finalState", "noPartialState"],
         "properties": {
+          "executionId": { "type": "string", "pattern": "^(faultBoundary|race)-[a-z-]+$" },
           "class": { "type": "string", "minLength": 1 },
+          "kind": { "enum": ["faultBoundary", "race"] },
           "observedOperation": { "type": "string", "minLength": 1 },
           "injectionAction": { "enum": ["kill", "concurrent", "drift", "symlink-swap", "target-swap", "corrupt-journal", "recovery-race"] },
+          "planDigest": { "type": "string", "pattern": "^sha256-[a-f0-9]{64}$" },
+          "commandDigest": { "type": "string", "pattern": "^sha256-[a-f0-9]{64}$" },
+          "observerEventDigest": { "type": "string", "pattern": "^sha256-[a-f0-9]{64}$" },
           "beforeDigest": { "type": "string", "pattern": "^sha256-[a-f0-9]{64}$" },
           "afterDigest": { "type": "string", "pattern": "^sha256-[a-f0-9]{64}$" },
+          "unmanagedBeforeDigest": { "type": "string", "pattern": "^sha256-[a-f0-9]{64}$" },
+          "unmanagedAfterDigest": { "type": "string", "pattern": "^sha256-[a-f0-9]{64}$" },
+          "exitCode": { "type": "integer", "minimum": 0, "maximum": 4294967295 },
+          "exitSignal": { "type": ["string", "null"], "maxLength": 32 },
+          "recoveryAction": { "enum": ["none", "rollback", "cleanup", "fail-closed"] },
+          "recoveryStatus": { "type": "string", "minLength": 1, "maxLength": 64 },
+          "recoveryPlanDigest": { "type": "string", "pattern": "^sha256-[a-f0-9]{64}$" },
           "finalState": { "enum": ["previous", "new"] },
           "noPartialState": { "const": true }
         },

--- a/verification/aas-v1/verifier/bin/generate-transaction-evidence.mjs
+++ b/verification/aas-v1/verifier/bin/generate-transaction-evidence.mjs
@@ -1,0 +1,31 @@
+#!/usr/bin/env node
+
+import fs from "node:fs";
+import path from "node:path";
+import { canonicalJson } from "../lib/canonical.mjs";
+import { isolatedZones } from "../lib/runtime.mjs";
+import { generateTransactionEvidence } from "../lib/transaction-controller.mjs";
+
+function args(values) {
+  const out = {};
+  for (let index = 2; index < values.length; index += 2) {
+    if (!values[index].startsWith("--") || values[index + 1] === undefined) throw new Error(`Invalid argument: ${values[index]}`);
+    out[values[index].slice(2)] = values[index + 1];
+  }
+  return out;
+}
+
+const options = args(process.argv);
+if (!options.tarball || !options["work-root"] || !options.out) throw new Error("--tarball, --work-root, and --out are required");
+const workRoot = path.resolve(options["work-root"]);
+const output = path.resolve(options.out);
+fs.mkdirSync(path.dirname(output), { recursive: true, mode: 0o700 });
+const evidence = await generateTransactionEvidence({
+  tarball: path.resolve(options.tarball),
+  workRoot,
+  zones: isolatedZones(path.join(workRoot, "zones")),
+});
+const temporary = `${output}.pending-${process.pid}`;
+fs.writeFileSync(temporary, `${canonicalJson(evidence)}\n`, { mode: 0o600, flag: "wx" });
+fs.renameSync(temporary, output);
+process.stdout.write(`${JSON.stringify({ ok: true, output, executions: evidence.executions, eventDigest: evidence.observer.eventDigest })}\n`);

--- a/verification/aas-v1/verifier/bin/verify-product.mjs
+++ b/verification/aas-v1/verifier/bin/verify-product.mjs
@@ -9,6 +9,7 @@ import { snapshotZones } from "../lib/fs-evidence.mjs";
 import { selfTestObserver } from "../lib/observer.mjs";
 import { executableDigest, loadReceiptValidator, SUITE_IDS, writeCanonicalReceipt } from "../lib/receipt.mjs";
 import { installCandidate, isolatedZones, systemIdentity } from "../lib/runtime.mjs";
+import { assertTransactionEvidenceSemantics, readTransactionEvidence } from "../lib/transaction-evidence.mjs";
 import {
   packageSuite, prepareRuntimeCache, suite, verifyAdapters, verifyEntrypoints,
   verifyFuzz, verifyHostile, verifyLegacy, verifyMcp, verifyProperty,
@@ -40,16 +41,24 @@ function failedSuite(id, error) {
   return { id, status: "failed", executions: 0, failures: 1, evidenceSha256: digestJson(evidence), evidence };
 }
 
-function transactionSuite(file, manifest, validator) {
+function transactionSuite(file, manifest, validator, inspection, runtime, job, nativeObserver) {
   if (!file || !fs.existsSync(file)) throw Object.assign(new Error("OS-level transaction evidence is required"), { code: "AAS_VERIFIER_TRANSACTION_EVIDENCE_MISSING" });
-  const value = readJson(file);
-  if (!validator(value)) throw Object.assign(new Error("Transaction evidence schema failed"), { code: "AAS_VERIFIER_TRANSACTION_EVIDENCE_SCHEMA" });
-  const fault = new Set(value.faultBoundaryClasses || []);
-  const race = new Set(value.raceClasses || []);
-  for (const item of manifest.faultBoundaryClasses) if (!fault.has(item)) throw Object.assign(new Error(`Fault boundary not covered: ${item}`), { code: "AAS_VERIFIER_FAULT_BOUNDARY_MISSING" });
-  for (const item of manifest.raceClasses) if (!race.has(item)) throw Object.assign(new Error(`Race class not covered: ${item}`), { code: "AAS_VERIFIER_RACE_CLASS_MISSING" });
-  if (value.testMode === true || value.mocked === true || value.productionBinary !== true) throw Object.assign(new Error("Transaction evidence is not production black-box evidence"), { code: "AAS_VERIFIER_TRANSACTION_NOT_BLACK_BOX" });
-  if (value.partialStates !== 0 || value.unmanagedMutations !== 0 || value.hardPolicyViolations !== 0) throw Object.assign(new Error("Transaction safety invariant failed"), { code: "AAS_VERIFIER_TRANSACTION_INVARIANT" });
+  const value = readTransactionEvidence(file, validator);
+  const expectedCandidate = {
+    package: runtime.manifest.name,
+    version: runtime.manifest.version,
+    tarballSha512: inspection.sha512,
+    installedTreeSha256: runtime.treeDigest,
+    aasEntrypointSha256: sha256(fs.readFileSync(runtime.bins.aas)),
+  };
+  assertTransactionEvidenceSemantics(value, {
+    expectedCandidate,
+    jobId: job.id,
+    nativeObserverBackend: nativeObserver.backend,
+    controllerVersion: "1.0.0",
+    faultBoundaryClasses: manifest.faultBoundaryClasses,
+    raceClasses: manifest.raceClasses,
+  });
   return suite("transaction", value, value.executions || 0);
 }
 
@@ -97,7 +106,7 @@ await run("property", () => verifyProperty(runtime, budgets, runtimeMatrix.jobs.
 await run("fuzz", () => verifyFuzz(runtime, budgets, runtimeMatrix.jobs.indexOf(job), verifierRoot));
 await run("hostile", () => verifyHostile(runtime, zones, evidenceDir, hostileManifest, path.join(baselineRoot, "hostile"), verifierRoot));
 await run("legacy", () => verifyLegacy(runtime, zones, verifierRoot, path.join(baselineRoot, "legacy", "14.6.0")));
-await run("transaction", () => transactionSuite(options["transaction-evidence"], manifest, transactionValidator));
+await run("transaction", () => transactionSuite(options["transaction-evidence"], manifest, transactionValidator, inspection, runtime, job, observer));
 await run("adapters", () => verifyAdapters(runtime, zones, path.join(baselineRoot, "host-adapters"), inspection.sha512, runtimePromotion.identity.closureDigest));
 for (const id of SUITE_IDS) if (!suites.some((entry) => entry.id === id)) suites.push(failedSuite(id, Object.assign(new Error("Suite did not execute"), { code: "AAS_VERIFIER_SUITE_MISSING" })));
 

--- a/verification/aas-v1/verifier/drivers/transaction-fault.mjs
+++ b/verification/aas-v1/verifier/drivers/transaction-fault.mjs
@@ -1,0 +1,169 @@
+#!/usr/bin/env node
+
+import fs from "node:fs";
+import path from "node:path";
+import { spawn, spawnSync } from "node:child_process";
+import crypto from "node:crypto";
+
+function digest(value) {
+  return `sha256-${crypto.createHash("sha256").update(JSON.stringify(value)).digest("hex")}`;
+}
+
+function listMatching(root, matcher) {
+  const found = [];
+  const visit = (directory) => {
+    if (!fs.existsSync(directory)) return;
+    for (const name of fs.readdirSync(directory)) {
+      const absolute = path.join(directory, name);
+      let stat;
+      try { stat = fs.lstatSync(absolute); } catch { continue; }
+      const relative = path.relative(root, absolute).split(path.sep).join("/");
+      if (matcher(relative, stat)) found.push(relative);
+      if (stat.isDirectory() && !stat.isSymbolicLink()) visit(absolute);
+    }
+  };
+  visit(root);
+  return found.sort();
+}
+
+function predicate(className, targetRoot, skillId) {
+  const matchers = {
+    lock: (relative) => relative === ".aas-transaction.lock",
+    journal: (relative) => /^\.aas-transaction-recovery-[a-f0-9]+\.wal$/.test(relative),
+    backup: (relative) => relative.includes("/backups/") && relative.endsWith(`/${skillId}`),
+    write: (relative, stat) => relative.includes("/staged/") && stat.isFile(),
+    fsync: (relative) => /^\.aas-bootstrap-recovery-[a-f0-9]+\.json$/.test(relative),
+    rename: (relative) => relative === `.agents/skills/${skillId}`,
+    commit: (relative) => /^\.aas-transaction-recovery-[a-f0-9]+\.wal$/.test(relative),
+  };
+  if (!matchers[className]) throw new Error(`Unknown fault class: ${className}`);
+  const lockPath = path.join(targetRoot, ".aas-transaction.lock");
+  if (!fs.existsSync(lockPath)) return null;
+  try {
+    const text = fs.readFileSync(lockPath, "utf8");
+    const record = JSON.parse(text);
+    if (!text.endsWith("\n") || record.kind !== "apply" || !Number.isSafeInteger(record.pid)
+      || !/^[a-f0-9]{48}$/.test(record.token || "") || !/^sha256-[a-f0-9]{64}$/.test(record.planDigest || "")) return null;
+  } catch { return null; }
+  const matches = listMatching(targetRoot, matchers[className]);
+  if (!matches.length) return null;
+  try {
+    if (className === "journal") {
+      const text = fs.readFileSync(path.join(targetRoot, matches[0]), "utf8");
+      const first = JSON.parse(text.split("\n").filter(Boolean)[0]);
+      if (!text.includes("\n") || first.event !== "started" || first.sequence !== 0) return null;
+    }
+    if (className === "fsync") {
+      const text = fs.readFileSync(path.join(targetRoot, matches[0]), "utf8");
+      const value = JSON.parse(text);
+      if (!text.endsWith("\n") || !/^sha256-[a-f0-9]{64}$/.test(value.recordDigest || "")) return null;
+    }
+    if (className === "commit") {
+      const text = fs.readFileSync(path.join(targetRoot, matches[0]), "utf8");
+      const records = text.split("\n").filter(Boolean).map((line) => JSON.parse(line));
+      if (!text.endsWith("\n") || !records.some((record) => record.event === "committed")) return null;
+    }
+  } catch { return null; }
+  return { class: className, pathsDigest: digest(matches), count: matches.length };
+}
+
+function walEvidence(targetRoot) {
+  const wal = fs.readdirSync(targetRoot).find((name) => /^\.aas-transaction-recovery-[a-f0-9]+\.wal$/.test(name));
+  if (!wal) return { events: [], digest: digest([]), pathDigest: null };
+  const text = fs.readFileSync(path.join(targetRoot, wal), "utf8");
+  const records = text.split("\n").filter(Boolean).map((line) => JSON.parse(line));
+  return { events: records.map((record) => record.event), digest: digest(records), pathDigest: digest(wal) };
+}
+
+function laterBoundaryEvidence(className, targetRoot, skillId) {
+  const later = {
+    lock: (relative) => /^\.aas-bootstrap-|^\.aas-transaction-recovery-/.test(relative)
+      || relative.includes("/staged/") || relative === `.agents/skills/${skillId}` || relative === ".aas/managed-state.codex.json",
+    fsync: (relative) => /^\.aas-transaction-recovery-[a-f0-9]+\.wal$/.test(relative),
+    journal: (relative) => relative.includes("/staged/") || relative === `.agents/skills/${skillId}` || relative === ".aas/managed-state.codex.json",
+    write: (relative) => relative === `.agents/skills/${skillId}` || relative === ".aas/managed-state.codex.json",
+    backup: (relative) => relative === ".aas/managed-state.codex.json",
+    rename: (relative) => relative === ".aas/managed-state.codex.json",
+    commit: () => false,
+  };
+  return listMatching(targetRoot, later[className]);
+}
+
+function terminate(pid) {
+  if (process.platform === "win32") {
+    spawnSync("taskkill.exe", ["/PID", String(pid), "/T", "/F"], { windowsHide: true, encoding: "utf8", timeout: 10_000 });
+    return;
+  }
+  try { process.kill(-pid, "SIGKILL"); } catch (error) {
+    if (error.code !== "ESRCH") throw error;
+  }
+}
+
+const chunks = [];
+for await (const chunk of process.stdin) chunks.push(chunk);
+const input = JSON.parse(Buffer.concat(chunks).toString("utf8"));
+const child = spawn(input.executable, input.args, {
+  cwd: input.cwd,
+  env: input.env,
+  detached: process.platform !== "win32",
+  windowsHide: true,
+  stdio: ["ignore", "pipe", "pipe"],
+});
+const stdout = [];
+const stderr = [];
+child.stdout.on("data", (chunk) => stdout.push(chunk));
+child.stderr.on("data", (chunk) => stderr.push(chunk));
+const closed = new Promise((resolve, reject) => {
+  child.once("error", reject);
+  child.once("close", (code, signal) => resolve({ code: code ?? 128, signal }));
+});
+const started = Date.now();
+let observed = null;
+let terminationStarted = false;
+const observeAndTerminate = () => {
+  if (observed || terminationStarted) return;
+  const value = predicate(input.className, input.targetRoot, input.skillId);
+  if (!value) return;
+  observed = value;
+  terminationStarted = true;
+  terminate(child.pid);
+};
+const watchers = [];
+const watchDirectory = (directory) => {
+  try {
+    const watcher = fs.watch(directory, { persistent: false }, observeAndTerminate);
+    watcher.on("error", () => watcher.close());
+    watchers.push(watcher);
+  } catch {}
+};
+const visitDirectories = (directory) => {
+  watchDirectory(directory);
+  for (const entry of fs.readdirSync(directory, { withFileTypes: true })) {
+    if (entry.isDirectory() && !entry.isSymbolicLink()) visitDirectories(path.join(directory, entry.name));
+  }
+};
+visitDirectories(input.targetRoot);
+while (Date.now() - started < input.timeoutMs) {
+  observeAndTerminate();
+  if (observed) break;
+  const settled = await Promise.race([closed.then(() => true), new Promise((resolve) => setTimeout(() => resolve(false), 2))]);
+  if (settled) break;
+}
+if (!observed) terminate(child.pid);
+const outcome = await closed;
+for (const watcher of watchers) watcher.close();
+const laterBoundaries = observed ? laterBoundaryEvidence(input.className, input.targetRoot, input.skillId) : [];
+const recoveryLockPresent = fs.existsSync(path.join(input.targetRoot, ".aas-transaction.lock"));
+const wal = walEvidence(input.targetRoot);
+process.stdout.write(`${JSON.stringify({
+  schemaVersion: 1,
+  observed,
+  elapsedMilliseconds: Date.now() - started,
+  outcome,
+  laterBoundaries,
+  recoveryLockPresent,
+  wal,
+  stdoutDigest: digest(Buffer.concat(stdout).toString("utf8")),
+  stderrDigest: digest(Buffer.concat(stderr).toString("utf8")),
+})}\n`);
+if (!observed || laterBoundaries.length || !recoveryLockPresent) process.exitCode = 2;

--- a/verification/aas-v1/verifier/drivers/transaction-fault.mjs
+++ b/verification/aas-v1/verifier/drivers/transaction-fault.mjs
@@ -178,6 +178,15 @@ const laterBoundaries = observed
   : [];
 const recoveryLockPresent = fs.existsSync(path.join(input.targetRoot, ".aas-transaction.lock"));
 const wal = walEvidence(input.targetRoot);
+let value = null;
+for (const line of (outcome.code === 0 ? Buffer.concat(stdout) : Buffer.concat(stderr)).toString("utf8").split("\n").reverse()) {
+  if (!line.trim()) continue;
+  try {
+    const parsed = JSON.parse(line);
+    value = { status: parsed?.status ?? null, code: parsed?.code ?? null, category: parsed?.category ?? null };
+    break;
+  } catch {}
+}
 process.stdout.write(`${JSON.stringify({
   schemaVersion: 1,
   observed,
@@ -186,6 +195,7 @@ process.stdout.write(`${JSON.stringify({
   laterBoundaries,
   recoveryLockPresent,
   wal,
+  value,
   stdoutDigest: digest(Buffer.concat(stdout).toString("utf8")),
   stderrDigest: digest(Buffer.concat(stderr).toString("utf8")),
 })}\n`);

--- a/verification/aas-v1/verifier/drivers/transaction-fault.mjs
+++ b/verification/aas-v1/verifier/drivers/transaction-fault.mjs
@@ -75,7 +75,7 @@ function walEvidence(targetRoot) {
   return { events: records.map((record) => record.event), digest: digest(records), pathDigest: digest(wal) };
 }
 
-function laterBoundaryEvidence(className, targetRoot, skillId) {
+function laterBoundarySnapshot(className, targetRoot, skillId) {
   const later = {
     lock: (relative) => /^\.aas-bootstrap-|^\.aas-transaction-recovery-/.test(relative)
       || relative.includes("/staged/") || relative === `.agents/skills/${skillId}` || relative === ".aas/managed-state.codex.json",
@@ -86,7 +86,24 @@ function laterBoundaryEvidence(className, targetRoot, skillId) {
     rename: (relative) => relative === ".aas/managed-state.codex.json",
     commit: () => false,
   };
-  return listMatching(targetRoot, later[className]);
+  return listMatching(targetRoot, later[className]).map((relative) => {
+    const absolute = path.join(targetRoot, relative);
+    const stat = fs.lstatSync(absolute);
+    if (stat.isFile()) {
+      return { path: relative, type: "file", size: stat.size, contentDigest: digest(fs.readFileSync(absolute).toString("base64")) };
+    }
+    if (stat.isSymbolicLink()) return { path: relative, type: "symlink", target: fs.readlinkSync(absolute) };
+    return { path: relative, type: stat.isDirectory() ? "directory" : "special", size: stat.size };
+  });
+}
+
+function changedLaterBoundaries(before, after) {
+  const beforeByPath = new Map(before.map((entry) => [entry.path, JSON.stringify(entry)]));
+  const afterByPath = new Map(after.map((entry) => [entry.path, JSON.stringify(entry)]));
+  return [
+    ...after.filter((entry) => beforeByPath.get(entry.path) !== JSON.stringify(entry)).map((entry) => entry.path),
+    ...before.filter((entry) => !afterByPath.has(entry.path)).map((entry) => `removed:${entry.path}`),
+  ].sort();
 }
 
 function terminate(pid) {
@@ -102,6 +119,7 @@ function terminate(pid) {
 const chunks = [];
 for await (const chunk of process.stdin) chunks.push(chunk);
 const input = JSON.parse(Buffer.concat(chunks).toString("utf8"));
+const beforeLaterBoundaries = laterBoundarySnapshot(input.className, input.targetRoot, input.skillId);
 const child = spawn(input.executable, input.args, {
   cwd: input.cwd,
   env: input.env,
@@ -152,7 +170,9 @@ while (Date.now() - started < input.timeoutMs) {
 if (!observed) terminate(child.pid);
 const outcome = await closed;
 for (const watcher of watchers) watcher.close();
-const laterBoundaries = observed ? laterBoundaryEvidence(input.className, input.targetRoot, input.skillId) : [];
+const laterBoundaries = observed
+  ? changedLaterBoundaries(beforeLaterBoundaries, laterBoundarySnapshot(input.className, input.targetRoot, input.skillId))
+  : [];
 const recoveryLockPresent = fs.existsSync(path.join(input.targetRoot, ".aas-transaction.lock"));
 const wal = walEvidence(input.targetRoot);
 process.stdout.write(`${JSON.stringify({

--- a/verification/aas-v1/verifier/drivers/transaction-fault.mjs
+++ b/verification/aas-v1/verifier/drivers/transaction-fault.mjs
@@ -30,7 +30,7 @@ function predicate(className, targetRoot, skillId) {
   const matchers = {
     lock: (relative) => relative === ".aas-transaction.lock",
     journal: (relative) => /^\.aas-transaction-recovery-[a-f0-9]+\.wal$/.test(relative),
-    backup: (relative) => relative.includes("/backups/") && relative.endsWith(`/${skillId}`),
+    backup: (relative) => relative.includes("/backups/") && relative.split("/backups/")[1]?.split("/").length === 1,
     write: (relative, stat) => relative.includes("/staged/") && stat.isFile(),
     fsync: (relative) => /^\.aas-bootstrap-recovery-[a-f0-9]+\.json$/.test(relative),
     rename: (relative) => relative === `.agents/skills/${skillId}`,

--- a/verification/aas-v1/verifier/drivers/transaction-fault.mjs
+++ b/verification/aas-v1/verifier/drivers/transaction-fault.mjs
@@ -79,7 +79,10 @@ function laterBoundarySnapshot(className, targetRoot, skillId) {
   const later = {
     lock: (relative) => /^\.aas-bootstrap-|^\.aas-transaction-recovery-/.test(relative)
       || relative.includes("/staged/") || relative === `.agents/skills/${skillId}` || relative === ".aas/managed-state.codex.json",
-    fsync: (relative) => /^\.aas-transaction-recovery-[a-f0-9]+\.wal$/.test(relative),
+    // The WAL is reversible recovery metadata and may be created immediately
+    // after the observed bootstrap fsync. A kill at this boundary is too late
+    // only if it reaches user-visible publication or the state-last commit.
+    fsync: (relative) => relative === `.agents/skills/${skillId}` || relative === ".aas/managed-state.codex.json",
     journal: (relative) => relative.includes("/staged/") || relative === `.agents/skills/${skillId}` || relative === ".aas/managed-state.codex.json",
     write: (relative) => relative === `.agents/skills/${skillId}` || relative === ".aas/managed-state.codex.json",
     backup: (relative) => relative === ".aas/managed-state.codex.json",

--- a/verification/aas-v1/verifier/drivers/transaction-race.mjs
+++ b/verification/aas-v1/verifier/drivers/transaction-race.mjs
@@ -1,0 +1,114 @@
+#!/usr/bin/env node
+
+import crypto from "node:crypto";
+import fs from "node:fs";
+import path from "node:path";
+import { spawn } from "node:child_process";
+
+function digest(value) {
+  return `sha256-${crypto.createHash("sha256").update(value).digest("hex")}`;
+}
+
+function treeDigest(root) {
+  const records = [];
+  const visit = (directory) => {
+    if (!fs.existsSync(directory)) return;
+    for (const name of fs.readdirSync(directory).sort()) {
+      const absolute = path.join(directory, name);
+      const relative = path.relative(root, absolute).split(path.sep).join("/");
+      const stat = fs.lstatSync(absolute);
+      if (stat.isDirectory() && !stat.isSymbolicLink()) {
+        records.push({ path: relative, type: "directory" });
+        visit(absolute);
+      } else if (stat.isFile()) records.push({ path: relative, type: "file", digest: digest(fs.readFileSync(absolute)) });
+      else if (stat.isSymbolicLink()) records.push({ path: relative, type: "symlink", target: fs.readlinkSync(absolute) });
+    }
+  };
+  visit(root);
+  return digest(JSON.stringify(records));
+}
+
+function stagedBoundary(targetRoot) {
+  const root = path.join(targetRoot, ".aas", "transactions", "codex");
+  if (!fs.existsSync(root)) return null;
+  const stack = [root];
+  while (stack.length) {
+    const directory = stack.pop();
+    for (const name of fs.readdirSync(directory)) {
+      const absolute = path.join(directory, name);
+      const stat = fs.lstatSync(absolute);
+      if (stat.isDirectory()) stack.push(absolute);
+      if (stat.isFile() && absolute.includes(`${path.sep}staged${path.sep}`)) return digest(path.relative(targetRoot, absolute));
+    }
+  }
+  return null;
+}
+
+const chunks = [];
+for await (const chunk of process.stdin) chunks.push(chunk);
+const input = JSON.parse(Buffer.concat(chunks).toString("utf8"));
+const outside = path.join(input.caseRoot, `outside-${input.className}`);
+fs.mkdirSync(outside, { mode: 0o700 });
+fs.writeFileSync(path.join(outside, "canary.txt"), "outside-must-not-change\n", { mode: 0o600 });
+const outsideBefore = treeDigest(outside);
+const child = spawn(input.executable, input.args, {
+  cwd: input.cwd, env: input.env, detached: false, windowsHide: true, stdio: ["ignore", "pipe", "pipe"],
+});
+const stdout = [];
+const stderr = [];
+child.stdout.on("data", (chunk) => stdout.push(chunk));
+child.stderr.on("data", (chunk) => stderr.push(chunk));
+const closed = new Promise((resolve, reject) => {
+  child.once("error", reject);
+  child.once("close", (code, signal) => resolve({ code: code ?? 128, signal }));
+});
+let boundaryDigest = null;
+const started = Date.now();
+while (Date.now() - started < input.timeoutMs) {
+  boundaryDigest = stagedBoundary(input.targetRoot);
+  if (boundaryDigest) break;
+  const settled = await Promise.race([closed.then(() => true), new Promise((resolve) => setTimeout(() => resolve(false), 2))]);
+  if (settled) break;
+}
+let restore = () => {};
+if (boundaryDigest) {
+  if (input.className === "drift") {
+    const destination = path.join(input.targetRoot, ".agents", "skills", input.skillId);
+    fs.mkdirSync(destination, { mode: 0o700 });
+    fs.writeFileSync(path.join(destination, "personal.txt"), "injected-after-preflight\n", { mode: 0o600 });
+    restore = () => fs.rmSync(destination, { recursive: true, force: true });
+  } else if (input.className === "symlink-swap") {
+    const skills = path.join(input.targetRoot, ".agents", "skills");
+    const original = `${skills}.pre-swap`;
+    fs.renameSync(skills, original);
+    fs.symlinkSync(outside, skills, process.platform === "win32" ? "junction" : "dir");
+    restore = () => {
+      fs.rmSync(skills, { force: true });
+      fs.renameSync(original, skills);
+    };
+  } else if (input.className === "target-swap") {
+    const original = `${input.targetRoot}.pre-swap`;
+    fs.renameSync(input.targetRoot, original);
+    fs.mkdirSync(input.targetRoot, { mode: 0o700 });
+    restore = () => {
+      fs.rmSync(input.targetRoot, { recursive: true, force: true });
+      fs.renameSync(original, input.targetRoot);
+    };
+  }
+}
+const outcome = await closed;
+restore();
+const outsideAfter = treeDigest(outside);
+let value = null;
+try { value = JSON.parse((outcome.code === 0 ? Buffer.concat(stdout) : Buffer.concat(stderr)).toString("utf8").trim()); } catch {}
+process.stdout.write(`${JSON.stringify({
+  schemaVersion: 1,
+  boundaryDigest,
+  outsideBefore,
+  outsideAfter,
+  outcome,
+  value,
+  stdoutDigest: digest(Buffer.concat(stdout)),
+  stderrDigest: digest(Buffer.concat(stderr)),
+})}\n`);
+if (!boundaryDigest || outsideBefore !== outsideAfter || outcome.code === 0) process.exitCode = 2;

--- a/verification/aas-v1/verifier/lib/observer.mjs
+++ b/verification/aas-v1/verifier/lib/observer.mjs
@@ -341,9 +341,13 @@ export function macObserverBudgets(candidateTimeoutMs = 30_000) {
     });
   }
   const startupMs = 1_500;
-  const readinessMaxAttempts = 2;
+  // fs_usage can delay live output for more than two four-second canary
+  // processes on loaded hosted macOS runners. Keep probing with independently
+  // visible writes before the candidate starts; this widens observation
+  // readiness only and does not relax any candidate evidence requirement.
+  const readinessMaxAttempts = 4;
   const readinessProcessTimeoutMs = 10_000;
-  const readinessDelayMs = 250;
+  const readinessDelayMs = 500;
   const drainMs = 1_000;
   return {
     startupMs,

--- a/verification/aas-v1/verifier/lib/observer.mjs
+++ b/verification/aas-v1/verifier/lib/observer.mjs
@@ -110,6 +110,20 @@ function fsUsageLines(text) {
   return text.split(/\r?\n/).map((line) => line.trim()).filter((line) => /^\d{2}:\d{2}:\d{2}\.\d+/.test(line));
 }
 
+function fsUsageTimestamp(line) {
+  const match = line.match(/^(\d{2}):(\d{2}):(\d{2})\.(\d+)/);
+  if (!match) return null;
+  const fraction = Number(`0.${match[4]}`);
+  return ((Number(match[1]) * 60 + Number(match[2])) * 60 + Number(match[3])) * 1000 + fraction * 1000;
+}
+
+const FS_USAGE_DAY_MS = 24 * 60 * 60 * 1000;
+const FS_USAGE_MAX_INTERVAL_MS = 15 * 60 * 1000;
+
+function forwardClockDelta(timestamp, boundary) {
+  return (timestamp - boundary + FS_USAGE_DAY_MS) % FS_USAGE_DAY_MS;
+}
+
 export function parseMacFsUsage(filesystemText, networkText, execText, zones = {}) {
   const events = [];
   for (const line of fsUsageLines(networkText)) events.push({ kind: "network", targetDigest: redactToken(line, zones) });
@@ -125,18 +139,19 @@ export function parseMacFsUsage(filesystemText, networkText, execText, zones = {
 
 export function parseMacCombinedFsUsage(text, zones = {}, readinessToken = "", candidateToken = "") {
   const classified = [];
-  let readinessIndex = -1;
-  let candidateIndex = -1;
+  const readinessTimestamps = [];
+  const candidateTimestamps = [];
   const lines = fsUsageLines(text);
-  for (const [index, line] of lines.entries()) {
+  for (const line of lines) {
+    const timestamp = fsUsageTimestamp(line);
     if (/\b(?:socket|connect|bind|listen|accept|sendto|sendmsg|recvfrom|recvmsg|getaddrinfo)\b/i.test(line)) {
-      classified.push({ index, kind: "network", line });
+      classified.push({ timestamp, kind: "network", line });
     } else if (/\b(?:WrData|WrMeta|write|pwrite|rename|unlink|mkdir|rmdir|truncate|chmod|chown|fsync|fdatasync|setattr|setxattr)\b/i.test(line)) {
-      if (readinessToken && line.includes(readinessToken)) readinessIndex = index;
-      else if (candidateToken && line.includes(candidateToken)) candidateIndex = index;
-      else classified.push({ index, kind: "write", line });
+      if (readinessToken && line.includes(readinessToken)) readinessTimestamps.push(timestamp);
+      else if (candidateToken && line.includes(candidateToken)) candidateTimestamps.push(timestamp);
+      else classified.push({ timestamp, kind: "write", line });
     } else if (/\b(?:execve|posix_spawn|exec|spawn)\b/i.test(line)) {
-      classified.push({ index, kind: "process", line });
+      classified.push({ timestamp, kind: "process", line });
     }
   }
   const diagnostic = () => JSON.stringify({
@@ -145,18 +160,32 @@ export function parseMacCombinedFsUsage(text, zones = {}, readinessToken = "", c
     candidateTokenAnywhere: candidateToken ? text.includes(candidateToken) : null,
     callNames: [...new Set(lines.map((line) => line.match(/^\d{2}:\d{2}:\d{2}\.\d+\s+(\S+)/)?.[1]).filter(Boolean))].slice(0, 24),
   });
-  if (readinessToken && readinessIndex < 0) {
+  if (readinessToken && !readinessTimestamps.length) {
     throw Object.assign(new Error(`fs_usage missed the observer readiness canary: ${diagnostic()}`), { code: "AAS_OBSERVER_UNAVAILABLE" });
   }
-  if (candidateToken && candidateIndex < 0) {
+  if (candidateToken && !candidateTimestamps.length) {
     throw Object.assign(new Error(`fs_usage missed the candidate start canary: ${diagnostic()}`), { code: "AAS_OBSERVER_UNAVAILABLE" });
   }
-  if (candidateToken && candidateIndex <= readinessIndex) {
+  const readinessTimestamp = readinessTimestamps.length ? Math.max(...readinessTimestamps) : null;
+  const candidateTimestamp = candidateTimestamps
+    .map((timestamp) => ({ timestamp, delta: forwardClockDelta(timestamp, readinessTimestamp) }))
+    .filter(({ delta }) => delta > 0 && delta <= FS_USAGE_MAX_INTERVAL_MS)
+    .sort((left, right) => left.delta - right.delta)
+    .at(-1)?.timestamp ?? null;
+  if (candidateToken && candidateTimestamp === null) {
     throw Object.assign(new Error("fs_usage canary ordering is ambiguous"), { code: "AAS_OBSERVER_AMBIGUOUS_LINEAGE" });
   }
-  const boundary = candidateToken ? candidateIndex : -1;
+  const boundary = candidateToken ? candidateTimestamp : -Infinity;
   const events = classified
-    .filter((entry) => entry.index > boundary)
+    // fs_usage may flush filesystem and network buffers out of line order.
+    // Native timestamps, not output position, bind calls to the candidate
+    // interval established by the final start-canary heartbeat.
+    .filter((entry) => {
+      if (!candidateToken) return true;
+      if (entry.timestamp === null) return false;
+      const delta = forwardClockDelta(entry.timestamp, boundary);
+      return delta > 0 && delta <= FS_USAGE_MAX_INTERVAL_MS;
+    })
     .map(({ kind, line }) => ({ kind, targetDigest: redactToken(line, zones) }));
   return summarizeEvents(events);
 }

--- a/verification/aas-v1/verifier/lib/observer.mjs
+++ b/verification/aas-v1/verifier/lib/observer.mjs
@@ -249,7 +249,7 @@ async function macObserved(executable, args, options) {
       ...options,
       detached: true,
       timeoutMs: budgets.observerTimeoutMs,
-      maxOutputBytes: 8 * 1024 * 1024,
+      maxOutputBytes: budgets.traceMaxOutputBytes,
       onSpawn(child) { observerPid = child.pid; },
       onStdoutData: captureObserverOutput(options.onStdoutData),
       onStderrData: captureObserverOutput(options.onStderrData),
@@ -351,6 +351,7 @@ export function macObserverBudgets(candidateTimeoutMs = 30_000) {
     readinessProcessTimeoutMs,
     readinessDelayMs,
     drainMs,
+    traceMaxOutputBytes: 64 * 1024 * 1024,
     observerTimeoutMs: startupMs
       + readinessMaxAttempts * (readinessProcessTimeoutMs + readinessDelayMs)
       + candidateTimeoutMs

--- a/verification/aas-v1/verifier/lib/observer.mjs
+++ b/verification/aas-v1/verifier/lib/observer.mjs
@@ -155,6 +155,17 @@ export function parseMacCombinedFsUsage(text, zones = {}, readinessToken = "", c
   return summarizeEvents(events);
 }
 
+export function rewriteMacObservedNodeInput(stdin, originalExecutable, observedExecutable) {
+  if (typeof stdin !== "string" || !stdin.length) return stdin;
+  try {
+    const value = JSON.parse(stdin);
+    if (!value || typeof value !== "object" || Array.isArray(value) || value.executable !== originalExecutable) return stdin;
+    return JSON.stringify({ ...value, executable: observedExecutable });
+  } catch {
+    return stdin;
+  }
+}
+
 async function macObserved(executable, args, options) {
   if (!commandExists("fs_usage")) throw Object.assign(new Error("fs_usage is required"), { code: "AAS_OBSERVER_UNAVAILABLE" });
   if (path.resolve(executable) !== path.resolve(process.execPath)) {
@@ -279,7 +290,13 @@ async function macObserved(executable, args, options) {
       throw Object.assign(new Error("fs_usage did not confirm readiness before the candidate deadline"), { code: "AAS_OBSERVER_UNAVAILABLE" });
     }
     assertObserverActive("candidate-start");
-    const result = await runProcess(observedExecutable, [launcher], options);
+    const result = await runProcess(observedExecutable, [launcher], {
+      ...options,
+      // fs_usage filters by executable name rather than ancestry. Make a
+      // transaction driver launch the byte-identical observed Node copy so
+      // the candidate child remains inside the native process filter.
+      stdin: rewriteMacObservedNodeInput(options.stdin, process.execPath, observedExecutable),
+    });
     await new Promise((resolve) => setTimeout(resolve, budgets.drainMs));
     assertObserverActive("candidate-drain");
     await stopObserver();

--- a/verification/aas-v1/verifier/lib/observer.mjs
+++ b/verification/aas-v1/verifier/lib/observer.mjs
@@ -186,8 +186,11 @@ async function macObserved(executable, args, options) {
   fs.writeFileSync(launcher, [
     `process.title = ${JSON.stringify(observedName)};`,
     "const fs = require('node:fs');",
-    `const fd = fs.openSync(${JSON.stringify(candidateCanary)}, 'w', 0o600);`,
-    "fs.writeSync(fd, 'start'); fs.fsyncSync(fd); fs.closeSync(fd);",
+    "const waitArray = new Int32Array(new SharedArrayBuffer(4));",
+    // Give fs_usage time to attach its process-name filter after Node updates
+    // the copied executable's title. The candidate begins only after this
+    // bounded native canary heartbeat has completed.
+    `for (let attempt = 0; attempt < 20; attempt += 1) { const fd = fs.openSync(${JSON.stringify(candidateCanary)}, 'w', 0o600); fs.writeSync(fd, 'start'); fs.fsyncSync(fd); fs.closeSync(fd); Atomics.wait(waitArray, 0, 0, 100); }`,
     `const args = JSON.parse(Buffer.from(${JSON.stringify(encodedArgs)}, 'base64').toString('utf8'));`,
     "if (args[0] === '-e') { process.argv = [process.execPath, ...args.slice(2)]; eval(args[1]); }",
     "else { process.argv = [process.execPath, ...args]; require('node:module').runMain(); }",

--- a/verification/aas-v1/verifier/lib/observer.mjs
+++ b/verification/aas-v1/verifier/lib/observer.mjs
@@ -10,7 +10,7 @@ import { runProcess } from "./process.mjs";
 const NETWORK_CALL = /\b(?:socket|socketpair|connect|bind|listen|accept|accept4|sendto|sendmsg|recvfrom|recvmsg|getaddrinfo|GetAddrInfoW)\s*\(/;
 const MUTATION_CALL = /\b(?:creat|mkdir|mkdirat|rmdir|unlink|unlinkat|rename|renameat|renameat2|link|linkat|symlink|symlinkat|truncate|ftruncate|chmod|fchmod|fchmodat|chown|fchown|fchownat|utime|utimes|futimes|futimens|fsync|fdatasync)\s*\(/;
 const OPEN_WRITE = /\b(?:open|openat|openat2)\s*\([^\n]*\b(?:O_WRONLY|O_RDWR|O_CREAT|O_TRUNC|O_APPEND)\b/;
-const FD_WRITE = /\b(?:write|writev|pwrite|pwritev)\s*\((\d+)(?:<[^>]*>)?,/;
+const FD_WRITE = /\b(?:write|writev|pwrite|pwritev)\s*\((\d+)(?:<([^>]*)>)?,/;
 const PROCESS_CALL = /\b(?:execve|execveat|posix_spawn)\s*\(/;
 
 function resolveCommandPath(command) {
@@ -42,7 +42,13 @@ export function parseLinuxStrace(text, zones = {}) {
     else if (MUTATION_CALL.test(line) || OPEN_WRITE.test(line)) kind = "write";
     else {
       const fdWrite = line.match(FD_WRITE);
-      if (fdWrite && !["1", "2"].includes(fdWrite[1])) kind = "write";
+      const nonPersistentKernelTarget = fdWrite?.[2]
+        && /^(?:pipe:\[|socket:\[|anon_inode:|\/dev\/null$)/.test(fdWrite[2]);
+      // strace exposes libuv's pipe/eventfd bookkeeping as write(2), unlike
+      // the macOS and Windows filesystem observers. Those kernel IPC targets
+      // cannot persist project/cache state; unknown or regular-file targets
+      // remain fail-closed and count as writes.
+      if (fdWrite && !["1", "2"].includes(fdWrite[1]) && !nonPersistentKernelTarget) kind = "write";
       else if (PROCESS_CALL.test(line)) {
         if (!rootExecSeen) rootExecSeen = true;
         else kind = "process";

--- a/verification/aas-v1/verifier/lib/process.mjs
+++ b/verification/aas-v1/verifier/lib/process.mjs
@@ -17,6 +17,7 @@ export function runProcess(executable, args, options = {}) {
     let stderrBytes = 0;
     const maxOutputBytes = options.maxOutputBytes ?? 4 * 1024 * 1024;
     let killedForOutput = false;
+    let killedForTimeout = false;
     const collect = (chunks, kind) => (chunk) => {
       const callback = kind === "stdout" ? options.onStdoutData : options.onStderrData;
       if (typeof callback === "function") callback(chunk);
@@ -35,7 +36,10 @@ export function runProcess(executable, args, options = {}) {
     if (options.stdin !== undefined) {
       child.stdin.end(options.stdin);
     }
-    const timer = setTimeout(() => child.kill("SIGKILL"), timeoutMs);
+    const timer = setTimeout(() => {
+      killedForTimeout = true;
+      child.kill("SIGKILL");
+    }, timeoutMs);
     child.once("close", (code, signal) => {
       clearTimeout(timer);
       resolve({
@@ -43,7 +47,7 @@ export function runProcess(executable, args, options = {}) {
         signal,
         stdout: Buffer.concat(stdout).toString("utf8"),
         stderr: Buffer.concat(stderr).toString("utf8"),
-        timedOut: signal === "SIGKILL" && !killedForOutput,
+        timedOut: killedForTimeout,
         outputLimitExceeded: killedForOutput,
       });
     });

--- a/verification/aas-v1/verifier/lib/runtime.mjs
+++ b/verification/aas-v1/verifier/lib/runtime.mjs
@@ -5,17 +5,31 @@ import { digestJson } from "./canonical.mjs";
 import { snapshotTree } from "./fs-evidence.mjs";
 import { runProcess } from "./process.mjs";
 
-function npmExecutable() {
-  return process.platform === "win32" ? "npm.cmd" : "npm";
+function quoteWindowsCommandToken(value) {
+  if (typeof value !== "string" || value.length === 0 || /[\0\r\n"%&|<>^()!]/.test(value)) {
+    throw Object.assign(new Error("Unsafe Windows npm command token"), { code: "AAS_VERIFIER_UNSAFE_NPM_ARGUMENT" });
+  }
+  return `"${value}"`;
+}
+
+export function npmInvocation(args, platform = process.platform, environment = process.env) {
+  if (platform !== "win32") return { executable: "npm", args };
+  const executable = environment.ComSpec || environment.COMSPEC || "C:\\Windows\\System32\\cmd.exe";
+  if (!path.win32.isAbsolute(executable) || path.win32.basename(executable).toLowerCase() !== "cmd.exe") {
+    throw Object.assign(new Error("Windows command processor is not trusted"), { code: "AAS_VERIFIER_UNSAFE_COMSPEC" });
+  }
+  const command = ["npm.cmd", ...args].map(quoteWindowsCommandToken).join(" ");
+  return { executable, args: ["/D", "/S", "/C", command] };
 }
 
 export async function installCandidate(tarball, root) {
   fs.mkdirSync(root, { recursive: true, mode: 0o700 });
   fs.writeFileSync(path.join(root, "package.json"), `${JSON.stringify({ private: true }, null, 2)}\n`, { mode: 0o600 });
   const npmCache = path.join(root, ".npm-cache");
-  const result = await runProcess(npmExecutable(), [
+  const invocation = npmInvocation([
     "install", "--ignore-scripts", "--no-audit", "--no-fund", "--no-package-lock", "--save=false", path.resolve(tarball),
-  ], {
+  ]);
+  const result = await runProcess(invocation.executable, invocation.args, {
     cwd: root,
     env: { ...process.env, npm_config_cache: npmCache, npm_config_ignore_scripts: "true" },
     timeoutMs: 180_000,

--- a/verification/aas-v1/verifier/lib/runtime.mjs
+++ b/verification/aas-v1/verifier/lib/runtime.mjs
@@ -5,21 +5,13 @@ import { digestJson } from "./canonical.mjs";
 import { snapshotTree } from "./fs-evidence.mjs";
 import { runProcess } from "./process.mjs";
 
-function quoteWindowsCommandToken(value) {
-  if (typeof value !== "string" || value.length === 0 || /[\0\r\n"%&|<>^()!]/.test(value)) {
-    throw Object.assign(new Error("Unsafe Windows npm command token"), { code: "AAS_VERIFIER_UNSAFE_NPM_ARGUMENT" });
-  }
-  return `"${value}"`;
-}
-
-export function npmInvocation(args, platform = process.platform, environment = process.env) {
+export function npmInvocation(args, platform = process.platform, nodeExecutable = process.execPath) {
   if (platform !== "win32") return { executable: "npm", args };
-  const executable = environment.ComSpec || environment.COMSPEC || "C:\\Windows\\System32\\cmd.exe";
-  if (!path.win32.isAbsolute(executable) || path.win32.basename(executable).toLowerCase() !== "cmd.exe") {
-    throw Object.assign(new Error("Windows command processor is not trusted"), { code: "AAS_VERIFIER_UNSAFE_COMSPEC" });
+  if (!path.win32.isAbsolute(nodeExecutable) || path.win32.basename(nodeExecutable).toLowerCase() !== "node.exe") {
+    throw Object.assign(new Error("Windows Node executable is not trusted"), { code: "AAS_VERIFIER_UNSAFE_NODE_EXECUTABLE" });
   }
-  const command = ["npm.cmd", ...args].map(quoteWindowsCommandToken).join(" ");
-  return { executable, args: ["/D", "/S", "/C", command] };
+  const npmCli = path.win32.join(path.win32.dirname(nodeExecutable), "node_modules", "npm", "bin", "npm-cli.js");
+  return { executable: nodeExecutable, args: [npmCli, ...args] };
 }
 
 export async function installCandidate(tarball, root) {

--- a/verification/aas-v1/verifier/lib/transaction-controller.mjs
+++ b/verification/aas-v1/verifier/lib/transaction-controller.mjs
@@ -24,8 +24,12 @@ function sleep(milliseconds) {
 }
 
 function readOneJson(result, expectedCode = 0) {
+  let structuredErrorCode = null;
+  try {
+    structuredErrorCode = parseJsonLines(result.stderr || "")[0]?.code || null;
+  } catch {}
   assert(result.code === expectedCode, "AAS_TRANSACTION_CONTROLLER_CLI_EXIT", {
-    expectedCode, actualCode: result.code, stderrDigest: sha256(result.stderr || ""),
+    expectedCode, actualCode: result.code, structuredErrorCode, stderrDigest: sha256(result.stderr || ""),
   });
   const values = parseJsonLines(result.stdout || "");
   assert(values.length === 1, "AAS_TRANSACTION_CONTROLLER_CLI_OUTPUT");

--- a/verification/aas-v1/verifier/lib/transaction-controller.mjs
+++ b/verification/aas-v1/verifier/lib/transaction-controller.mjs
@@ -290,6 +290,7 @@ async function doctor(fixture) {
 }
 
 async function recover(fixture) {
+  let completed = null;
   for (let attempt = 0; attempt < 50; attempt += 1) {
     const diagnosis = await doctor(fixture);
     if (diagnosis.value.status === "recoveryRequired") {
@@ -302,9 +303,12 @@ async function recover(fixture) {
       const preview = await publicCli(fixture, base);
       assert(preview.value.status === "approvalRequired", "AAS_TRANSACTION_CONTROLLER_RECOVERY_PREVIEW");
       const applied = await publicCli(fixture, [...base, "--approve", preview.value.recoveryPlan.digest]);
-      return { action, status: applied.value.status, planDigest: preview.value.recoveryPlan.digest };
+      completed = { action, status: applied.value.status, planDigest: preview.value.recoveryPlan.digest };
+      continue;
     }
-    if (diagnosis.value.status === "healthy") return { action: "none", status: "healthy", planDigest: fixture.plan.digest };
+    if (diagnosis.value.status === "healthy") {
+      return completed || { action: "none", status: "healthy", planDigest: fixture.plan.digest };
+    }
     await sleep(10);
   }
   throw Object.assign(new Error("AAS_TRANSACTION_CONTROLLER_RECOVERY_UNAVAILABLE"), { code: "AAS_TRANSACTION_CONTROLLER_RECOVERY_UNAVAILABLE" });
@@ -383,8 +387,13 @@ async function faultCase(context, className) {
       : className === "commit"
         ? walEvents.includes("committed")
         : !walEvents.includes("committed");
+  // fs_usage observes the byte-identical child executable directly but does
+  // not emit process-creation records. On macOS, executable binding plus the
+  // native write trace establishes lineage; Linux/Windows must also expose a
+  // child-process event from their process-tree observers.
+  const childLineageObserved = process.platform === "darwin" || observed.observation.childProcesses > 0;
   assert(driverValue?.observed && driverValue.recoveryLockPresent === true && driverValue.laterBoundaries.length === 0
-      && observed.observation.writeAttempts > 0 && observed.observation.childProcesses > 0 && lineageVerified && walBoundaryValid,
+      && observed.observation.writeAttempts > 0 && childLineageObserved && lineageVerified && walBoundaryValid,
     "AAS_TRANSACTION_CONTROLLER_NATIVE_OBSERVATION_MISSING", {
       className,
       writeAttempts: observed.observation.writeAttempts,

--- a/verification/aas-v1/verifier/lib/transaction-controller.mjs
+++ b/verification/aas-v1/verifier/lib/transaction-controller.mjs
@@ -129,6 +129,20 @@ export function walBoundaryIsValid(className, walEvents) {
   return !walEvents.includes("committed");
 }
 
+export function nativeObservationLineage(platform, observed) {
+  const backendExpected = platform === "linux"
+    ? observed?.backend === "linux-strace-process-tree"
+    : platform === "darwin"
+      ? observed?.backend === "macos-fs_usage-process"
+      : observed?.backend === "windows-etw-kernel-process-tree";
+  const childObserved = platform === "darwin" || (observed?.observation?.childProcesses ?? 0) > 0;
+  const verified = backendExpected
+    && observed?.result?.timedOut !== true
+    && observed?.result?.outputLimitExceeded !== true
+    && (platform !== "win32" || observed?.diagnostics?.processTreeEmpty === true);
+  return { childObserved, verified };
+}
+
 function finalState(targetRoot, skillId, expectedContentDigest, plan) {
   const destination = path.join(targetRoot, ".agents", "skills", skillId);
   const state = path.join(targetRoot, ".aas", "managed-state.codex.json");
@@ -454,20 +468,15 @@ async function faultCase(context, className) {
     recoveryLockPresent: driverValue?.recoveryLockPresent ?? null,
     stderrDigest: sha256(observed.result.stderr || ""),
   });
-  const nativeBackendExpected = process.platform === "linux" ? observed.backend === "linux-strace-process-tree"
-    : process.platform === "darwin" ? observed.backend === "macos-fs_usage-process"
-      : observed.backend === "windows-etw-kernel-process-tree";
-  const lineageVerified = nativeBackendExpected
-    && observed.result.timedOut !== true
-    && observed.result.outputLimitExceeded !== true
-    && (process.platform !== "win32" || observed.diagnostics?.processTreeEmpty === true);
+  const nativeLineage = nativeObservationLineage(process.platform, observed);
+  const lineageVerified = nativeLineage.verified;
   const walEvents = driverValue?.wal?.events || [];
   const walBoundaryValid = walBoundaryIsValid(className, walEvents);
   // fs_usage observes the byte-identical child executable directly but does
   // not emit process-creation records. On macOS, executable binding plus the
   // native write trace establishes lineage; Linux/Windows must also expose a
   // child-process event from their process-tree observers.
-  const childLineageObserved = process.platform === "darwin" || observed.observation.childProcesses > 0;
+  const childLineageObserved = nativeLineage.childObserved;
   assert(driverValue?.observed && driverValue.recoveryLockPresent === true && driverValue.laterBoundaries.length === 0
       && observed.observation.writeAttempts > 0 && childLineageObserved && lineageVerified && walBoundaryValid,
     "AAS_TRANSACTION_CONTROLLER_NATIVE_OBSERVATION_MISSING", {
@@ -540,7 +549,8 @@ async function raceCase(context, className) {
       zones: fixture.zones,
       evidenceDir: path.join(fixture.evidenceDir, `race-${className}`),
     });
-    assert(observed.result.code === 0 && observed.observation.writeAttempts > 0 && observed.observation.childProcesses > 0,
+    const nativeLineage = nativeObservationLineage(process.platform, observed);
+    assert(observed.result.code === 0 && observed.observation.writeAttempts > 0 && nativeLineage.childObserved,
       "AAS_TRANSACTION_CONTROLLER_DYNAMIC_RACE_NOT_OBSERVED", { className, code: observed.result.code });
     const driverValue = parseJsonLines(observed.result.stdout)[0];
     assert(driverValue?.boundaryDigest && driverValue.outsideBefore === driverValue.outsideAfter
@@ -556,8 +566,7 @@ async function raceCase(context, className) {
       }),
     };
     recoveryResult = await recover(fixture);
-    const lineageVerified = observed.result.timedOut !== true && observed.result.outputLimitExceeded !== true
-      && (process.platform !== "win32" || observed.diagnostics?.processTreeEmpty === true);
+    const lineageVerified = nativeLineage.verified;
     assert(lineageVerified, "AAS_TRANSACTION_CONTROLLER_DYNAMIC_RACE_LINEAGE");
     native = { backend: observed.backend, lineageVerified, overflow: observed.result.outputLimitExceeded === true };
   } else {

--- a/verification/aas-v1/verifier/lib/transaction-controller.mjs
+++ b/verification/aas-v1/verifier/lib/transaction-controller.mjs
@@ -165,6 +165,15 @@ export function faultFixtureProfile(className, backupSkillIds) {
   };
 }
 
+export function faultObservationSkillId(className, primarySkillId, additionalSkillIds = []) {
+  if (className !== "rename") return primarySkillId;
+  // Observe the first deterministic publication in the staged corpus. This
+  // leaves the remaining verified skill renames between the observed boundary
+  // and the state-last commit, giving an external macOS observer enough time
+  // to terminate the process without weakening the later-boundary assertion.
+  return [primarySkillId, ...additionalSkillIds].sort()[0];
+}
+
 export function raceFixtureProfile(className, contentionSkillIds) {
   const requiresVisibleStaging = ["concurrency", "drift", "symlink-swap", "target-swap"].includes(className);
   return {
@@ -484,6 +493,7 @@ async function faultCase(context, className) {
   const profile = faultFixtureProfile(className, context.backupSkillIds);
   const replace = profile.installed;
   const fixture = await createFixture(context, `fault-${className}`, profile);
+  const observedSkillId = faultObservationSkillId(className, fixture.skillId, profile.additionalSkills);
   const args = applyArgs(fixture);
   const observed = await runObserved(process.execPath, [DRIVER], {
     cwd: fixture.caseRoot,
@@ -494,7 +504,7 @@ async function faultCase(context, className) {
       cwd: fixture.caseRoot,
       env: fixture.env,
       targetRoot: fixture.targetRoot,
-      skillId: fixture.skillId,
+      skillId: observedSkillId,
       className,
       timeoutMs: 120_000,
     }),

--- a/verification/aas-v1/verifier/lib/transaction-controller.mjs
+++ b/verification/aas-v1/verifier/lib/transaction-controller.mjs
@@ -156,6 +156,15 @@ export function faultFixtureProfile(className, backupSkillIds) {
   };
 }
 
+export function raceFixtureProfile(className, contentionSkillIds) {
+  return {
+    // Keep the first apply active long enough for a separately spawned CLI to
+    // contend on the externally observed lock. A one-skill apply can complete
+    // between lock observation and process scheduling on fast Linux runners.
+    additionalSkills: className === "concurrency" ? contentionSkillIds : [],
+  };
+}
+
 function finalState(targetRoot, skillId, expectedContentDigest, plan) {
   const destination = path.join(targetRoot, ".agents", "skills", skillId);
   const state = path.join(targetRoot, ".aas", "managed-state.codex.json");
@@ -521,7 +530,7 @@ async function faultCase(context, className) {
 }
 
 async function raceCase(context, className) {
-  const fixture = await createFixture(context, `race-${className}`);
+  const fixture = await createFixture(context, `race-${className}`, raceFixtureProfile(className, context.backupSkillIds));
   let outcome;
   let observation;
   let recoveryResult = { action: "none", status: "healthy", planDigest: fixture.plan.digest };
@@ -535,7 +544,10 @@ async function raceCase(context, className) {
     const results = [await first.completed, secondResult];
     const values = results.map((result) => ({ result, value: parseJsonLines(result.code === 0 ? result.stdout : result.stderr)[0] }));
     assert(values.some(({ value }) => value?.status === "applied"), "AAS_TRANSACTION_CONTROLLER_CONCURRENCY_NO_WINNER");
-    assert(values[1].value?.code === "AAS_TRANSACTION_LOCKED", "AAS_TRANSACTION_CONTROLLER_CONCURRENCY_NOT_SERIALIZED", { code: values[1].value?.code });
+    assert(values[1].value?.code === "AAS_TRANSACTION_LOCKED", "AAS_TRANSACTION_CONTROLLER_CONCURRENCY_NOT_SERIALIZED", {
+      code: values[1].value?.code,
+      status: values[1].value?.status,
+    });
     outcome = secondResult;
     observation = { eventDigest: digestJson({ liveLockDigest, outcomes: values.map(({ value }) => ({ status: value?.status || null, code: value?.code || null })) }) };
     expectedFinal = "new";

--- a/verification/aas-v1/verifier/lib/transaction-controller.mjs
+++ b/verification/aas-v1/verifier/lib/transaction-controller.mjs
@@ -616,7 +616,7 @@ export async function generateTransactionEvidence({ tarball, workRoot, zones }) 
   // verified runtime or manufacturing a synthetic source tree.
   const skillId = fs.existsSync(path.join(runtime.packageRoot, "skills", "react-best-practices")) ? "react-best-practices" : "ai-agents-architect";
   const backupSkillIds = fs.readdirSync(path.join(runtime.packageRoot, "skills"), { withFileTypes: true })
-    .filter((entry) => entry.isDirectory() && entry.name !== skillId)
+    .filter((entry) => entry.isDirectory() && entry.name !== skillId && /^[a-z0-9][a-z0-9-]*$/.test(entry.name))
     .map((entry) => entry.name)
     .sort()
     .slice(0, 12);

--- a/verification/aas-v1/verifier/lib/transaction-controller.mjs
+++ b/verification/aas-v1/verifier/lib/transaction-controller.mjs
@@ -58,6 +58,15 @@ function logicalDigest(targetRoot, skillId) {
   return digestJson(logicalSnapshot(targetRoot, skillId));
 }
 
+export function portableTreeDigest(root) {
+  const entries = snapshotTree(root).entries.map((entry) => {
+    if (entry.type === "directory") return { path: entry.path, type: entry.type };
+    assert(entry.type === "file", "AAS_TRANSACTION_CONTROLLER_EXPECTED_TREE_UNSAFE", { type: entry.type });
+    return { path: entry.path, type: entry.type, size: entry.size, sha256: entry.sha256 };
+  });
+  return digestJson(entries);
+}
+
 function recoveryArtifacts(targetRoot) {
   if (!fs.existsSync(targetRoot)) return [];
   const rootNames = fs.readdirSync(targetRoot).filter((name) => /^\.aas-(?:bootstrap|layout|transaction)/.test(name));
@@ -120,13 +129,13 @@ export function walBoundaryIsValid(className, walEvents) {
   return !walEvents.includes("committed");
 }
 
-function finalState(targetRoot, skillId, expectedDigest, plan) {
+function finalState(targetRoot, skillId, expectedContentDigest, plan) {
   const destination = path.join(targetRoot, ".agents", "skills", skillId);
   const state = path.join(targetRoot, ".aas", "managed-state.codex.json");
   if (!fs.existsSync(destination) && !fs.existsSync(state)) return "previous";
   if (!fs.existsSync(destination) || !fs.existsSync(state)) return "partial";
   const stateValue = JSON.parse(fs.readFileSync(state, "utf8"));
-  return snapshotTree(destination).digest === expectedDigest && stateValue.stateDigest === plan.payload.stateCommit.nextDigest ? "new" : "partial";
+  return portableTreeDigest(destination) === expectedContentDigest && stateValue.stateDigest === plan.payload.stateCommit.nextDigest ? "new" : "partial";
 }
 
 async function run(executable, args, options = {}) {
@@ -330,7 +339,15 @@ async function createFixture(context, id, { installed = false, desired = true, a
     assert(replanned.value.status === "planned", "AAS_TRANSACTION_CONTROLLER_REPLAN");
     plan = JSON.parse(fs.readFileSync(planPath, "utf8"));
   }
-  return { ...fixture, manifestPath, planPath, plan, beforeDigest: logicalDigest(targetRoot, context.skillId), unmanagedBefore: unmanagedDigest(targetRoot) };
+  return {
+    ...fixture,
+    manifestPath,
+    planPath,
+    plan,
+    beforeDigest: logicalDigest(targetRoot, context.skillId),
+    expectedSkillContentDigest: portableTreeDigest(path.join(context.packageRoot, "skills", context.skillId)),
+    unmanagedBefore: unmanagedDigest(targetRoot),
+  };
 }
 
 function applyArgs(fixture) {
@@ -372,10 +389,11 @@ async function recover(fixture) {
 function evidenceRecord(fixture, className, kind, injectionAction, observedOperation, observation, outcome, recoveryResult, expectedFinal) {
   const afterDigest = logicalDigest(fixture.targetRoot, fixture.skillId);
   const unmanagedAfter = unmanagedDigest(fixture.targetRoot);
-  const expectedSkillDigest = fixture.plan.payload.operations.find((operation) => operation.skillId === fixture.skillId)?.resultTreeDigest || null;
   const observedFinal = afterDigest === fixture.beforeDigest
     ? "previous"
-    : expectedSkillDigest ? finalState(fixture.targetRoot, fixture.skillId, expectedSkillDigest, fixture.plan) : "partial";
+    : fixture.expectedSkillContentDigest
+      ? finalState(fixture.targetRoot, fixture.skillId, fixture.expectedSkillContentDigest, fixture.plan)
+      : "partial";
   const noPartialState = observedFinal === expectedFinal && unmanagedAfter === fixture.unmanagedBefore && recoveryArtifacts(fixture.targetRoot).length === 0;
   assert(noPartialState, "AAS_TRANSACTION_CONTROLLER_PARTIAL_STATE", { className, observedFinal, expectedFinal, artifacts: recoveryArtifacts(fixture.targetRoot) });
   return {
@@ -664,7 +682,7 @@ export async function generateTransactionEvidence({ tarball, workRoot, zones }) 
   const backupSkillIds = selectBackupSkillIds(runtime.packageRoot, skillId);
   const context = {
     workRoot: path.join(workRoot, "cases"), cacheRoot, runtime: promoted.runtimeIdentity,
-    aas: runtime.bins.aas, skillId, backupSkillIds, env: candidateEnvironment(zones), zones,
+    aas: runtime.bins.aas, packageRoot: runtime.packageRoot, skillId, backupSkillIds, env: candidateEnvironment(zones), zones,
     evidenceDir: path.join(workRoot, "native-observer-evidence"),
   };
   fs.mkdirSync(context.workRoot, { recursive: true, mode: 0o700 });

--- a/verification/aas-v1/verifier/lib/transaction-controller.mjs
+++ b/verification/aas-v1/verifier/lib/transaction-controller.mjs
@@ -435,13 +435,15 @@ async function faultCase(context, className) {
     && observed.result.outputLimitExceeded !== true
     && (process.platform !== "win32" || observed.diagnostics?.processTreeEmpty === true);
   const walEvents = driverValue?.wal?.events || [];
-  const walBoundaryValid = className === "lock" || className === "fsync"
+  const walBoundaryValid = className === "lock"
     ? walEvents.length === 0
-    : className === "journal"
-      ? walEvents.length === 1 && walEvents[0] === "started"
-      : className === "commit"
-        ? walEvents.includes("committed")
-        : !walEvents.includes("committed");
+    : className === "fsync"
+      ? !walEvents.includes("committed")
+      : className === "journal"
+        ? walEvents.length === 1 && walEvents[0] === "started"
+        : className === "commit"
+          ? walEvents.includes("committed")
+          : !walEvents.includes("committed");
   // fs_usage observes the byte-identical child executable directly but does
   // not emit process-creation records. On macOS, executable binding plus the
   // native write trace establishes lineage; Linux/Windows must also expose a

--- a/verification/aas-v1/verifier/lib/transaction-controller.mjs
+++ b/verification/aas-v1/verifier/lib/transaction-controller.mjs
@@ -168,6 +168,14 @@ export function raceFixtureProfile(className, contentionSkillIds) {
   };
 }
 
+export function classifyConcurrencyOutcomes(values) {
+  if (!Array.isArray(values) || values.filter(({ value }) => value?.status === "applied").length !== 1) return null;
+  const follower = values[1];
+  if (follower?.value?.code === "AAS_TRANSACTION_LOCKED" && follower.result?.code !== 0) return "locked";
+  if (follower?.value?.status === "alreadyApplied" && follower.result?.code === 0) return "alreadyApplied";
+  return null;
+}
+
 function finalState(targetRoot, skillId, expectedContentDigest, plan) {
   const destination = path.join(targetRoot, ".agents", "skills", skillId);
   const state = path.join(targetRoot, ".aas", "managed-state.codex.json");
@@ -546,13 +554,17 @@ async function raceCase(context, className) {
     const secondResult = await run(process.execPath, [fixture.aas, ...args], { cwd: fixture.caseRoot, env: fixture.env, timeoutMs: 120_000 });
     const results = [await first.completed, secondResult];
     const values = results.map((result) => ({ result, value: parseJsonLines(result.code === 0 ? result.stdout : result.stderr)[0] }));
-    assert(values.some(({ value }) => value?.status === "applied"), "AAS_TRANSACTION_CONTROLLER_CONCURRENCY_NO_WINNER");
-    assert(values[1].value?.code === "AAS_TRANSACTION_LOCKED", "AAS_TRANSACTION_CONTROLLER_CONCURRENCY_NOT_SERIALIZED", {
+    const serializationOutcome = classifyConcurrencyOutcomes(values);
+    assert(serializationOutcome, "AAS_TRANSACTION_CONTROLLER_CONCURRENCY_NOT_SERIALIZED", {
       code: values[1].value?.code,
       status: values[1].value?.status,
     });
-    outcome = secondResult;
-    observation = { eventDigest: digestJson({ liveLockDigest, outcomes: values.map(({ value }) => ({ status: value?.status || null, code: value?.code || null })) }) };
+    outcome = values.find(({ value }) => value?.status === "applied").result;
+    observation = { eventDigest: digestJson({
+      liveLockDigest,
+      serializationOutcome,
+      outcomes: values.map(({ result, value }) => ({ exitCode: result.code, status: value?.status || null, code: value?.code || null })),
+    }) };
     expectedFinal = "new";
   } else if (["drift", "symlink-swap", "target-swap"].includes(className)) {
     const observed = await runObserved(process.execPath, [RACE_DRIVER], {

--- a/verification/aas-v1/verifier/lib/transaction-controller.mjs
+++ b/verification/aas-v1/verifier/lib/transaction-controller.mjs
@@ -157,11 +157,13 @@ export function faultFixtureProfile(className, backupSkillIds) {
 }
 
 export function raceFixtureProfile(className, contentionSkillIds) {
+  const requiresVisibleStaging = ["concurrency", "drift", "symlink-swap", "target-swap"].includes(className);
   return {
     // Keep the first apply active long enough for a separately spawned CLI to
-    // contend on the externally observed lock. A one-skill apply can complete
-    // between lock observation and process scheduling on fast Linux runners.
-    additionalSkills: className === "concurrency" ? contentionSkillIds : [],
+    // contend on the observed lock or for the external race driver to mutate
+    // the target after staging. A one-skill apply can publish between boundary
+    // observation and process scheduling on fast runners.
+    additionalSkills: requiresVisibleStaging ? contentionSkillIds : [],
   };
 }
 

--- a/verification/aas-v1/verifier/lib/transaction-controller.mjs
+++ b/verification/aas-v1/verifier/lib/transaction-controller.mjs
@@ -176,6 +176,12 @@ export function classifyConcurrencyOutcomes(values) {
   return null;
 }
 
+export function corruptPrefixIsFailClosed(status, findings) {
+  return ["degraded", "recoveryRequired"].includes(status)
+    && Array.isArray(findings)
+    && findings.some((code) => /CORRUPT|SCHEMA|DIGEST/.test(code));
+}
+
 function finalState(targetRoot, skillId, expectedContentDigest, plan) {
   const destination = path.join(targetRoot, ".agents", "skills", skillId);
   const state = path.join(targetRoot, ".aas", "managed-state.codex.json");
@@ -496,6 +502,9 @@ async function faultCase(context, className) {
     observed: Boolean(driverValue?.observed),
     laterBoundaryCount: driverValue?.laterBoundaries?.length ?? null,
     recoveryLockPresent: driverValue?.recoveryLockPresent ?? null,
+    productStatus: driverValue?.value?.status ?? null,
+    productCode: driverValue?.value?.code ?? null,
+    productCategory: driverValue?.value?.category ?? null,
     stderrDigest: sha256(observed.result.stderr || ""),
   });
   const nativeLineage = nativeObservationLineage(process.platform, observed);
@@ -642,12 +651,12 @@ async function raceCase(context, className) {
       const prefixDiagnosis = await doctor(prefixFixture);
       const prefixAfterDoctor = logicalDigest(prefixFixture.targetRoot, prefixFixture.skillId);
       const prefixUnmanagedAfter = unmanagedDigest(prefixFixture.targetRoot);
-      assert(prefixDiagnosis.value.status === "degraded"
-        && prefixDiagnosis.value.findings.some((finding) => /CORRUPT|SCHEMA|DIGEST/.test(finding.code))
+      const prefixFindingCodes = prefixDiagnosis.value.findings.map((finding) => finding.code);
+      assert(corruptPrefixIsFailClosed(prefixDiagnosis.value.status, prefixFindingCodes)
         && prefixBeforeDoctor === prefixAfterDoctor && prefixUnmanagedBefore === prefixUnmanagedAfter,
       "AAS_TRANSACTION_CONTROLLER_CORRUPT_PREFIX_NOT_FAIL_CLOSED", {
         status: prefixDiagnosis.value.status,
-        findings: prefixDiagnosis.value.findings.map((finding) => finding.code),
+        findings: prefixFindingCodes,
       });
       outcome = killed;
       observation = {
@@ -661,7 +670,7 @@ async function raceCase(context, className) {
           corruptPrefix: {
             killed: prefixKilled.observation.eventDigest,
             diagnosisStatus: prefixDiagnosis.value.status,
-            findings: prefixDiagnosis.value.findings.map((finding) => finding.code),
+            findings: prefixFindingCodes,
             beforeDigest: prefixBeforeDoctor,
             afterDigest: prefixAfterDoctor,
             unmanagedBeforeDigest: prefixUnmanagedBefore,

--- a/verification/aas-v1/verifier/lib/transaction-controller.mjs
+++ b/verification/aas-v1/verifier/lib/transaction-controller.mjs
@@ -25,11 +25,19 @@ function sleep(milliseconds) {
 
 function readOneJson(result, expectedCode = 0) {
   let structuredErrorCode = null;
+  let structuredErrorDetails = null;
   try {
-    structuredErrorCode = parseJsonLines(result.stderr || "")[0]?.code || null;
+    const structuredError = parseJsonLines(result.stderr || "")[0];
+    structuredErrorCode = structuredError?.code || null;
+    const details = structuredError?.details;
+    if (details && typeof details === "object" && !Array.isArray(details)) {
+      structuredErrorDetails = Object.fromEntries(Object.entries(details)
+        .filter(([key, value]) => ["platform", "capability", "helperPhase", "win32Error", "spawnCode", "helperExitCode"].includes(key)
+          && (typeof value === "string" || Number.isSafeInteger(value))));
+    }
   } catch {}
   assert(result.code === expectedCode, "AAS_TRANSACTION_CONTROLLER_CLI_EXIT", {
-    expectedCode, actualCode: result.code, structuredErrorCode, stderrDigest: sha256(result.stderr || ""),
+    expectedCode, actualCode: result.code, structuredErrorCode, structuredErrorDetails, stderrDigest: sha256(result.stderr || ""),
   });
   const values = parseJsonLines(result.stdout || "");
   assert(values.length === 1, "AAS_TRANSACTION_CONTROLLER_CLI_OUTPUT");

--- a/verification/aas-v1/verifier/lib/transaction-controller.mjs
+++ b/verification/aas-v1/verifier/lib/transaction-controller.mjs
@@ -143,6 +143,19 @@ export function nativeObservationLineage(platform, observed) {
   return { childObserved, verified };
 }
 
+export function faultFixtureProfile(className, backupSkillIds) {
+  const replace = className === "backup";
+  return {
+    installed: replace,
+    desired: !replace,
+    // A single small skill can be copied and renamed between two external
+    // polling samples. Stage the same policy-safe corpus used by the backup
+    // case so the write boundary remains observable without instrumenting or
+    // slowing the candidate under test.
+    additionalSkills: className === "write" || replace ? backupSkillIds : [],
+  };
+}
+
 function finalState(targetRoot, skillId, expectedContentDigest, plan) {
   const destination = path.join(targetRoot, ".agents", "skills", skillId);
   const state = path.join(targetRoot, ".aas", "managed-state.codex.json");
@@ -434,12 +447,9 @@ function evidenceRecord(fixture, className, kind, injectionAction, observedOpera
 }
 
 async function faultCase(context, className) {
-  const replace = className === "backup";
-  const fixture = await createFixture(context, `fault-${className}`, {
-    installed: replace,
-    desired: !replace,
-    additionalSkills: replace ? context.backupSkillIds : [],
-  });
+  const profile = faultFixtureProfile(className, context.backupSkillIds);
+  const replace = profile.installed;
+  const fixture = await createFixture(context, `fault-${className}`, profile);
   const args = applyArgs(fixture);
   const observed = await runObserved(process.execPath, [DRIVER], {
     cwd: fixture.caseRoot,

--- a/verification/aas-v1/verifier/lib/transaction-controller.mjs
+++ b/verification/aas-v1/verifier/lib/transaction-controller.mjs
@@ -111,6 +111,15 @@ export function selectBackupSkillIds(packageRoot, primarySkillId, limit = 12) {
   return selected.map((entry) => entry.id);
 }
 
+export function walBoundaryIsValid(className, walEvents) {
+  if (!Array.isArray(walEvents) || walEvents.some((event) => typeof event !== "string")) return false;
+  if (className === "lock") return walEvents.length === 0;
+  if (className === "fsync") return !walEvents.includes("committed");
+  if (className === "journal") return walEvents[0] === "started" && !walEvents.includes("committed");
+  if (className === "commit") return walEvents.includes("committed");
+  return !walEvents.includes("committed");
+}
+
 function finalState(targetRoot, skillId, expectedDigest, plan) {
   const destination = path.join(targetRoot, ".agents", "skills", skillId);
   const state = path.join(targetRoot, ".aas", "managed-state.codex.json");
@@ -435,15 +444,7 @@ async function faultCase(context, className) {
     && observed.result.outputLimitExceeded !== true
     && (process.platform !== "win32" || observed.diagnostics?.processTreeEmpty === true);
   const walEvents = driverValue?.wal?.events || [];
-  const walBoundaryValid = className === "lock"
-    ? walEvents.length === 0
-    : className === "fsync"
-      ? !walEvents.includes("committed")
-      : className === "journal"
-        ? walEvents.length === 1 && walEvents[0] === "started"
-        : className === "commit"
-          ? walEvents.includes("committed")
-          : !walEvents.includes("committed");
+  const walBoundaryValid = walBoundaryIsValid(className, walEvents);
   // fs_usage observes the byte-identical child executable directly but does
   // not emit process-creation records. On macOS, executable binding plus the
   // native write trace establishes lineage; Linux/Windows must also expose a

--- a/verification/aas-v1/verifier/lib/transaction-controller.mjs
+++ b/verification/aas-v1/verifier/lib/transaction-controller.mjs
@@ -62,7 +62,9 @@ function recoveryArtifacts(targetRoot) {
   if (!fs.existsSync(targetRoot)) return [];
   const rootNames = fs.readdirSync(targetRoot).filter((name) => /^\.aas-(?:bootstrap|layout|transaction)/.test(name));
   const transactionRoot = path.join(targetRoot, ".aas", "transactions");
-  const nested = fs.existsSync(transactionRoot) ? snapshotTree(transactionRoot).entries : [];
+  const nested = fs.existsSync(transactionRoot)
+    ? snapshotTree(transactionRoot).entries.filter((entry) => !(entry.type === "directory" && entry.path === "codex"))
+    : [];
   return [...rootNames, ...nested.map((entry) => `.aas/transactions/${entry.path}`)].sort();
 }
 
@@ -238,7 +240,7 @@ async function publicCli(fixture, args, expectedCode = 0) {
   return { result, value: readOneJson(result, expectedCode) };
 }
 
-async function createFixture(context, id, { installed = false, desired = true } = {}) {
+async function createFixture(context, id, { installed = false, desired = true, additionalSkills = [] } = {}) {
   const caseRoot = path.join(context.workRoot, id);
   const targetRoot = path.join(caseRoot, "target");
   fs.mkdirSync(targetRoot, { recursive: true, mode: 0o700 });
@@ -251,7 +253,8 @@ async function createFixture(context, id, { installed = false, desired = true } 
   const initialized = await publicCli(fixture, ["stack", "init", "--goal", "test", "--out", manifestPath]);
   assert(initialized.value.status === "initialized", "AAS_TRANSACTION_CONTROLLER_INIT");
   const manifest = JSON.parse(fs.readFileSync(manifestPath, "utf8"));
-  manifest.skills = desired || installed ? [{ id: context.skillId }] : [];
+  const selectedSkills = [context.skillId, ...additionalSkills].map((id) => ({ id }));
+  manifest.skills = desired || installed ? selectedSkills : [];
   fs.writeFileSync(manifestPath, `${JSON.stringify(manifest)}\n`);
   const planPath = path.join(caseRoot, "plan.json");
   const planArgs = [
@@ -268,7 +271,7 @@ async function createFixture(context, id, { installed = false, desired = true } 
       "--cache-root", context.cacheRoot, "--approve", plan.digest,
     ]);
     assert(applied.value.status === "applied", "AAS_TRANSACTION_CONTROLLER_SEED_APPLY");
-    manifest.skills = desired ? [{ id: context.skillId }] : [];
+    manifest.skills = desired ? selectedSkills : [];
     fs.writeFileSync(manifestPath, `${JSON.stringify(manifest)}\n`);
     fs.rmSync(planPath);
     const replanned = await publicCli(fixture, planArgs);
@@ -348,7 +351,11 @@ function evidenceRecord(fixture, className, kind, injectionAction, observedOpera
 
 async function faultCase(context, className) {
   const replace = className === "backup";
-  const fixture = await createFixture(context, `fault-${className}`, { installed: replace, desired: !replace });
+  const fixture = await createFixture(context, `fault-${className}`, {
+    installed: replace,
+    desired: !replace,
+    additionalSkills: replace ? context.backupSkillIds : [],
+  });
   const args = applyArgs(fixture);
   const observed = await runObserved(process.execPath, [DRIVER], {
     cwd: fixture.caseRoot,
@@ -368,10 +375,15 @@ async function faultCase(context, className) {
     zones: fixture.zones,
     evidenceDir: path.join(fixture.evidenceDir, `fault-${className}`),
   });
-  assert(observed.result.code === 0, "AAS_TRANSACTION_CONTROLLER_NATIVE_OBSERVER_CASE_FAILED", {
-    className, code: observed.result.code, stderrDigest: sha256(observed.result.stderr || ""),
-  });
   const driverValue = parseJsonLines(observed.result.stdout)[0];
+  assert(observed.result.code === 0, "AAS_TRANSACTION_CONTROLLER_NATIVE_OBSERVER_CASE_FAILED", {
+    className,
+    code: observed.result.code,
+    observed: Boolean(driverValue?.observed),
+    laterBoundaryCount: driverValue?.laterBoundaries?.length ?? null,
+    recoveryLockPresent: driverValue?.recoveryLockPresent ?? null,
+    stderrDigest: sha256(observed.result.stderr || ""),
+  });
   const nativeBackendExpected = process.platform === "linux" ? observed.backend === "linux-strace-process-tree"
     : process.platform === "darwin" ? observed.backend === "macos-fs_usage-process"
       : observed.backend === "windows-etw-kernel-process-tree";
@@ -603,9 +615,15 @@ export async function generateTransactionEvidence({ tarball, workRoot, zones }) 
   // the external observer a useful staging window without modifying the
   // verified runtime or manufacturing a synthetic source tree.
   const skillId = fs.existsSync(path.join(runtime.packageRoot, "skills", "react-best-practices")) ? "react-best-practices" : "ai-agents-architect";
+  const backupSkillIds = fs.readdirSync(path.join(runtime.packageRoot, "skills"), { withFileTypes: true })
+    .filter((entry) => entry.isDirectory() && entry.name !== skillId)
+    .map((entry) => entry.name)
+    .sort()
+    .slice(0, 12);
+  assert(backupSkillIds.length === 12, "AAS_TRANSACTION_CONTROLLER_BACKUP_FIXTURE_INCOMPLETE");
   const context = {
     workRoot: path.join(workRoot, "cases"), cacheRoot, runtime: promoted.runtimeIdentity,
-    aas: runtime.bins.aas, skillId, env: candidateEnvironment(zones), zones,
+    aas: runtime.bins.aas, skillId, backupSkillIds, env: candidateEnvironment(zones), zones,
     evidenceDir: path.join(workRoot, "native-observer-evidence"),
   };
   fs.mkdirSync(context.workRoot, { recursive: true, mode: 0o700 });

--- a/verification/aas-v1/verifier/lib/transaction-controller.mjs
+++ b/verification/aas-v1/verifier/lib/transaction-controller.mjs
@@ -145,6 +145,7 @@ export function nativeObservationLineage(platform, observed) {
 
 export function faultFixtureProfile(className, backupSkillIds) {
   const replace = className === "backup";
+  const requiresBoundaryWindow = className === "write" || className === "rename" || replace;
   return {
     installed: replace,
     desired: !replace,
@@ -152,7 +153,7 @@ export function faultFixtureProfile(className, backupSkillIds) {
     // polling samples. Stage the same policy-safe corpus used by the backup
     // case so the write boundary remains observable without instrumenting or
     // slowing the candidate under test.
-    additionalSkills: className === "write" || replace ? backupSkillIds : [],
+    additionalSkills: requiresBoundaryWindow ? backupSkillIds : [],
   };
 }
 

--- a/verification/aas-v1/verifier/lib/transaction-controller.mjs
+++ b/verification/aas-v1/verifier/lib/transaction-controller.mjs
@@ -68,6 +68,49 @@ function recoveryArtifacts(targetRoot) {
   return [...rootNames, ...nested.map((entry) => `.aas/transactions/${entry.path}`)].sort();
 }
 
+export function selectBackupSkillIds(packageRoot, primarySkillId, limit = 12) {
+  const metadataPath = path.join(packageRoot, "tools", "lib", "aas-v1", "metadata-overrides.v1.json");
+  const metadata = JSON.parse(fs.readFileSync(metadataPath, "utf8"));
+  const skills = metadata?.skills;
+  assert(skills && typeof skills === "object" && !Array.isArray(skills), "AAS_TRANSACTION_CONTROLLER_BACKUP_METADATA_INVALID");
+  const acceptedJudgment = (value) => ["known", "notApplicable"].includes(value?.status);
+  const selected = Object.entries(skills)
+    .filter(([id, entry]) => id !== primarySkillId
+      && /^[a-z0-9][a-z0-9-]*$/.test(id)
+      && fs.existsSync(path.join(packageRoot, "skills", id, "SKILL.md"))
+      && entry?.reviewDecision === "supported"
+      && Array.isArray(entry?.capabilities)
+      && entry.capabilities.length > 0
+      && entry?.risk?.status === "known"
+      && ["none", "safe"].includes(entry.risk.value)
+      && entry?.source?.status === "known"
+      && entry.source.value != null
+      && entry?.setup?.status === "known"
+      && entry.setup.value !== "manual"
+      && entry?.targets?.codex?.status === "known"
+      && entry.targets.codex.value === "supported"
+      && acceptedJudgment(entry.dependencies)
+      && acceptedJudgment(entry.conflicts)
+      && acceptedJudgment(entry.validation))
+    .map(([id]) => {
+      const entries = snapshotTree(path.join(packageRoot, "skills", id)).entries;
+      return {
+        id,
+        files: entries.filter((entry) => entry.type === "file").length,
+        size: entries.filter((entry) => entry.type === "file").reduce((total, entry) => total + entry.size, 0),
+      };
+    })
+    .sort((left, right) => right.size - left.size
+      || right.files - left.files
+      || (left.id < right.id ? -1 : left.id > right.id ? 1 : 0))
+    .slice(0, limit);
+  assert(selected.length === limit, "AAS_TRANSACTION_CONTROLLER_BACKUP_FIXTURE_INCOMPLETE", {
+    required: limit,
+    selected: selected.length,
+  });
+  return selected.map((entry) => entry.id);
+}
+
 function finalState(targetRoot, skillId, expectedDigest, plan) {
   const destination = path.join(targetRoot, ".agents", "skills", skillId);
   const state = path.join(targetRoot, ".aas", "managed-state.codex.json");
@@ -615,12 +658,7 @@ export async function generateTransactionEvidence({ tarball, workRoot, zones }) 
   // the external observer a useful staging window without modifying the
   // verified runtime or manufacturing a synthetic source tree.
   const skillId = fs.existsSync(path.join(runtime.packageRoot, "skills", "react-best-practices")) ? "react-best-practices" : "ai-agents-architect";
-  const backupSkillIds = fs.readdirSync(path.join(runtime.packageRoot, "skills"), { withFileTypes: true })
-    .filter((entry) => entry.isDirectory() && entry.name !== skillId && /^[a-z0-9][a-z0-9-]*$/.test(entry.name))
-    .map((entry) => entry.name)
-    .sort()
-    .slice(0, 12);
-  assert(backupSkillIds.length === 12, "AAS_TRANSACTION_CONTROLLER_BACKUP_FIXTURE_INCOMPLETE");
+  const backupSkillIds = selectBackupSkillIds(runtime.packageRoot, skillId);
   const context = {
     workRoot: path.join(workRoot, "cases"), cacheRoot, runtime: promoted.runtimeIdentity,
     aas: runtime.bins.aas, skillId, backupSkillIds, env: candidateEnvironment(zones), zones,

--- a/verification/aas-v1/verifier/lib/transaction-controller.mjs
+++ b/verification/aas-v1/verifier/lib/transaction-controller.mjs
@@ -1,0 +1,656 @@
+import fs from "node:fs";
+import path from "node:path";
+import { spawn } from "node:child_process";
+import { fileURLToPath } from "node:url";
+import { digestJson, sha256 } from "./canonical.mjs";
+import { snapshotTree } from "./fs-evidence.mjs";
+import { candidateEnvironment, installCandidate, parseJsonLines } from "./runtime.mjs";
+import { prepareRuntimeCache } from "./suites.mjs";
+import { inspectPackageTarball } from "./tarball.mjs";
+import { runObserved } from "./observer.mjs";
+
+const FAULT_CLASSES = Object.freeze(["lock", "journal", "backup", "write", "fsync", "rename", "commit"]);
+const RACE_CLASSES = Object.freeze(["concurrency", "drift", "symlink-swap", "target-swap", "corrupt-journal", "recovery-race"]);
+const CONTROLLER_VERSION = "1.0.0";
+const DRIVER = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..", "drivers", "transaction-fault.mjs");
+const RACE_DRIVER = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..", "drivers", "transaction-race.mjs");
+
+function assert(condition, code, details = {}) {
+  if (!condition) throw Object.assign(new Error(code), { code, details });
+}
+
+function sleep(milliseconds) {
+  return new Promise((resolve) => setTimeout(resolve, milliseconds));
+}
+
+function readOneJson(result, expectedCode = 0) {
+  assert(result.code === expectedCode, "AAS_TRANSACTION_CONTROLLER_CLI_EXIT", {
+    expectedCode, actualCode: result.code, stderrDigest: sha256(result.stderr || ""),
+  });
+  const values = parseJsonLines(result.stdout || "");
+  assert(values.length === 1, "AAS_TRANSACTION_CONTROLLER_CLI_OUTPUT");
+  return values[0];
+}
+
+function commandDigest(executable, args) {
+  return digestJson({ executable: path.basename(executable), args: args.map((value) => path.isAbsolute(value) ? sha256(value) : value) });
+}
+
+function unmanagedDigest(targetRoot) {
+  return snapshotTree(path.join(targetRoot, "unmanaged-sentinel")).digest;
+}
+
+function logicalSnapshot(targetRoot, skillId) {
+  const destination = path.join(targetRoot, ".agents", "skills", skillId);
+  const stateFile = path.join(targetRoot, ".aas", "managed-state.codex.json");
+  return {
+    managedStateDigest: fs.existsSync(stateFile) ? sha256(fs.readFileSync(stateFile)) : null,
+    managedDestinationDigest: fs.existsSync(destination) ? snapshotTree(destination).digest : null,
+    unmanagedDigest: unmanagedDigest(targetRoot),
+  };
+}
+
+function logicalDigest(targetRoot, skillId) {
+  return digestJson(logicalSnapshot(targetRoot, skillId));
+}
+
+function recoveryArtifacts(targetRoot) {
+  if (!fs.existsSync(targetRoot)) return [];
+  const rootNames = fs.readdirSync(targetRoot).filter((name) => /^\.aas-(?:bootstrap|layout|transaction)/.test(name));
+  const transactionRoot = path.join(targetRoot, ".aas", "transactions");
+  const nested = fs.existsSync(transactionRoot) ? snapshotTree(transactionRoot).entries : [];
+  return [...rootNames, ...nested.map((entry) => `.aas/transactions/${entry.path}`)].sort();
+}
+
+function finalState(targetRoot, skillId, expectedDigest, plan) {
+  const destination = path.join(targetRoot, ".agents", "skills", skillId);
+  const state = path.join(targetRoot, ".aas", "managed-state.codex.json");
+  if (!fs.existsSync(destination) && !fs.existsSync(state)) return "previous";
+  if (!fs.existsSync(destination) || !fs.existsSync(state)) return "partial";
+  const stateValue = JSON.parse(fs.readFileSync(state, "utf8"));
+  return snapshotTree(destination).digest === expectedDigest && stateValue.stateDigest === plan.payload.stateCommit.nextDigest ? "new" : "partial";
+}
+
+async function run(executable, args, options = {}) {
+  return new Promise((resolve, reject) => {
+    const child = spawn(executable, args, {
+      cwd: options.cwd,
+      env: options.env,
+      windowsHide: true,
+      detached: options.detached === true,
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    const stdout = [];
+    const stderr = [];
+    child.stdout.on("data", (chunk) => stdout.push(chunk));
+    child.stderr.on("data", (chunk) => stderr.push(chunk));
+    child.once("error", reject);
+    const timer = setTimeout(() => {
+      terminateTree(child.pid).catch(() => {});
+    }, options.timeoutMs ?? 60_000);
+    child.once("close", (code, signal) => {
+      clearTimeout(timer);
+      resolve({ code: code ?? 128, signal, stdout: Buffer.concat(stdout).toString("utf8"), stderr: Buffer.concat(stderr).toString("utf8") });
+    });
+  });
+}
+
+function startProcess(executable, args, options = {}) {
+  const child = spawn(executable, args, {
+    cwd: options.cwd,
+    env: options.env,
+    windowsHide: true,
+    detached: false,
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  const stdout = [];
+  const stderr = [];
+  child.stdout.on("data", (chunk) => stdout.push(chunk));
+  child.stderr.on("data", (chunk) => stderr.push(chunk));
+  const completed = new Promise((resolve, reject) => {
+    child.once("error", reject);
+    child.once("close", (code, signal) => resolve({
+      code: code ?? 128,
+      signal,
+      stdout: Buffer.concat(stdout).toString("utf8"),
+      stderr: Buffer.concat(stderr).toString("utf8"),
+    }));
+  });
+  return { child, completed };
+}
+
+async function waitForActiveLock(targetRoot, expectedPid, timeoutMs = 30_000) {
+  const lockPath = path.join(targetRoot, ".aas-transaction.lock");
+  const started = Date.now();
+  while (Date.now() - started < timeoutMs) {
+    try {
+      const text = fs.readFileSync(lockPath, "utf8");
+      const value = JSON.parse(text);
+      if (text.endsWith("\n") && value.pid === expectedPid && value.kind === "apply"
+        && /^[a-f0-9]{48}$/.test(value.token || "")) return digestJson({ pid: value.pid, token: value.token, planDigest: value.planDigest });
+    } catch {}
+    await sleep(2);
+  }
+  throw Object.assign(new Error("AAS_TRANSACTION_CONTROLLER_CONCURRENCY_BOUNDARY_NOT_OBSERVED"), { code: "AAS_TRANSACTION_CONTROLLER_CONCURRENCY_BOUNDARY_NOT_OBSERVED" });
+}
+
+async function terminateTree(pid) {
+  if (!Number.isSafeInteger(pid) || pid <= 0) return;
+  if (process.platform === "win32") {
+    await run("taskkill.exe", ["/PID", String(pid), "/T", "/F"], { timeoutMs: 10_000 }).catch(() => null);
+    return;
+  }
+  try { process.kill(-pid, "SIGKILL"); } catch (error) {
+    if (error.code !== "ESRCH") throw error;
+  }
+}
+
+async function spawnUntil({ executable, args, cwd, env, predicate, timeoutMs = 30_000 }) {
+  const child = spawn(executable, args, { cwd, env, detached: process.platform !== "win32", windowsHide: true, stdio: ["ignore", "pipe", "pipe"] });
+  const stdout = [];
+  const stderr = [];
+  child.stdout.on("data", (chunk) => stdout.push(chunk));
+  child.stderr.on("data", (chunk) => stderr.push(chunk));
+  const closed = new Promise((resolve, reject) => {
+    child.once("error", reject);
+    child.once("close", (code, signal) => resolve({ code: code ?? 128, signal }));
+  });
+  const events = [];
+  const started = Date.now();
+  let observed = null;
+  while (Date.now() - started < timeoutMs) {
+    observed = predicate();
+    if (observed) {
+      events.push({ elapsedMilliseconds: Date.now() - started, observed });
+      await terminateTree(child.pid);
+      break;
+    }
+    const settled = await Promise.race([closed.then(() => true), sleep(2).then(() => false)]);
+    if (settled) break;
+  }
+  const outcome = await closed;
+  assert(observed, "AAS_TRANSACTION_CONTROLLER_BOUNDARY_NOT_OBSERVED", {
+    commandDigest: commandDigest(executable, args), code: outcome.code, signal: outcome.signal,
+    stdoutDigest: sha256(Buffer.concat(stdout)), stderrDigest: sha256(Buffer.concat(stderr)),
+  });
+  return {
+    ...outcome,
+    stdout: Buffer.concat(stdout).toString("utf8"),
+    stderr: Buffer.concat(stderr).toString("utf8"),
+    observation: { events, eventDigest: digestJson(events) },
+  };
+}
+
+function listMatching(root, matcher) {
+  const found = [];
+  const visit = (directory) => {
+    if (!fs.existsSync(directory)) return;
+    for (const name of fs.readdirSync(directory)) {
+      const absolute = path.join(directory, name);
+      let stat;
+      try { stat = fs.lstatSync(absolute); } catch { continue; }
+      const relative = path.relative(root, absolute).split(path.sep).join("/");
+      if (matcher(relative, stat)) found.push(relative);
+      if (stat.isDirectory() && !stat.isSymbolicLink()) visit(absolute);
+    }
+  };
+  visit(root);
+  return found.sort();
+}
+
+function boundaryPredicate(className, targetRoot, skillId) {
+  const matchers = {
+    lock: (relative) => relative === ".aas-transaction.lock",
+    journal: (relative) => /^\.aas-transaction-recovery-[a-f0-9]+\.wal$/.test(relative),
+    backup: (relative) => relative.includes("/backups/") && relative.endsWith(`/${skillId}`),
+    write: (relative, stat) => relative.includes("/staged/") && stat.isFile(),
+    // Publication of the durable bootstrap record can only happen after its
+    // bytes and file descriptor have been flushed. Observing it from another
+    // process is therefore an external durability-boundary signal.
+    fsync: (relative) => /^\.aas-bootstrap-recovery-[a-f0-9]+\.json$/.test(relative),
+    rename: (relative) => relative === `.agents/skills/${skillId}`,
+    commit: (relative) => relative === ".aas/managed-state.codex.json",
+  };
+  return () => {
+    const matches = listMatching(targetRoot, matchers[className]);
+    if (!matches.length) return null;
+    if (className === "journal") {
+      try {
+        const text = fs.readFileSync(path.join(targetRoot, matches[0]), "utf8");
+        const first = JSON.parse(text.split("\n").filter(Boolean)[0]);
+        if (!text.includes("\n") || first.event !== "started" || first.sequence !== 0) return null;
+      } catch { return null; }
+    }
+    return { class: className, pathsDigest: digestJson(matches), count: matches.length };
+  };
+}
+
+async function publicCli(fixture, args, expectedCode = 0) {
+  const result = await run(process.execPath, [fixture.aas, ...args], {
+    cwd: fixture.caseRoot,
+    env: fixture.env,
+    timeoutMs: 120_000,
+  });
+  return { result, value: readOneJson(result, expectedCode) };
+}
+
+async function createFixture(context, id, { installed = false, desired = true } = {}) {
+  const caseRoot = path.join(context.workRoot, id);
+  const targetRoot = path.join(caseRoot, "target");
+  fs.mkdirSync(targetRoot, { recursive: true, mode: 0o700 });
+  fs.mkdirSync(path.join(targetRoot, ".aas"), { mode: 0o700 });
+  fs.mkdirSync(path.join(targetRoot, ".agents", "skills"), { recursive: true, mode: 0o700 });
+  fs.mkdirSync(path.join(targetRoot, "unmanaged-sentinel"), { mode: 0o700 });
+  fs.writeFileSync(path.join(targetRoot, "unmanaged-sentinel", "keep.txt"), "unmanaged-must-survive\n", { mode: 0o600 });
+  const fixture = { ...context, id, caseRoot, targetRoot };
+  const manifestPath = path.join(caseRoot, "aas-stack.json");
+  const initialized = await publicCli(fixture, ["stack", "init", "--goal", "test", "--out", manifestPath]);
+  assert(initialized.value.status === "initialized", "AAS_TRANSACTION_CONTROLLER_INIT");
+  const manifest = JSON.parse(fs.readFileSync(manifestPath, "utf8"));
+  manifest.skills = desired || installed ? [{ id: context.skillId }] : [];
+  fs.writeFileSync(manifestPath, `${JSON.stringify(manifest)}\n`);
+  const planPath = path.join(caseRoot, "plan.json");
+  const planArgs = [
+    "stack", "plan", "--manifest", manifestPath, "--target", "codex:project", "--target-root", targetRoot,
+    "--cache-root", context.cacheRoot, "--runtime-version", context.runtime.version,
+    "--runtime-integrity", context.runtime.integrity, "--out", planPath,
+  ];
+  const planned = await publicCli(fixture, planArgs);
+  assert(planned.value.status === "planned", "AAS_TRANSACTION_CONTROLLER_PLAN");
+  let plan = JSON.parse(fs.readFileSync(planPath, "utf8"));
+  if (installed) {
+    const applied = await publicCli(fixture, [
+      "stack", "apply", "--experimental-apply", "--plan", planPath, "--target-root", targetRoot,
+      "--cache-root", context.cacheRoot, "--approve", plan.digest,
+    ]);
+    assert(applied.value.status === "applied", "AAS_TRANSACTION_CONTROLLER_SEED_APPLY");
+    manifest.skills = desired ? [{ id: context.skillId }] : [];
+    fs.writeFileSync(manifestPath, `${JSON.stringify(manifest)}\n`);
+    fs.rmSync(planPath);
+    const replanned = await publicCli(fixture, planArgs);
+    assert(replanned.value.status === "planned", "AAS_TRANSACTION_CONTROLLER_REPLAN");
+    plan = JSON.parse(fs.readFileSync(planPath, "utf8"));
+  }
+  return { ...fixture, manifestPath, planPath, plan, beforeDigest: logicalDigest(targetRoot, context.skillId), unmanagedBefore: unmanagedDigest(targetRoot) };
+}
+
+function applyArgs(fixture) {
+  return [
+    "stack", "apply", "--experimental-apply", "--plan", fixture.planPath, "--target-root", fixture.targetRoot,
+    "--cache-root", fixture.cacheRoot, "--approve", fixture.plan.digest,
+  ];
+}
+
+async function doctor(fixture) {
+  return publicCli(fixture, ["stack", "doctor", "--plan", fixture.planPath, "--target-root", fixture.targetRoot, "--cache-root", fixture.cacheRoot]);
+}
+
+async function recover(fixture) {
+  for (let attempt = 0; attempt < 50; attempt += 1) {
+    const diagnosis = await doctor(fixture);
+    if (diagnosis.value.status === "recoveryRequired") {
+      const recovery = diagnosis.value.recoveries[0];
+      const action = recovery.allowedActions.includes("rollback") ? "rollback" : "cleanup";
+      const base = [
+        "stack", "recover", "--experimental-recovery", "--plan", fixture.planPath, "--target-root", fixture.targetRoot,
+        "--cache-root", fixture.cacheRoot, "--id", recovery.recoveryId, "--action", action,
+      ];
+      const preview = await publicCli(fixture, base);
+      assert(preview.value.status === "approvalRequired", "AAS_TRANSACTION_CONTROLLER_RECOVERY_PREVIEW");
+      const applied = await publicCli(fixture, [...base, "--approve", preview.value.recoveryPlan.digest]);
+      return { action, status: applied.value.status, planDigest: preview.value.recoveryPlan.digest };
+    }
+    if (diagnosis.value.status === "healthy") return { action: "none", status: "healthy", planDigest: fixture.plan.digest };
+    await sleep(10);
+  }
+  throw Object.assign(new Error("AAS_TRANSACTION_CONTROLLER_RECOVERY_UNAVAILABLE"), { code: "AAS_TRANSACTION_CONTROLLER_RECOVERY_UNAVAILABLE" });
+}
+
+function evidenceRecord(fixture, className, kind, injectionAction, observedOperation, observation, outcome, recoveryResult, expectedFinal) {
+  const afterDigest = logicalDigest(fixture.targetRoot, fixture.skillId);
+  const unmanagedAfter = unmanagedDigest(fixture.targetRoot);
+  const expectedSkillDigest = fixture.plan.payload.operations.find((operation) => operation.skillId === fixture.skillId)?.resultTreeDigest || null;
+  const observedFinal = afterDigest === fixture.beforeDigest
+    ? "previous"
+    : expectedSkillDigest ? finalState(fixture.targetRoot, fixture.skillId, expectedSkillDigest, fixture.plan) : "partial";
+  const noPartialState = observedFinal === expectedFinal && unmanagedAfter === fixture.unmanagedBefore && recoveryArtifacts(fixture.targetRoot).length === 0;
+  assert(noPartialState, "AAS_TRANSACTION_CONTROLLER_PARTIAL_STATE", { className, observedFinal, expectedFinal, artifacts: recoveryArtifacts(fixture.targetRoot) });
+  return {
+    executionId: `${kind}-${className}`,
+    class: className,
+    kind,
+    observedOperation,
+    injectionAction,
+    planDigest: fixture.plan.digest,
+    commandDigest: commandDigest(process.execPath, [fixture.aas, ...applyArgs(fixture)]),
+    observerEventDigest: observation.eventDigest,
+    beforeDigest: fixture.beforeDigest,
+    afterDigest,
+    unmanagedBeforeDigest: fixture.unmanagedBefore,
+    unmanagedAfterDigest: unmanagedAfter,
+    exitCode: outcome.code,
+    exitSignal: outcome.signal || null,
+    recoveryAction: recoveryResult.action,
+    recoveryStatus: recoveryResult.status,
+    recoveryPlanDigest: recoveryResult.planDigest,
+    finalState: observedFinal,
+    noPartialState: true,
+  };
+}
+
+async function faultCase(context, className) {
+  const replace = className === "backup";
+  const fixture = await createFixture(context, `fault-${className}`, { installed: replace, desired: !replace });
+  const args = applyArgs(fixture);
+  const observed = await runObserved(process.execPath, [DRIVER], {
+    cwd: fixture.caseRoot,
+    env: fixture.env,
+    stdin: JSON.stringify({
+      executable: process.execPath,
+      args: [fixture.aas, ...args],
+      cwd: fixture.caseRoot,
+      env: fixture.env,
+      targetRoot: fixture.targetRoot,
+      skillId: fixture.skillId,
+      className,
+      timeoutMs: 120_000,
+    }),
+    timeoutMs: 130_000,
+    maxOutputBytes: 1024 * 1024,
+    zones: fixture.zones,
+    evidenceDir: path.join(fixture.evidenceDir, `fault-${className}`),
+  });
+  assert(observed.result.code === 0, "AAS_TRANSACTION_CONTROLLER_NATIVE_OBSERVER_CASE_FAILED", {
+    className, code: observed.result.code, stderrDigest: sha256(observed.result.stderr || ""),
+  });
+  const driverValue = parseJsonLines(observed.result.stdout)[0];
+  const nativeBackendExpected = process.platform === "linux" ? observed.backend === "linux-strace-process-tree"
+    : process.platform === "darwin" ? observed.backend === "macos-fs_usage-process"
+      : observed.backend === "windows-etw-kernel-process-tree";
+  const lineageVerified = nativeBackendExpected
+    && observed.result.timedOut !== true
+    && observed.result.outputLimitExceeded !== true
+    && (process.platform !== "win32" || observed.diagnostics?.processTreeEmpty === true);
+  const walEvents = driverValue?.wal?.events || [];
+  const walBoundaryValid = className === "lock" || className === "fsync"
+    ? walEvents.length === 0
+    : className === "journal"
+      ? walEvents.length === 1 && walEvents[0] === "started"
+      : className === "commit"
+        ? walEvents.includes("committed")
+        : !walEvents.includes("committed");
+  assert(driverValue?.observed && driverValue.recoveryLockPresent === true && driverValue.laterBoundaries.length === 0
+      && observed.observation.writeAttempts > 0 && observed.observation.childProcesses > 0 && lineageVerified && walBoundaryValid,
+    "AAS_TRANSACTION_CONTROLLER_NATIVE_OBSERVATION_MISSING", {
+      className,
+      writeAttempts: observed.observation.writeAttempts,
+      childProcesses: observed.observation.childProcesses,
+      laterBoundaries: driverValue?.laterBoundaries || [],
+      recoveryLockPresent: driverValue?.recoveryLockPresent ?? null,
+      lineageVerified,
+      walEvents,
+    });
+  const killed = {
+    ...driverValue.outcome,
+    observation: {
+      events: [{ boundary: driverValue.observed, nativeEventDigest: observed.observation.eventDigest }],
+      eventDigest: digestJson({ boundary: driverValue.observed, native: observed.observation.eventDigest, wal: driverValue.wal }),
+    },
+    backend: observed.backend,
+  };
+  const recoveryResult = await recover(fixture);
+  const expectedFinal = className === "commit" ? "new" : "previous";
+  // A remove plan's pre-kill seeded installation is its previous state.
+  if (replace) {
+    const destination = path.join(fixture.targetRoot, ".agents", "skills", fixture.skillId);
+    assert(fs.existsSync(destination), "AAS_TRANSACTION_CONTROLLER_BACKUP_NOT_RESTORED");
+  }
+  const record = evidenceRecord(
+    fixture, className, "faultBoundary", "kill", `external-filesystem:${className}`,
+    killed.observation, killed, recoveryResult, expectedFinal,
+  );
+  return { record, backend: observed.backend, lineageVerified, overflow: observed.result.outputLimitExceeded === true };
+}
+
+async function raceCase(context, className) {
+  const fixture = await createFixture(context, `race-${className}`);
+  let outcome;
+  let observation;
+  let recoveryResult = { action: "none", status: "healthy", planDigest: fixture.plan.digest };
+  let expectedFinal = "previous";
+  let native = null;
+  if (className === "concurrency") {
+    const args = applyArgs(fixture);
+    const first = startProcess(process.execPath, [fixture.aas, ...args], { cwd: fixture.caseRoot, env: fixture.env });
+    const liveLockDigest = await waitForActiveLock(fixture.targetRoot, first.child.pid);
+    const secondResult = await run(process.execPath, [fixture.aas, ...args], { cwd: fixture.caseRoot, env: fixture.env, timeoutMs: 120_000 });
+    const results = [await first.completed, secondResult];
+    const values = results.map((result) => ({ result, value: parseJsonLines(result.code === 0 ? result.stdout : result.stderr)[0] }));
+    assert(values.some(({ value }) => value?.status === "applied"), "AAS_TRANSACTION_CONTROLLER_CONCURRENCY_NO_WINNER");
+    assert(values[1].value?.code === "AAS_TRANSACTION_LOCKED", "AAS_TRANSACTION_CONTROLLER_CONCURRENCY_NOT_SERIALIZED", { code: values[1].value?.code });
+    outcome = secondResult;
+    observation = { eventDigest: digestJson({ liveLockDigest, outcomes: values.map(({ value }) => ({ status: value?.status || null, code: value?.code || null })) }) };
+    expectedFinal = "new";
+  } else if (["drift", "symlink-swap", "target-swap"].includes(className)) {
+    const observed = await runObserved(process.execPath, [RACE_DRIVER], {
+      cwd: fixture.caseRoot,
+      env: fixture.env,
+      stdin: JSON.stringify({
+        executable: process.execPath,
+        args: [fixture.aas, ...applyArgs(fixture)],
+        cwd: fixture.caseRoot,
+        env: fixture.env,
+        caseRoot: fixture.caseRoot,
+        targetRoot: fixture.targetRoot,
+        skillId: fixture.skillId,
+        className,
+        timeoutMs: 120_000,
+      }),
+      timeoutMs: 130_000,
+      maxOutputBytes: 1024 * 1024,
+      zones: fixture.zones,
+      evidenceDir: path.join(fixture.evidenceDir, `race-${className}`),
+    });
+    assert(observed.result.code === 0 && observed.observation.writeAttempts > 0 && observed.observation.childProcesses > 0,
+      "AAS_TRANSACTION_CONTROLLER_DYNAMIC_RACE_NOT_OBSERVED", { className, code: observed.result.code });
+    const driverValue = parseJsonLines(observed.result.stdout)[0];
+    assert(driverValue?.boundaryDigest && driverValue.outsideBefore === driverValue.outsideAfter
+      && driverValue.outcome.code !== 0 && typeof driverValue.value?.code === "string",
+    "AAS_TRANSACTION_CONTROLLER_DYNAMIC_RACE_BINDING", { className, value: driverValue?.value || null });
+    outcome = driverValue.outcome;
+    observation = {
+      eventDigest: digestJson({
+        nativeEventDigest: observed.observation.eventDigest,
+        boundaryDigest: driverValue.boundaryDigest,
+        outsideDigest: driverValue.outsideAfter,
+        productCode: driverValue.value.code,
+      }),
+    };
+    recoveryResult = await recover(fixture);
+    const lineageVerified = observed.result.timedOut !== true && observed.result.outputLimitExceeded !== true
+      && (process.platform !== "win32" || observed.diagnostics?.processTreeEmpty === true);
+    assert(lineageVerified, "AAS_TRANSACTION_CONTROLLER_DYNAMIC_RACE_LINEAGE");
+    native = { backend: observed.backend, lineageVerified, overflow: observed.result.outputLimitExceeded === true };
+  } else {
+    const killed = await spawnUntil({
+      executable: process.execPath, args: [fixture.aas, ...applyArgs(fixture)], cwd: fixture.caseRoot, env: fixture.env,
+      predicate: boundaryPredicate("journal", fixture.targetRoot, fixture.skillId), timeoutMs: 120_000,
+    });
+    if (className === "corrupt-journal") {
+      const wal = fs.readdirSync(fixture.targetRoot).find((name) => name.endsWith(".wal"));
+      assert(wal, "AAS_TRANSACTION_CONTROLLER_WAL_MISSING");
+      fs.appendFileSync(path.join(fixture.targetRoot, wal), "{corrupt");
+      const diagnosis = await doctor(fixture);
+      assert(diagnosis.value.status === "recoveryRequired", "AAS_TRANSACTION_CONTROLLER_CORRUPT_JOURNAL_ACCEPTED", {
+        status: diagnosis.value.status,
+      });
+      const recovered = await recover(fixture);
+      const prefixFixture = await createFixture(context, "race-corrupt-journal-prefix");
+      const prefixKilled = await spawnUntil({
+        executable: process.execPath,
+        args: [prefixFixture.aas, ...applyArgs(prefixFixture)],
+        cwd: prefixFixture.caseRoot,
+        env: prefixFixture.env,
+        predicate: boundaryPredicate("journal", prefixFixture.targetRoot, prefixFixture.skillId),
+        timeoutMs: 120_000,
+      });
+      const prefixWalName = fs.readdirSync(prefixFixture.targetRoot).find((name) => name.endsWith(".wal"));
+      assert(prefixWalName, "AAS_TRANSACTION_CONTROLLER_PREFIX_WAL_MISSING");
+      const prefixWal = path.join(prefixFixture.targetRoot, prefixWalName);
+      const prefixLines = fs.readFileSync(prefixWal, "utf8").split("\n").filter(Boolean);
+      const firstRecord = JSON.parse(prefixLines[0]);
+      firstRecord.recordDigest = `sha256-${"0".repeat(64)}`;
+      prefixLines[0] = JSON.stringify(firstRecord);
+      fs.writeFileSync(prefixWal, `${prefixLines.join("\n")}\n`);
+      const prefixBeforeDoctor = logicalDigest(prefixFixture.targetRoot, prefixFixture.skillId);
+      const prefixUnmanagedBefore = unmanagedDigest(prefixFixture.targetRoot);
+      const prefixDiagnosis = await doctor(prefixFixture);
+      const prefixAfterDoctor = logicalDigest(prefixFixture.targetRoot, prefixFixture.skillId);
+      const prefixUnmanagedAfter = unmanagedDigest(prefixFixture.targetRoot);
+      assert(prefixDiagnosis.value.status === "degraded"
+        && prefixDiagnosis.value.findings.some((finding) => /CORRUPT|SCHEMA|DIGEST/.test(finding.code))
+        && prefixBeforeDoctor === prefixAfterDoctor && prefixUnmanagedBefore === prefixUnmanagedAfter,
+      "AAS_TRANSACTION_CONTROLLER_CORRUPT_PREFIX_NOT_FAIL_CLOSED", {
+        status: prefixDiagnosis.value.status,
+        findings: prefixDiagnosis.value.findings.map((finding) => finding.code),
+      });
+      outcome = killed;
+      observation = {
+        eventDigest: digestJson({
+          tornTail: {
+            killed: killed.observation.eventDigest,
+            diagnosisStatus: diagnosis.value.status,
+            recoveryId: diagnosis.value.recoveries[0].recoveryId,
+            tailDigest: sha256("{corrupt"),
+          },
+          corruptPrefix: {
+            killed: prefixKilled.observation.eventDigest,
+            diagnosisStatus: prefixDiagnosis.value.status,
+            findings: prefixDiagnosis.value.findings.map((finding) => finding.code),
+            beforeDigest: prefixBeforeDoctor,
+            afterDigest: prefixAfterDoctor,
+            unmanagedBeforeDigest: prefixUnmanagedBefore,
+            unmanagedAfterDigest: prefixUnmanagedAfter,
+          },
+        }),
+      };
+      recoveryResult = recovered;
+      fs.rmSync(prefixFixture.caseRoot, { recursive: true, force: true });
+    } else {
+      let diagnosis;
+      for (let attempt = 0; attempt < 50; attempt += 1) {
+        diagnosis = await doctor(fixture);
+        if (diagnosis.value.status === "recoveryRequired") break;
+        await sleep(10);
+      }
+      const rec = diagnosis.value.recoveries[0];
+      const action = rec.allowedActions.includes("rollback") ? "rollback" : "cleanup";
+      const base = ["stack", "recover", "--experimental-recovery", "--plan", fixture.planPath, "--target-root", fixture.targetRoot, "--cache-root", fixture.cacheRoot, "--id", rec.recoveryId, "--action", action];
+      const preview = await publicCli(fixture, base);
+      const args = [...base, "--approve", preview.value.recoveryPlan.digest];
+      const [one, two] = await Promise.all([
+        run(process.execPath, [fixture.aas, ...args], { cwd: fixture.caseRoot, env: fixture.env }),
+        run(process.execPath, [fixture.aas, ...args], { cwd: fixture.caseRoot, env: fixture.env }),
+      ]);
+      const successes = [one, two].filter((result) => result.code === 0);
+      assert(successes.length === 1, "AAS_TRANSACTION_CONTROLLER_RECOVERY_RACE_NOT_SERIALIZED", { codes: [one.code, two.code] });
+      outcome = [one, two].find((result) => result.code !== 0);
+      observation = { eventDigest: digestJson([one, two].map((result) => ({ code: result.code, signal: result.signal }))) };
+      recoveryResult = { action, status: parseJsonLines(successes[0].stdout)[0].status, planDigest: preview.value.recoveryPlan.digest };
+    }
+  }
+  observation = {
+    eventDigest: digestJson({
+      processEvidence: observation.eventDigest,
+      filesystemEvidence: {
+        beforeDigest: fixture.beforeDigest,
+        afterDigest: logicalDigest(fixture.targetRoot, fixture.skillId),
+        unmanagedBeforeDigest: fixture.unmanagedBefore,
+        unmanagedAfterDigest: unmanagedDigest(fixture.targetRoot),
+        recoveryArtifacts: recoveryArtifacts(fixture.targetRoot),
+      },
+    }),
+  };
+  const record = evidenceRecord(
+    fixture, className, "race", className === "concurrency" ? "concurrent" : className,
+    `external-race:${className}`, observation, outcome, recoveryResult, expectedFinal,
+  );
+  return native ? { record, ...native } : { record };
+}
+
+export async function generateTransactionEvidence({ tarball, workRoot, zones }) {
+  const inspection = inspectPackageTarball(tarball);
+  assert(inspection.failures.length === 0, "AAS_TRANSACTION_CONTROLLER_TARBALL_INVALID", { failures: inspection.failures });
+  fs.mkdirSync(workRoot, { recursive: true, mode: 0o700 });
+  const runtime = await installCandidate(tarball, path.join(workRoot, "candidate-install"));
+  const cacheRoot = path.join(workRoot, "runtime-cache");
+  const tarballBytes = fs.readFileSync(tarball);
+  const promoted = await prepareRuntimeCache(runtime, tarballBytes, inspection.sha512, cacheRoot);
+  // This evidence-backed skill is deliberately non-trivial in size, giving
+  // the external observer a useful staging window without modifying the
+  // verified runtime or manufacturing a synthetic source tree.
+  const skillId = fs.existsSync(path.join(runtime.packageRoot, "skills", "react-best-practices")) ? "react-best-practices" : "ai-agents-architect";
+  const context = {
+    workRoot: path.join(workRoot, "cases"), cacheRoot, runtime: promoted.runtimeIdentity,
+    aas: runtime.bins.aas, skillId, env: candidateEnvironment(zones), zones,
+    evidenceDir: path.join(workRoot, "native-observer-evidence"),
+  };
+  fs.mkdirSync(context.workRoot, { recursive: true, mode: 0o700 });
+  fs.mkdirSync(context.evidenceDir, { recursive: true, mode: 0o700 });
+  const boundaryEvidence = [];
+  const nativeBackends = new Set();
+  const nativeLineage = [];
+  const nativeOverflow = [];
+  for (const className of FAULT_CLASSES) {
+    const result = await faultCase(context, className);
+    boundaryEvidence.push(result.record);
+    nativeBackends.add(result.backend);
+    nativeLineage.push(result.lineageVerified);
+    nativeOverflow.push(result.overflow);
+  }
+  for (const className of RACE_CLASSES) {
+    const result = await raceCase(context, className);
+    boundaryEvidence.push(result.record);
+    if (result.backend) nativeBackends.add(result.backend);
+    if (result.lineageVerified !== undefined) nativeLineage.push(result.lineageVerified);
+    if (result.overflow !== undefined) nativeOverflow.push(result.overflow);
+  }
+  assert(nativeBackends.size === 1, "AAS_TRANSACTION_CONTROLLER_OBSERVER_AMBIGUOUS", { backends: [...nativeBackends] });
+  assert(nativeLineage.every(Boolean) && nativeOverflow.every((value) => value === false), "AAS_TRANSACTION_CONTROLLER_OBSERVER_INCOMPLETE");
+  const eventDigest = digestJson(boundaryEvidence.map((item) => item.observerEventDigest));
+  const backend = [...nativeBackends][0];
+  return {
+    schemaVersion: 1,
+    status: "passed",
+    productionBinary: true,
+    testMode: false,
+    mocked: false,
+    candidate: {
+      package: runtime.manifest.name,
+      version: runtime.manifest.version,
+      tarballSha512: inspection.sha512,
+      installedTreeSha256: runtime.treeDigest,
+      aasEntrypointSha256: sha256(fs.readFileSync(runtime.bins.aas)),
+    },
+    controller: { version: CONTROLLER_VERSION, digest: digestJson({ version: CONTROLLER_VERSION, faultClasses: FAULT_CLASSES, raceClasses: RACE_CLASSES }) },
+    observer: {
+      backend,
+      eventDigest,
+      eventCount: boundaryEvidence.length,
+      overflow: nativeOverflow.some(Boolean),
+      ambiguousLineage: !nativeLineage.every(Boolean),
+    },
+    faultBoundaryClasses: [...FAULT_CLASSES],
+    raceClasses: [...RACE_CLASSES],
+    executions: boundaryEvidence.length,
+    killExecutions: FAULT_CLASSES.length,
+    swapExecutions: boundaryEvidence.filter((item) => item.injectionAction.endsWith("swap")).length,
+    recoveryExecutions: boundaryEvidence.filter((item) => !["none", "fail-closed"].includes(item.recoveryAction)).length,
+    partialStates: 0,
+    unmanagedMutations: 0,
+    hardPolicyViolations: 0,
+    boundaryEvidence,
+  };
+}
+
+export { FAULT_CLASSES, RACE_CLASSES };

--- a/verification/aas-v1/verifier/lib/transaction-evidence.mjs
+++ b/verification/aas-v1/verifier/lib/transaction-evidence.mjs
@@ -1,0 +1,261 @@
+import { digestJson } from "./canonical.mjs";
+
+export const TRANSACTION_FAULT_CLASSES = Object.freeze([
+  "lock", "journal", "backup", "write", "fsync", "rename", "commit",
+]);
+
+export const TRANSACTION_RACE_CLASSES = Object.freeze([
+  "concurrency", "drift", "symlink-swap", "target-swap", "corrupt-journal", "recovery-race",
+]);
+
+const BACKEND_BY_JOB_PREFIX = Object.freeze({
+  linux: "linux-strace-process-tree",
+  macos: "macos-fs_usage-process",
+  windows: "windows-etw-kernel-process-tree",
+});
+
+const RACE_ACTION = Object.freeze({
+  concurrency: "concurrent",
+  drift: "drift",
+  "symlink-swap": "symlink-swap",
+  "target-swap": "target-swap",
+  "corrupt-journal": "corrupt-journal",
+  "recovery-race": "recovery-race",
+});
+
+const RACE_FINAL_STATE = Object.freeze({
+  concurrency: "new",
+  drift: "previous",
+  "symlink-swap": "previous",
+  "target-swap": "previous",
+  "corrupt-journal": "previous",
+  "recovery-race": "previous",
+});
+
+function failure(code, details = {}) {
+  return { code, details };
+}
+
+function sameCanonical(left, right) {
+  try {
+    return digestJson(left) === digestJson(right);
+  } catch {
+    return false;
+  }
+}
+
+function expectedBackend(jobId) {
+  const prefix = typeof jobId === "string" ? jobId.split("-", 1)[0] : "";
+  return BACKEND_BY_JOB_PREFIX[prefix] || null;
+}
+
+function duplicateValues(values) {
+  const seen = new Set();
+  const duplicates = new Set();
+  for (const value of values) {
+    if (seen.has(value)) duplicates.add(value);
+    seen.add(value);
+  }
+  return [...duplicates].sort();
+}
+
+/**
+ * Validate cross-field bindings that JSON Schema cannot express.
+ *
+ * The caller must supply identities derived independently from the candidate
+ * tarball and the frozen verifier job. Self-declared evidence identities are
+ * never accepted as their own trust anchor.
+ */
+export function transactionEvidenceFailures(value, context = {}) {
+  const failures = [];
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return [failure("AAS_VERIFIER_TRANSACTION_SEMANTIC_INPUT")];
+  }
+
+  const faultClasses = context.faultBoundaryClasses || TRANSACTION_FAULT_CLASSES;
+  const raceClasses = context.raceClasses || TRANSACTION_RACE_CLASSES;
+  const expectedClasses = [...faultClasses, ...raceClasses];
+  const records = Array.isArray(value.boundaryEvidence) ? value.boundaryEvidence : [];
+
+  if (!context.expectedCandidate || !context.jobId || !context.nativeObserverBackend || !context.controllerVersion) {
+    failures.push(failure("AAS_VERIFIER_TRANSACTION_TRUST_CONTEXT_MISSING"));
+  }
+
+  if (!sameCanonical(value.candidate, context.expectedCandidate)) {
+    failures.push(failure("AAS_VERIFIER_TRANSACTION_CANDIDATE_MISMATCH"));
+  }
+
+  const jobBackend = expectedBackend(context.jobId);
+  if (!jobBackend || context.nativeObserverBackend !== jobBackend || value.observer?.backend !== jobBackend) {
+    failures.push(failure("AAS_VERIFIER_TRANSACTION_OBSERVER_JOB_MISMATCH", {
+      jobId: context.jobId || null,
+      expected: jobBackend,
+      native: context.nativeObserverBackend || null,
+      evidence: value.observer?.backend || null,
+    }));
+  }
+
+  const controllerVersion = typeof context.controllerVersion === "string" ? context.controllerVersion : null;
+  const expectedController = {
+    version: controllerVersion,
+    digest: digestJson({ version: controllerVersion, faultClasses, raceClasses }),
+  };
+  if (!sameCanonical(value.controller, expectedController)) {
+    failures.push(failure("AAS_VERIFIER_TRANSACTION_CONTROLLER_MISMATCH"));
+  }
+
+  if (!sameCanonical(value.faultBoundaryClasses, faultClasses)
+    || !sameCanonical(value.raceClasses, raceClasses)) {
+    failures.push(failure("AAS_VERIFIER_TRANSACTION_CLASS_SUMMARY_MISMATCH"));
+  }
+
+  if (records.length !== expectedClasses.length) {
+    failures.push(failure("AAS_VERIFIER_TRANSACTION_EXECUTION_COUNT", {
+      expected: expectedClasses.length,
+      actual: records.length,
+    }));
+  }
+
+  const ids = records.map((record) => record?.executionId);
+  const classes = records.map((record) => record?.class);
+  for (const [field, values] of [["executionId", ids], ["class", classes]]) {
+    const duplicates = duplicateValues(values);
+    if (duplicates.length) failures.push(failure("AAS_VERIFIER_TRANSACTION_DUPLICATE_EXECUTION", { field, duplicates }));
+  }
+
+  for (let index = 0; index < records.length; index += 1) {
+    const record = records[index];
+    if (!record || typeof record !== "object" || Array.isArray(record)) {
+      failures.push(failure("AAS_VERIFIER_TRANSACTION_EXECUTION_BINDING", { index }));
+      continue;
+    }
+    const className = expectedClasses[index];
+    const isFault = index < faultClasses.length;
+    const kind = isFault ? "faultBoundary" : "race";
+    const action = isFault ? "kill" : RACE_ACTION[className];
+    const operation = `${isFault ? "external-filesystem" : "external-race"}:${className}`;
+    if (record.class !== className
+      || record.kind !== kind
+      || record.executionId !== `${kind}-${className}`
+      || record.injectionAction !== action
+      || record.observedOperation !== operation) {
+      failures.push(failure("AAS_VERIFIER_TRANSACTION_EXECUTION_BINDING", {
+        index,
+        expectedClass: className,
+        executionId: record.executionId || null,
+      }));
+    }
+
+    if (record.unmanagedBeforeDigest !== record.unmanagedAfterDigest) {
+      failures.push(failure("AAS_VERIFIER_TRANSACTION_UNMANAGED_MUTATION", { executionId: record.executionId || null }));
+    }
+    if (record.noPartialState !== true) {
+      failures.push(failure("AAS_VERIFIER_TRANSACTION_PARTIAL_STATE", { executionId: record.executionId || null }));
+    }
+    if (record.finalState === "previous" && record.afterDigest !== record.beforeDigest) {
+      failures.push(failure("AAS_VERIFIER_TRANSACTION_FINAL_STATE_MISMATCH", { executionId: record.executionId || null, finalState: record.finalState }));
+    }
+    if (record.finalState === "new" && record.afterDigest === record.beforeDigest) {
+      failures.push(failure("AAS_VERIFIER_TRANSACTION_FINAL_STATE_MISMATCH", { executionId: record.executionId || null, finalState: record.finalState }));
+    }
+
+    if (isFault) {
+      const interrupted = record.exitSignal !== null || (Number.isInteger(record.exitCode) && record.exitCode !== 0);
+      if (!interrupted) failures.push(failure("AAS_VERIFIER_TRANSACTION_KILL_NOT_OBSERVED", { executionId: record.executionId || null }));
+      const expectedFinal = className === "commit" ? "new" : "previous";
+      if (record.finalState !== expectedFinal) {
+        failures.push(failure("AAS_VERIFIER_TRANSACTION_FINAL_STATE_MISMATCH", { executionId: record.executionId || null, expected: expectedFinal }));
+      }
+    } else {
+      if (className !== "concurrency" && record.exitSignal === null && record.exitCode === 0) {
+        failures.push(failure("AAS_VERIFIER_TRANSACTION_RACE_NOT_BLOCKED", { executionId: record.executionId || null }));
+      }
+      if (record.finalState !== RACE_FINAL_STATE[className]) {
+        failures.push(failure("AAS_VERIFIER_TRANSACTION_FINAL_STATE_MISMATCH", {
+          executionId: record.executionId || null,
+          expected: RACE_FINAL_STATE[className],
+        }));
+      }
+    }
+
+    const expectedRecoveryStatus = {
+      none: "healthy",
+      rollback: "rolledBack",
+      cleanup: "cleaned",
+      "fail-closed": "degraded",
+    }[record.recoveryAction];
+    if (record.recoveryStatus !== expectedRecoveryStatus) {
+      failures.push(failure("AAS_VERIFIER_TRANSACTION_RECOVERY_BINDING", { executionId: record.executionId || null }));
+    }
+    if (["none", "fail-closed"].includes(record.recoveryAction)) {
+      if (record.recoveryPlanDigest !== record.planDigest) {
+        failures.push(failure("AAS_VERIFIER_TRANSACTION_RECOVERY_BINDING", { executionId: record.executionId || null }));
+      }
+    } else if (!["rollback", "cleanup"].includes(record.recoveryAction)
+      || record.recoveryPlanDigest === record.planDigest) {
+      failures.push(failure("AAS_VERIFIER_TRANSACTION_RECOVERY_BINDING", { executionId: record.executionId || null }));
+    }
+
+    if (className === "corrupt-journal" && !["rollback", "cleanup"].includes(record.recoveryAction)) {
+      failures.push(failure("AAS_VERIFIER_TRANSACTION_RECOVERY_BINDING", { executionId: record.executionId || null }));
+    }
+    if (className === "recovery-race" && !["rollback", "cleanup"].includes(record.recoveryAction)) {
+      failures.push(failure("AAS_VERIFIER_TRANSACTION_RECOVERY_BINDING", { executionId: record.executionId || null }));
+    }
+  }
+
+  for (const [field, values] of [
+    ["planDigest", records.map((record) => record?.planDigest)],
+    ["commandDigest", records.map((record) => record?.commandDigest)],
+    ["observerEventDigest", records.map((record) => record?.observerEventDigest)],
+  ]) {
+    const duplicates = duplicateValues(values);
+    if (duplicates.length) failures.push(failure("AAS_VERIFIER_TRANSACTION_DUPLICATE_BINDING", { field, duplicates }));
+  }
+
+  const killExecutions = records.filter((record) => record?.injectionAction === "kill").length;
+  const swapExecutions = records.filter((record) => typeof record?.injectionAction === "string" && record.injectionAction.endsWith("swap")).length;
+  const recoveryExecutions = records.filter((record) => !["none", "fail-closed"].includes(record?.recoveryAction)).length;
+  let expectedEventDigest = null;
+  try {
+    expectedEventDigest = digestJson(records.map((record) => record?.observerEventDigest));
+  } catch {
+    failures.push(failure("AAS_VERIFIER_TRANSACTION_TRACE_BINDING"));
+  }
+  const aggregateMatches = value.executions === records.length
+    && value.killExecutions === killExecutions
+    && value.swapExecutions === swapExecutions
+    && value.recoveryExecutions === recoveryExecutions
+    && value.observer?.eventCount === records.length
+    && value.observer?.eventDigest === expectedEventDigest;
+  if (!aggregateMatches) {
+    failures.push(failure("AAS_VERIFIER_TRANSACTION_AGGREGATE_BINDING", {
+      executions: records.length,
+      killExecutions,
+      swapExecutions,
+      recoveryExecutions,
+      eventDigest: expectedEventDigest,
+    }));
+  }
+
+  if (value.productionBinary !== true || value.testMode !== false || value.mocked !== false) {
+    failures.push(failure("AAS_VERIFIER_TRANSACTION_NOT_BLACK_BOX"));
+  }
+  if (value.partialStates !== 0 || value.unmanagedMutations !== 0 || value.hardPolicyViolations !== 0
+    || value.observer?.overflow !== false || value.observer?.ambiguousLineage !== false) {
+    failures.push(failure("AAS_VERIFIER_TRANSACTION_INVARIANT"));
+  }
+
+  return failures;
+}
+
+export function assertTransactionEvidenceSemantics(value, context) {
+  const failures = transactionEvidenceFailures(value, context);
+  if (failures.length) {
+    throw Object.assign(new Error("Transaction evidence semantic validation failed"), {
+      code: failures[0].code,
+      failures,
+    });
+  }
+  return value;
+}

--- a/verification/aas-v1/verifier/lib/transaction-evidence.mjs
+++ b/verification/aas-v1/verifier/lib/transaction-evidence.mjs
@@ -1,3 +1,4 @@
+import fs from "node:fs";
 import { digestJson } from "./canonical.mjs";
 
 export const TRANSACTION_FAULT_CLASSES = Object.freeze([
@@ -31,6 +32,20 @@ const RACE_FINAL_STATE = Object.freeze({
   "corrupt-journal": "previous",
   "recovery-race": "previous",
 });
+
+export function readTransactionEvidence(file, validator) {
+  let value;
+  try { value = JSON.parse(fs.readFileSync(file, "utf8")); } catch (cause) {
+    throw Object.assign(new Error("Transaction evidence is not valid JSON"), {
+      code: "AAS_VERIFIER_TRANSACTION_EVIDENCE_SCHEMA",
+      cause,
+    });
+  }
+  if (!validator(value)) {
+    throw Object.assign(new Error("Transaction evidence schema failed"), { code: "AAS_VERIFIER_TRANSACTION_EVIDENCE_SCHEMA" });
+  }
+  return value;
+}
 
 function failure(code, details = {}) {
   return { code, details };

--- a/verification/aas-v1/verifier/package-lock.json
+++ b/verification/aas-v1/verifier/package-lock.json
@@ -8,7 +8,7 @@
       "name": "aas-v1-independent-verifier",
       "version": "1.0.1",
       "dependencies": {
-        "ajv": "8.17.1",
+        "ajv": "8.20.0",
         "ajv-formats": "3.0.1"
       },
       "engines": {
@@ -16,9 +16,9 @@
       }
     },
     "node_modules/ajv": {
-      "version": "8.17.1",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
-      "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
       "license": "MIT",
       "dependencies": {
         "fast-deep-equal": "^3.1.3",

--- a/verification/aas-v1/verifier/package.json
+++ b/verification/aas-v1/verifier/package.json
@@ -15,6 +15,7 @@
     "freeze:write": "node bin/freeze-baseline.mjs --write",
     "freeze:check": "node bin/freeze-baseline.mjs",
     "verify:product": "node bin/verify-product.mjs",
+    "verify:transaction": "node bin/generate-transaction-evidence.mjs",
     "verify:merge": "node bin/merge-product-evidence.mjs",
     "test:platform": "node bin/self-test-platform.mjs",
     "test": "node --test tests/*.test.mjs"
@@ -23,7 +24,7 @@
     "node": ">=22"
   },
   "dependencies": {
-    "ajv": "8.17.1",
+    "ajv": "8.20.0",
     "ajv-formats": "3.0.1"
   }
 }

--- a/verification/aas-v1/verifier/tests/observer.test.mjs
+++ b/verification/aas-v1/verifier/tests/observer.test.mjs
@@ -38,6 +38,7 @@ test("macOS observer lifetime covers readiness, candidate, drain, and stop margi
     readinessProcessTimeoutMs: 10_000,
     readinessDelayMs: 250,
     drainMs: 1_000,
+    traceMaxOutputBytes: 64 * 1024 * 1024,
     observerTimeoutMs: 38_000,
   });
   assert.throws(() => macObserverBudgets(0), (error) => error.code === "AAS_OBSERVER_INVALID_TIMEOUT");

--- a/verification/aas-v1/verifier/tests/observer.test.mjs
+++ b/verification/aas-v1/verifier/tests/observer.test.mjs
@@ -21,6 +21,9 @@ test("strace parser counts failed network attempts and non-stream writes", () =>
     'connect(7<TCP:[1]>, {sa_family=AF_INET}, 16) = -1 ECONNREFUSED',
     'openat(AT_FDCWD, "/tmp/x", O_WRONLY|O_CREAT, 0600) = 8',
     'write(8</tmp/x>, "x", 1) = 1',
+    'write(5<pipe:[123]>, "x", 1) = 1',
+    'write(6<anon_inode:[eventfd]>, "x", 1) = 1',
+    'write(7</dev/null>, "x", 1) = 1',
     'write(1</dev/pts/1>, "ok", 2) = 2',
     'execve("/bin/true", ["true"], 0x0) = 0',
   ].join("\n"), { tmp: "/tmp" });

--- a/verification/aas-v1/verifier/tests/observer.test.mjs
+++ b/verification/aas-v1/verifier/tests/observer.test.mjs
@@ -80,6 +80,20 @@ test("combined macOS fs_usage parser enforces canary ordering and classifies can
     "12:00:00.040 posix_spawn child node.1",
   ].join("\n"), {}, "aas-ready-1", "aas-start-1");
   assert.deepEqual([result.networkAttempts, result.writeAttempts, result.childProcesses], [1, 1, 1]);
+  const bufferedOutOfOrder = parseMacCombinedFsUsage([
+    "12:00:02.030 connect 127.0.0.1:9 node.1",
+    "12:00:02.020 WrData[A] F=3 /tmp/candidate-output node.1",
+    "12:00:00.005 WrData[A] F=3 /tmp/aas-ready-1 aasobs.1",
+    "12:00:02.010 WrData[A] F=3 /tmp/aas-start-1 aasobs.1",
+  ].join("\n"), {}, "aas-ready-1", "aas-start-1");
+  assert.deepEqual([bufferedOutOfOrder.networkAttempts, bufferedOutOfOrder.writeAttempts], [1, 1]);
+  const midnightWrap = parseMacCombinedFsUsage([
+    "00:00:00.250 connect 127.0.0.1:9 node.1",
+    "23:59:59.900 WrData[A] F=3 /tmp/aas-ready-1 aasobs.1",
+    "00:00:00.100 WrData[A] F=3 /tmp/aas-start-1 aasobs.1",
+    "00:00:00.200 WrData[A] F=3 /tmp/candidate-output node.1",
+  ].join("\n"), {}, "aas-ready-1", "aas-start-1");
+  assert.deepEqual([midnightWrap.networkAttempts, midnightWrap.writeAttempts], [1, 1]);
   assert.throws(() => parseMacCombinedFsUsage("12:00:00.010 WrData[A] F=3 /tmp/aas-start-1 aasobs.1\n", {}, "aas-ready-1", "aas-start-1"), /readiness canary/);
   assert.throws(() => parseMacCombinedFsUsage("12:00:00.010 WrData[A] F=3 /tmp/aas-ready-1 aasobs.1\n", {}, "aas-ready-1", "aas-start-1"), /candidate start canary/);
 });

--- a/verification/aas-v1/verifier/tests/observer.test.mjs
+++ b/verification/aas-v1/verifier/tests/observer.test.mjs
@@ -1,6 +1,19 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 import { macObserverBudgets, parseDelimitedObserver, parseLinuxStrace, parseMacCombinedFsUsage, parseMacFsUsage, rewriteMacObservedNodeInput, windowsObserverBudgets } from "../lib/observer.mjs";
+import { runProcess } from "../lib/process.mjs";
+
+test("process runner distinguishes observer cleanup kills from timeouts", async () => {
+  const externallyKilled = await runProcess(process.execPath, ["-e", "setInterval(() => {}, 1000)"], {
+    timeoutMs: 5_000,
+    onSpawn(child) { setTimeout(() => child.kill("SIGKILL"), 25); },
+  });
+  assert.equal(externallyKilled.signal, "SIGKILL");
+  assert.equal(externallyKilled.timedOut, false);
+  const timedOut = await runProcess(process.execPath, ["-e", "setInterval(() => {}, 1000)"], { timeoutMs: 25 });
+  assert.equal(timedOut.signal, "SIGKILL");
+  assert.equal(timedOut.timedOut, true);
+});
 
 test("strace parser counts failed network attempts and non-stream writes", () => {
   const result = parseLinuxStrace([

--- a/verification/aas-v1/verifier/tests/observer.test.mjs
+++ b/verification/aas-v1/verifier/tests/observer.test.mjs
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import { macObserverBudgets, parseDelimitedObserver, parseLinuxStrace, parseMacCombinedFsUsage, parseMacFsUsage, windowsObserverBudgets } from "../lib/observer.mjs";
+import { macObserverBudgets, parseDelimitedObserver, parseLinuxStrace, parseMacCombinedFsUsage, parseMacFsUsage, rewriteMacObservedNodeInput, windowsObserverBudgets } from "../lib/observer.mjs";
 
 test("strace parser counts failed network attempts and non-stream writes", () => {
   const result = parseLinuxStrace([
@@ -65,4 +65,15 @@ test("combined macOS fs_usage parser enforces canary ordering and classifies can
   assert.deepEqual([result.networkAttempts, result.writeAttempts, result.childProcesses], [1, 1, 1]);
   assert.throws(() => parseMacCombinedFsUsage("12:00:00.010 WrData[A] F=3 /tmp/aas-start-1 aasobs.1\n", {}, "aas-ready-1", "aas-start-1"), /readiness canary/);
   assert.throws(() => parseMacCombinedFsUsage("12:00:00.010 WrData[A] F=3 /tmp/aas-ready-1 aasobs.1\n", {}, "aas-ready-1", "aas-start-1"), /candidate start canary/);
+});
+
+test("macOS observer keeps transaction children inside its native process filter", () => {
+  const input = JSON.stringify({ executable: "/usr/local/bin/node", args: ["candidate.js"], untouched: true });
+  assert.deepEqual(JSON.parse(rewriteMacObservedNodeInput(input, "/usr/local/bin/node", "/tmp/aasobs123")), {
+    executable: "/tmp/aasobs123",
+    args: ["candidate.js"],
+    untouched: true,
+  });
+  assert.equal(rewriteMacObservedNodeInput(input, "/other/node", "/tmp/aasobs123"), input);
+  assert.equal(rewriteMacObservedNodeInput("not-json", "/usr/local/bin/node", "/tmp/aasobs123"), "not-json");
 });

--- a/verification/aas-v1/verifier/tests/observer.test.mjs
+++ b/verification/aas-v1/verifier/tests/observer.test.mjs
@@ -47,12 +47,12 @@ test("Windows observer separates the candidate limit from ETW finalization grace
 test("macOS observer lifetime covers readiness, candidate, drain, and stop margin", () => {
   assert.deepEqual(macObserverBudgets(10_000), {
     startupMs: 1_500,
-    readinessMaxAttempts: 2,
+    readinessMaxAttempts: 4,
     readinessProcessTimeoutMs: 10_000,
-    readinessDelayMs: 250,
+    readinessDelayMs: 500,
     drainMs: 1_000,
     traceMaxOutputBytes: 64 * 1024 * 1024,
-    observerTimeoutMs: 38_000,
+    observerTimeoutMs: 59_500,
   });
   assert.throws(() => macObserverBudgets(0), (error) => error.code === "AAS_OBSERVER_INVALID_TIMEOUT");
 });

--- a/verification/aas-v1/verifier/tests/runtime.test.mjs
+++ b/verification/aas-v1/verifier/tests/runtime.test.mjs
@@ -1,0 +1,30 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { npmInvocation } from "../lib/runtime.mjs";
+
+test("npm invocation executes directly on POSIX", () => {
+  assert.deepEqual(npmInvocation(["install", "/tmp/candidate.tgz"], "linux", {}), {
+    executable: "npm",
+    args: ["install", "/tmp/candidate.tgz"],
+  });
+});
+
+test("npm invocation uses the trusted Windows command processor for npm.cmd", () => {
+  assert.deepEqual(npmInvocation(["install", "C:\\runner temp\\candidate.tgz"], "win32", {
+    ComSpec: "C:\\Windows\\System32\\cmd.exe",
+  }), {
+    executable: "C:\\Windows\\System32\\cmd.exe",
+    args: ["/D", "/S", "/C", '"npm.cmd" "install" "C:\\runner temp\\candidate.tgz"'],
+  });
+});
+
+test("npm invocation rejects shell metacharacters and an untrusted COMSPEC", () => {
+  assert.throws(
+    () => npmInvocation(["install", "C:\\tmp\\candidate&other.tgz"], "win32", { ComSpec: "C:\\Windows\\System32\\cmd.exe" }),
+    (error) => error.code === "AAS_VERIFIER_UNSAFE_NPM_ARGUMENT",
+  );
+  assert.throws(
+    () => npmInvocation(["install"], "win32", { ComSpec: "relative\\cmd.exe" }),
+    (error) => error.code === "AAS_VERIFIER_UNSAFE_COMSPEC",
+  );
+});

--- a/verification/aas-v1/verifier/tests/runtime.test.mjs
+++ b/verification/aas-v1/verifier/tests/runtime.test.mjs
@@ -9,22 +9,16 @@ test("npm invocation executes directly on POSIX", () => {
   });
 });
 
-test("npm invocation uses the trusted Windows command processor for npm.cmd", () => {
-  assert.deepEqual(npmInvocation(["install", "C:\\runner temp\\candidate.tgz"], "win32", {
-    ComSpec: "C:\\Windows\\System32\\cmd.exe",
-  }), {
-    executable: "C:\\Windows\\System32\\cmd.exe",
-    args: ["/D", "/S", "/C", '"npm.cmd" "install" "C:\\runner temp\\candidate.tgz"'],
+test("npm invocation runs npm-cli.js through the current Windows Node binary", () => {
+  assert.deepEqual(npmInvocation(["install", "C:\\runner temp\\candidate.tgz"], "win32", "C:\\node\\node.exe"), {
+    executable: "C:\\node\\node.exe",
+    args: ["C:\\node\\node_modules\\npm\\bin\\npm-cli.js", "install", "C:\\runner temp\\candidate.tgz"],
   });
 });
 
-test("npm invocation rejects shell metacharacters and an untrusted COMSPEC", () => {
+test("npm invocation rejects an untrusted Windows Node executable", () => {
   assert.throws(
-    () => npmInvocation(["install", "C:\\tmp\\candidate&other.tgz"], "win32", { ComSpec: "C:\\Windows\\System32\\cmd.exe" }),
-    (error) => error.code === "AAS_VERIFIER_UNSAFE_NPM_ARGUMENT",
-  );
-  assert.throws(
-    () => npmInvocation(["install"], "win32", { ComSpec: "relative\\cmd.exe" }),
-    (error) => error.code === "AAS_VERIFIER_UNSAFE_COMSPEC",
+    () => npmInvocation(["install"], "win32", "relative\\node.exe"),
+    (error) => error.code === "AAS_VERIFIER_UNSAFE_NODE_EXECUTABLE",
   );
 });

--- a/verification/aas-v1/verifier/tests/transaction-evidence-semantics.test.mjs
+++ b/verification/aas-v1/verifier/tests/transaction-evidence-semantics.test.mjs
@@ -1,12 +1,24 @@
 import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
 import test from "node:test";
 import { digestJson } from "../lib/canonical.mjs";
 import {
   assertTransactionEvidenceSemantics,
+  readTransactionEvidence,
   TRANSACTION_FAULT_CLASSES,
   TRANSACTION_RACE_CLASSES,
   transactionEvidenceFailures,
 } from "../lib/transaction-evidence.mjs";
+
+test("malformed transaction JSON maps to the public schema failure", () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "aas-transaction-json-"));
+  const file = path.join(root, "evidence.json");
+  fs.writeFileSync(file, "{not-json");
+  assert.throws(() => readTransactionEvidence(file, () => true), { code: "AAS_VERIFIER_TRANSACTION_EVIDENCE_SCHEMA" });
+  fs.rmSync(root, { recursive: true, force: true });
+});
 
 const digest = (label) => digestJson({ label });
 const candidate = Object.freeze({

--- a/verification/aas-v1/verifier/tests/transaction-evidence-semantics.test.mjs
+++ b/verification/aas-v1/verifier/tests/transaction-evidence-semantics.test.mjs
@@ -1,0 +1,209 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { digestJson } from "../lib/canonical.mjs";
+import {
+  assertTransactionEvidenceSemantics,
+  TRANSACTION_FAULT_CLASSES,
+  TRANSACTION_RACE_CLASSES,
+  transactionEvidenceFailures,
+} from "../lib/transaction-evidence.mjs";
+
+const digest = (label) => digestJson({ label });
+const candidate = Object.freeze({
+  package: "agentic-awesome-skills",
+  version: "14.6.0",
+  tarballSha512: "sha512-YWFzLXRyYW5zYWN0aW9uLWV2aWRlbmNl",
+  installedTreeSha256: digest("installed-tree"),
+  aasEntrypointSha256: digest("aas-entrypoint"),
+});
+const context = Object.freeze({
+  expectedCandidate: candidate,
+  jobId: "linux-node-22",
+  nativeObserverBackend: "linux-strace-process-tree",
+  controllerVersion: "1.0.0",
+});
+
+function evidence() {
+  const classes = [...TRANSACTION_FAULT_CLASSES, ...TRANSACTION_RACE_CLASSES];
+  const boundaryEvidence = classes.map((className, index) => {
+    const fault = index < TRANSACTION_FAULT_CLASSES.length;
+    const kind = fault ? "faultBoundary" : "race";
+    const injectionAction = fault ? "kill" : className === "concurrency" ? "concurrent" : className;
+    const finalState = fault ? className === "commit" ? "new" : "previous" : className === "concurrency" ? "new" : "previous";
+    const planDigest = digest(`plan-${index}`);
+    let recoveryAction = fault ? "cleanup" : "none";
+    if (className === "corrupt-journal") recoveryAction = "cleanup";
+    if (className === "recovery-race") recoveryAction = "rollback";
+    return {
+      executionId: `${kind}-${className}`,
+      class: className,
+      kind,
+      observedOperation: `${fault ? "external-filesystem" : "external-race"}:${className}`,
+      injectionAction,
+      planDigest,
+      commandDigest: digest(`command-${index}`),
+      observerEventDigest: digest(`trace-${index}`),
+      beforeDigest: digest(`before-${index}`),
+      afterDigest: finalState === "previous" ? digest(`before-${index}`) : digest(`after-${index}`),
+      unmanagedBeforeDigest: digest(`unmanaged-${index}`),
+      unmanagedAfterDigest: digest(`unmanaged-${index}`),
+      exitCode: fault ? 137 : className === "concurrency" ? 0 : 1,
+      exitSignal: fault ? "SIGKILL" : null,
+      recoveryAction,
+      recoveryStatus: recoveryAction === "none" ? "healthy" : recoveryAction === "cleanup" ? "cleaned" : "rolledBack",
+      recoveryPlanDigest: ["none", "fail-closed"].includes(recoveryAction) ? planDigest : digest(`recovery-plan-${index}`),
+      finalState,
+      noPartialState: true,
+    };
+  });
+  return {
+    schemaVersion: 1,
+    status: "passed",
+    productionBinary: true,
+    testMode: false,
+    mocked: false,
+    candidate: { ...candidate },
+    controller: {
+      version: context.controllerVersion,
+      digest: digestJson({
+        version: context.controllerVersion,
+        faultClasses: TRANSACTION_FAULT_CLASSES,
+        raceClasses: TRANSACTION_RACE_CLASSES,
+      }),
+    },
+    observer: {
+      backend: context.nativeObserverBackend,
+      eventDigest: digestJson(boundaryEvidence.map((record) => record.observerEventDigest)),
+      eventCount: boundaryEvidence.length,
+      overflow: false,
+      ambiguousLineage: false,
+    },
+    faultBoundaryClasses: [...TRANSACTION_FAULT_CLASSES],
+    raceClasses: [...TRANSACTION_RACE_CLASSES],
+    executions: boundaryEvidence.length,
+    killExecutions: boundaryEvidence.filter((record) => record.injectionAction === "kill").length,
+    swapExecutions: boundaryEvidence.filter((record) => record.injectionAction.endsWith("swap")).length,
+    recoveryExecutions: boundaryEvidence.filter((record) => !["none", "fail-closed"].includes(record.recoveryAction)).length,
+    partialStates: 0,
+    unmanagedMutations: 0,
+    hardPolicyViolations: 0,
+    boundaryEvidence,
+  };
+}
+
+function codes(value, validationContext = context) {
+  return transactionEvidenceFailures(value, validationContext).map((entry) => entry.code);
+}
+
+test("transaction semantic contract accepts independently bound unique executions", () => {
+  const value = evidence();
+  assert.deepEqual(transactionEvidenceFailures(value, context), []);
+  assert.equal(assertTransactionEvidenceSemantics(value, context), value);
+});
+
+test("transaction semantic contract rejects duplicated or reordered execution claims", () => {
+  const duplicate = evidence();
+  duplicate.boundaryEvidence[1] = structuredClone(duplicate.boundaryEvidence[0]);
+  duplicate.observer.eventDigest = digestJson(duplicate.boundaryEvidence.map((record) => record.observerEventDigest));
+  assert.ok(codes(duplicate).includes("AAS_VERIFIER_TRANSACTION_DUPLICATE_EXECUTION"));
+  assert.ok(codes(duplicate).includes("AAS_VERIFIER_TRANSACTION_DUPLICATE_BINDING"));
+
+  const reordered = evidence();
+  [reordered.boundaryEvidence[0], reordered.boundaryEvidence[1]] = [reordered.boundaryEvidence[1], reordered.boundaryEvidence[0]];
+  reordered.observer.eventDigest = digestJson(reordered.boundaryEvidence.map((record) => record.observerEventDigest));
+  assert.ok(codes(reordered).includes("AAS_VERIFIER_TRANSACTION_EXECUTION_BINDING"));
+});
+
+test("transaction semantic contract derives every summary and trace aggregate", () => {
+  for (const field of ["executions", "killExecutions", "swapExecutions", "recoveryExecutions"]) {
+    const forged = evidence();
+    forged[field] += 1;
+    assert.ok(codes(forged).includes("AAS_VERIFIER_TRANSACTION_AGGREGATE_BINDING"), field);
+  }
+  const forgedTrace = evidence();
+  forgedTrace.observer.eventDigest = digest("unrelated-trace");
+  assert.ok(codes(forgedTrace).includes("AAS_VERIFIER_TRANSACTION_AGGREGATE_BINDING"));
+});
+
+test("transaction semantic contract binds candidate controller observer and job", () => {
+  const wrongCandidate = evidence();
+  wrongCandidate.candidate.installedTreeSha256 = digest("other-tree");
+  assert.ok(codes(wrongCandidate).includes("AAS_VERIFIER_TRANSACTION_CANDIDATE_MISMATCH"));
+
+  const wrongController = evidence();
+  wrongController.controller.digest = digest("other-controller");
+  assert.ok(codes(wrongController).includes("AAS_VERIFIER_TRANSACTION_CONTROLLER_MISMATCH"));
+
+  const wrongBackend = evidence();
+  wrongBackend.observer.backend = "windows-etw-kernel-process-tree";
+  assert.ok(codes(wrongBackend).includes("AAS_VERIFIER_TRANSACTION_OBSERVER_JOB_MISMATCH"));
+
+  assert.ok(codes(evidence(), {}).includes("AAS_VERIFIER_TRANSACTION_TRUST_CONTEXT_MISSING"));
+});
+
+test("transaction semantic contract rejects disconnected plans commands and traces", () => {
+  for (const field of ["planDigest", "commandDigest", "observerEventDigest"]) {
+    const duplicate = evidence();
+    duplicate.boundaryEvidence[1][field] = duplicate.boundaryEvidence[0][field];
+    if (field === "observerEventDigest") {
+      duplicate.observer.eventDigest = digestJson(duplicate.boundaryEvidence.map((record) => record.observerEventDigest));
+    }
+    assert.ok(codes(duplicate).includes("AAS_VERIFIER_TRANSACTION_DUPLICATE_BINDING"), field);
+  }
+});
+
+test("transaction semantic contract rejects forged action, kill, recovery and final state", () => {
+  const action = evidence();
+  action.boundaryEvidence[0].injectionAction = "drift";
+  assert.ok(codes(action).includes("AAS_VERIFIER_TRANSACTION_EXECUTION_BINDING"));
+
+  const kill = evidence();
+  kill.boundaryEvidence[0].exitCode = 0;
+  kill.boundaryEvidence[0].exitSignal = null;
+  assert.ok(codes(kill).includes("AAS_VERIFIER_TRANSACTION_KILL_NOT_OBSERVED"));
+
+  const race = evidence();
+  const drift = race.boundaryEvidence.find((record) => record.class === "drift");
+  drift.exitCode = 0;
+  assert.ok(codes(race).includes("AAS_VERIFIER_TRANSACTION_RACE_NOT_BLOCKED"));
+
+  const recovery = evidence();
+  const recoveryRace = recovery.boundaryEvidence.find((record) => record.class === "recovery-race");
+  recoveryRace.recoveryAction = "none";
+  recoveryRace.recoveryPlanDigest = recoveryRace.planDigest;
+  recovery.recoveryExecutions -= 1;
+  assert.ok(codes(recovery).includes("AAS_VERIFIER_TRANSACTION_RECOVERY_BINDING"));
+
+  const finalState = evidence();
+  finalState.boundaryEvidence[0].afterDigest = digest("partial-result");
+  assert.ok(codes(finalState).includes("AAS_VERIFIER_TRANSACTION_FINAL_STATE_MISMATCH"));
+});
+
+test("transaction semantic contract rejects unmanaged, partial, mocked, and ambiguous evidence", () => {
+  const unmanaged = evidence();
+  unmanaged.boundaryEvidence[0].unmanagedAfterDigest = digest("mutated-unmanaged");
+  assert.ok(codes(unmanaged).includes("AAS_VERIFIER_TRANSACTION_UNMANAGED_MUTATION"));
+
+  const partial = evidence();
+  partial.boundaryEvidence[0].noPartialState = false;
+  assert.ok(codes(partial).includes("AAS_VERIFIER_TRANSACTION_PARTIAL_STATE"));
+
+  const mocked = evidence();
+  mocked.mocked = true;
+  assert.ok(codes(mocked).includes("AAS_VERIFIER_TRANSACTION_NOT_BLACK_BOX"));
+
+  const ambiguous = evidence();
+  ambiguous.observer.ambiguousLineage = true;
+  assert.ok(codes(ambiguous).includes("AAS_VERIFIER_TRANSACTION_INVARIANT"));
+});
+
+test("transaction semantic assertion fails closed with stable reason codes", () => {
+  const duplicate = evidence();
+  duplicate.boundaryEvidence[1] = structuredClone(duplicate.boundaryEvidence[0]);
+  assert.throws(
+    () => assertTransactionEvidenceSemantics(duplicate, context),
+    (error) => error.code === "AAS_VERIFIER_TRANSACTION_DUPLICATE_EXECUTION"
+      && error.failures.every((entry) => /^AAS_VERIFIER_TRANSACTION_/.test(entry.code)),
+  );
+  assert.deepEqual(codes(null), ["AAS_VERIFIER_TRANSACTION_SEMANTIC_INPUT"]);
+});

--- a/verification/aas-v1/verifier/tests/transaction-evidence.test.mjs
+++ b/verification/aas-v1/verifier/tests/transaction-evidence.test.mjs
@@ -11,17 +11,43 @@ const fault = ["lock", "journal", "backup", "write", "fsync", "rename", "commit"
 const race = ["concurrency", "drift", "symlink-swap", "target-swap", "corrupt-journal", "recovery-race"];
 
 function evidence() {
+  const records = [...fault, ...race].map((value, index) => {
+    const kind = index < fault.length ? "faultBoundary" : "race";
+    const action = kind === "faultBoundary" ? "kill" : value === "concurrency" ? "concurrent" : value;
+    return {
+      executionId: `${kind}-${value}`,
+      class: value,
+      kind,
+      observedOperation: `event-${index}`,
+      injectionAction: action,
+      planDigest: digest,
+      commandDigest: digest,
+      observerEventDigest: digest,
+      beforeDigest: digest,
+      afterDigest: digest,
+      unmanagedBeforeDigest: digest,
+      unmanagedAfterDigest: digest,
+      exitCode: kind === "faultBoundary" ? 137 : 0,
+      exitSignal: kind === "faultBoundary" ? "SIGKILL" : null,
+      recoveryAction: kind === "faultBoundary" ? "cleanup" : "none",
+      recoveryStatus: kind === "faultBoundary" ? "cleaned" : "healthy",
+      recoveryPlanDigest: digest,
+      finalState: index % 2 ? "new" : "previous",
+      noPartialState: true,
+    };
+  });
   return {
     schemaVersion: 1, status: "passed", productionBinary: true, testMode: false, mocked: false,
-    observer: { backend: "linux-strace-process-tree", eventDigest: digest, overflow: false, ambiguousLineage: false },
-    faultBoundaryClasses: fault, raceClasses: race, executions: 13, killExecutions: 7,
-    swapExecutions: 2, recoveryExecutions: 2, partialStates: 0, unmanagedMutations: 0,
+    candidate: {
+      package: "agentic-awesome-skills", version: "14.6.0",
+      tarballSha512: `sha512-${"Y".repeat(86)}==`, installedTreeSha256: digest, aasEntrypointSha256: digest,
+    },
+    controller: { version: "1.0.0", digest },
+    observer: { backend: "linux-strace-process-tree", eventDigest: digest, eventCount: 13, overflow: false, ambiguousLineage: false },
+    faultBoundaryClasses: [...fault], raceClasses: [...race], executions: 13, killExecutions: 7,
+    swapExecutions: 2, recoveryExecutions: 7, partialStates: 0, unmanagedMutations: 0,
     hardPolicyViolations: 0,
-    boundaryEvidence: [...fault, ...race].map((value, index) => ({
-      class: value, observedOperation: `event-${index}`,
-      injectionAction: index < fault.length ? "kill" : value === "concurrency" ? "concurrent" : value,
-      beforeDigest: digest, afterDigest: digest, finalState: index % 2 ? "new" : "previous", noPartialState: true,
-    })),
+    boundaryEvidence: records,
   };
 }
 
@@ -33,4 +59,10 @@ test("transaction evidence requires full external black-box coverage", () => {
   const incomplete = evidence();
   incomplete.faultBoundaryClasses.pop();
   assert.equal(validate(incomplete), false);
+  const unbound = evidence();
+  delete unbound.boundaryEvidence[0].planDigest;
+  assert.equal(validate(unbound), false);
+  const mutatedUnmanaged = evidence();
+  mutatedUnmanaged.boundaryEvidence[0].unmanagedAfterDigest = `sha256-${"b".repeat(64)}`;
+  assert.equal(validate(mutatedUnmanaged), true, "schema leaves cross-field equality to the verifier");
 });

--- a/verification/aas-v1/verifier/tests/transaction-evidence.test.mjs
+++ b/verification/aas-v1/verifier/tests/transaction-evidence.test.mjs
@@ -5,7 +5,7 @@ import path from "node:path";
 import test from "node:test";
 import { fileURLToPath } from "node:url";
 import { loadReceiptValidator } from "../lib/receipt.mjs";
-import { faultFixtureProfile, nativeObservationLineage, portableTreeDigest, raceFixtureProfile, selectBackupSkillIds, walBoundaryIsValid } from "../lib/transaction-controller.mjs";
+import { classifyConcurrencyOutcomes, faultFixtureProfile, nativeObservationLineage, portableTreeDigest, raceFixtureProfile, selectBackupSkillIds, walBoundaryIsValid } from "../lib/transaction-controller.mjs";
 
 const here = path.dirname(fileURLToPath(import.meta.url));
 const validate = loadReceiptValidator(path.resolve(here, "..", "..", "schemas", "product-transaction-evidence.schema.json"));
@@ -183,4 +183,14 @@ test("concurrency races keep the externally observed target lock contended", () 
   assert.deepEqual(raceFixtureProfile("symlink-swap", corpus), { additionalSkills: corpus });
   assert.deepEqual(raceFixtureProfile("target-swap", corpus), { additionalSkills: corpus });
   assert.deepEqual(raceFixtureProfile("corrupt-journal", corpus), { additionalSkills: [] });
+});
+
+test("concurrency accepts only lock rejection or post-commit idempotence", () => {
+  const applied = { result: { code: 0 }, value: { status: "applied" } };
+  const locked = { result: { code: 4 }, value: { status: "error", code: "AAS_TRANSACTION_LOCKED" } };
+  const idempotent = { result: { code: 0 }, value: { status: "alreadyApplied" } };
+  assert.equal(classifyConcurrencyOutcomes([applied, locked]), "locked");
+  assert.equal(classifyConcurrencyOutcomes([applied, idempotent]), "alreadyApplied");
+  assert.equal(classifyConcurrencyOutcomes([applied, { result: { code: 0 }, value: { status: "applied" } }]), null);
+  assert.equal(classifyConcurrencyOutcomes([applied, { result: { code: 1 }, value: { status: "alreadyApplied" } }]), null);
 });

--- a/verification/aas-v1/verifier/tests/transaction-evidence.test.mjs
+++ b/verification/aas-v1/verifier/tests/transaction-evidence.test.mjs
@@ -5,7 +5,7 @@ import path from "node:path";
 import test from "node:test";
 import { fileURLToPath } from "node:url";
 import { loadReceiptValidator } from "../lib/receipt.mjs";
-import { faultFixtureProfile, nativeObservationLineage, portableTreeDigest, selectBackupSkillIds, walBoundaryIsValid } from "../lib/transaction-controller.mjs";
+import { faultFixtureProfile, nativeObservationLineage, portableTreeDigest, raceFixtureProfile, selectBackupSkillIds, walBoundaryIsValid } from "../lib/transaction-controller.mjs";
 
 const here = path.dirname(fileURLToPath(import.meta.url));
 const validate = loadReceiptValidator(path.resolve(here, "..", "..", "schemas", "product-transaction-evidence.schema.json"));
@@ -169,4 +169,10 @@ test("write faults use a policy-safe corpus to expose the transient staging boun
     desired: true,
     additionalSkills: [],
   });
+});
+
+test("concurrency races keep the externally observed target lock contended", () => {
+  const corpus = ["large-a", "large-b"];
+  assert.deepEqual(raceFixtureProfile("concurrency", corpus), { additionalSkills: corpus });
+  assert.deepEqual(raceFixtureProfile("drift", corpus), { additionalSkills: [] });
 });

--- a/verification/aas-v1/verifier/tests/transaction-evidence.test.mjs
+++ b/verification/aas-v1/verifier/tests/transaction-evidence.test.mjs
@@ -5,7 +5,7 @@ import path from "node:path";
 import test from "node:test";
 import { fileURLToPath } from "node:url";
 import { loadReceiptValidator } from "../lib/receipt.mjs";
-import { selectBackupSkillIds } from "../lib/transaction-controller.mjs";
+import { selectBackupSkillIds, walBoundaryIsValid } from "../lib/transaction-controller.mjs";
 
 const here = path.dirname(fileURLToPath(import.meta.url));
 const validate = loadReceiptValidator(path.resolve(here, "..", "..", "schemas", "product-transaction-evidence.schema.json"));
@@ -101,4 +101,16 @@ test("backup fixtures use only policy-safe reviewed skills", (t) => {
     fs.writeFileSync(path.join(skillRoot, "SKILL.md"), `# ${id}\n${id === "safe-b" ? "larger fixture\n" : ""}`);
   }
   assert.deepEqual(selectBackupSkillIds(root, "unused-primary", 2), ["safe-b", "safe-a"]);
+});
+
+test("WAL boundary rules reject commits without rejecting reversible recovery metadata", () => {
+  assert.equal(walBoundaryIsValid("lock", []), true);
+  assert.equal(walBoundaryIsValid("lock", ["started"]), false);
+  assert.equal(walBoundaryIsValid("journal", ["started", "layoutDirectoryCreated"]), true);
+  assert.equal(walBoundaryIsValid("journal", []), false);
+  assert.equal(walBoundaryIsValid("journal", ["started", "committed"]), false);
+  assert.equal(walBoundaryIsValid("fsync", ["started", "mutationIntent"]), true);
+  assert.equal(walBoundaryIsValid("fsync", ["started", "committed"]), false);
+  assert.equal(walBoundaryIsValid("commit", ["started", "committed"]), true);
+  assert.equal(walBoundaryIsValid("backup", ["started", "committed"]), false);
 });

--- a/verification/aas-v1/verifier/tests/transaction-evidence.test.mjs
+++ b/verification/aas-v1/verifier/tests/transaction-evidence.test.mjs
@@ -5,7 +5,7 @@ import path from "node:path";
 import test from "node:test";
 import { fileURLToPath } from "node:url";
 import { loadReceiptValidator } from "../lib/receipt.mjs";
-import { selectBackupSkillIds, walBoundaryIsValid } from "../lib/transaction-controller.mjs";
+import { portableTreeDigest, selectBackupSkillIds, walBoundaryIsValid } from "../lib/transaction-controller.mjs";
 
 const here = path.dirname(fileURLToPath(import.meta.url));
 const validate = loadReceiptValidator(path.resolve(here, "..", "..", "schemas", "product-transaction-evidence.schema.json"));
@@ -113,4 +113,22 @@ test("WAL boundary rules reject commits without rejecting reversible recovery me
   assert.equal(walBoundaryIsValid("fsync", ["started", "committed"]), false);
   assert.equal(walBoundaryIsValid("commit", ["started", "committed"]), true);
   assert.equal(walBoundaryIsValid("backup", ["started", "committed"]), false);
+});
+
+test("portable tree evidence compares content without product-specific digest metadata", (t) => {
+  const left = fs.mkdtempSync(path.join(os.tmpdir(), "aas-controller-tree-left-"));
+  const right = fs.mkdtempSync(path.join(os.tmpdir(), "aas-controller-tree-right-"));
+  t.after(() => {
+    fs.rmSync(left, { recursive: true, force: true });
+    fs.rmSync(right, { recursive: true, force: true });
+  });
+  for (const root of [left, right]) {
+    fs.mkdirSync(path.join(root, "nested"));
+    fs.writeFileSync(path.join(root, "nested", "SKILL.md"), "same bytes\n");
+  }
+  fs.chmodSync(path.join(left, "nested", "SKILL.md"), 0o600);
+  fs.chmodSync(path.join(right, "nested", "SKILL.md"), 0o644);
+  assert.equal(portableTreeDigest(left), portableTreeDigest(right));
+  fs.writeFileSync(path.join(right, "nested", "SKILL.md"), "changed bytes\n");
+  assert.notEqual(portableTreeDigest(left), portableTreeDigest(right));
 });

--- a/verification/aas-v1/verifier/tests/transaction-evidence.test.mjs
+++ b/verification/aas-v1/verifier/tests/transaction-evidence.test.mjs
@@ -5,7 +5,7 @@ import path from "node:path";
 import test from "node:test";
 import { fileURLToPath } from "node:url";
 import { loadReceiptValidator } from "../lib/receipt.mjs";
-import { nativeObservationLineage, portableTreeDigest, selectBackupSkillIds, walBoundaryIsValid } from "../lib/transaction-controller.mjs";
+import { faultFixtureProfile, nativeObservationLineage, portableTreeDigest, selectBackupSkillIds, walBoundaryIsValid } from "../lib/transaction-controller.mjs";
 
 const here = path.dirname(fileURLToPath(import.meta.url));
 const validate = loadReceiptValidator(path.resolve(here, "..", "..", "schemas", "product-transaction-evidence.schema.json"));
@@ -150,4 +150,23 @@ test("native lineage accepts macOS executable binding without invented child eve
     observation: { childProcesses: 1 },
     diagnostics: { processTreeEmpty: true },
   }).verified, true);
+});
+
+test("write faults use a policy-safe corpus to expose the transient staging boundary", () => {
+  const corpus = ["large-a", "large-b"];
+  assert.deepEqual(faultFixtureProfile("write", corpus), {
+    installed: false,
+    desired: true,
+    additionalSkills: corpus,
+  });
+  assert.deepEqual(faultFixtureProfile("backup", corpus), {
+    installed: true,
+    desired: false,
+    additionalSkills: corpus,
+  });
+  assert.deepEqual(faultFixtureProfile("commit", corpus), {
+    installed: false,
+    desired: true,
+    additionalSkills: [],
+  });
 });

--- a/verification/aas-v1/verifier/tests/transaction-evidence.test.mjs
+++ b/verification/aas-v1/verifier/tests/transaction-evidence.test.mjs
@@ -5,7 +5,7 @@ import path from "node:path";
 import test from "node:test";
 import { fileURLToPath } from "node:url";
 import { loadReceiptValidator } from "../lib/receipt.mjs";
-import { portableTreeDigest, selectBackupSkillIds, walBoundaryIsValid } from "../lib/transaction-controller.mjs";
+import { nativeObservationLineage, portableTreeDigest, selectBackupSkillIds, walBoundaryIsValid } from "../lib/transaction-controller.mjs";
 
 const here = path.dirname(fileURLToPath(import.meta.url));
 const validate = loadReceiptValidator(path.resolve(here, "..", "..", "schemas", "product-transaction-evidence.schema.json"));
@@ -131,4 +131,23 @@ test("portable tree evidence compares content without product-specific digest me
   assert.equal(portableTreeDigest(left), portableTreeDigest(right));
   fs.writeFileSync(path.join(right, "nested", "SKILL.md"), "changed bytes\n");
   assert.notEqual(portableTreeDigest(left), portableTreeDigest(right));
+});
+
+test("native lineage accepts macOS executable binding without invented child events", () => {
+  const base = { result: { timedOut: false, outputLimitExceeded: false }, observation: { childProcesses: 0 }, diagnostics: {} };
+  assert.deepEqual(nativeObservationLineage("darwin", { ...base, backend: "macos-fs_usage-process" }), {
+    childObserved: true,
+    verified: true,
+  });
+  assert.deepEqual(nativeObservationLineage("linux", { ...base, backend: "linux-strace-process-tree" }), {
+    childObserved: false,
+    verified: true,
+  });
+  assert.equal(nativeObservationLineage("linux", { ...base, backend: "macos-fs_usage-process" }).verified, false);
+  assert.equal(nativeObservationLineage("win32", {
+    ...base,
+    backend: "windows-etw-kernel-process-tree",
+    observation: { childProcesses: 1 },
+    diagnostics: { processTreeEmpty: true },
+  }).verified, true);
 });

--- a/verification/aas-v1/verifier/tests/transaction-evidence.test.mjs
+++ b/verification/aas-v1/verifier/tests/transaction-evidence.test.mjs
@@ -174,5 +174,8 @@ test("write faults use a policy-safe corpus to expose the transient staging boun
 test("concurrency races keep the externally observed target lock contended", () => {
   const corpus = ["large-a", "large-b"];
   assert.deepEqual(raceFixtureProfile("concurrency", corpus), { additionalSkills: corpus });
-  assert.deepEqual(raceFixtureProfile("drift", corpus), { additionalSkills: [] });
+  assert.deepEqual(raceFixtureProfile("drift", corpus), { additionalSkills: corpus });
+  assert.deepEqual(raceFixtureProfile("symlink-swap", corpus), { additionalSkills: corpus });
+  assert.deepEqual(raceFixtureProfile("target-swap", corpus), { additionalSkills: corpus });
+  assert.deepEqual(raceFixtureProfile("corrupt-journal", corpus), { additionalSkills: [] });
 });

--- a/verification/aas-v1/verifier/tests/transaction-evidence.test.mjs
+++ b/verification/aas-v1/verifier/tests/transaction-evidence.test.mjs
@@ -5,7 +5,7 @@ import path from "node:path";
 import test from "node:test";
 import { fileURLToPath } from "node:url";
 import { loadReceiptValidator } from "../lib/receipt.mjs";
-import { classifyConcurrencyOutcomes, faultFixtureProfile, nativeObservationLineage, portableTreeDigest, raceFixtureProfile, selectBackupSkillIds, walBoundaryIsValid } from "../lib/transaction-controller.mjs";
+import { classifyConcurrencyOutcomes, corruptPrefixIsFailClosed, faultFixtureProfile, nativeObservationLineage, portableTreeDigest, raceFixtureProfile, selectBackupSkillIds, walBoundaryIsValid } from "../lib/transaction-controller.mjs";
 
 const here = path.dirname(fileURLToPath(import.meta.url));
 const validate = loadReceiptValidator(path.resolve(here, "..", "..", "schemas", "product-transaction-evidence.schema.json"));
@@ -193,4 +193,11 @@ test("concurrency accepts only lock rejection or post-commit idempotence", () =>
   assert.equal(classifyConcurrencyOutcomes([applied, idempotent]), "alreadyApplied");
   assert.equal(classifyConcurrencyOutcomes([applied, { result: { code: 0 }, value: { status: "applied" } }]), null);
   assert.equal(classifyConcurrencyOutcomes([applied, { result: { code: 1 }, value: { status: "alreadyApplied" } }]), null);
+});
+
+test("corrupt journal prefixes fail closed under both actionable doctor statuses", () => {
+  assert.equal(corruptPrefixIsFailClosed("degraded", ["AAS_TRANSACTION_JOURNAL_CORRUPT"]), true);
+  assert.equal(corruptPrefixIsFailClosed("recoveryRequired", ["AAS_TRANSACTION_JOURNAL_CORRUPT"]), true);
+  assert.equal(corruptPrefixIsFailClosed("healthy", ["AAS_TRANSACTION_JOURNAL_CORRUPT"]), false);
+  assert.equal(corruptPrefixIsFailClosed("recoveryRequired", ["AAS_TRANSACTION_STALE_OR_ACTIVE_LOCK"]), false);
 });

--- a/verification/aas-v1/verifier/tests/transaction-evidence.test.mjs
+++ b/verification/aas-v1/verifier/tests/transaction-evidence.test.mjs
@@ -1,8 +1,11 @@
 import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
 import path from "node:path";
 import test from "node:test";
 import { fileURLToPath } from "node:url";
 import { loadReceiptValidator } from "../lib/receipt.mjs";
+import { selectBackupSkillIds } from "../lib/transaction-controller.mjs";
 
 const here = path.dirname(fileURLToPath(import.meta.url));
 const validate = loadReceiptValidator(path.resolve(here, "..", "..", "schemas", "product-transaction-evidence.schema.json"));
@@ -65,4 +68,37 @@ test("transaction evidence requires full external black-box coverage", () => {
   const mutatedUnmanaged = evidence();
   mutatedUnmanaged.boundaryEvidence[0].unmanagedAfterDigest = `sha256-${"b".repeat(64)}`;
   assert.equal(validate(mutatedUnmanaged), true, "schema leaves cross-field equality to the verifier");
+});
+
+test("backup fixtures use only policy-safe reviewed skills", (t) => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "aas-controller-skills-"));
+  t.after(() => fs.rmSync(root, { recursive: true, force: true }));
+  const complete = (risk = "safe") => ({
+    reviewDecision: "supported",
+    capabilities: ["test-capability"],
+    risk: { status: "known", value: risk },
+    source: { status: "known", value: { type: "test" } },
+    setup: { status: "known", value: "none" },
+    targets: { codex: { status: "known", value: "supported" } },
+    dependencies: { status: "known", value: [] },
+    conflicts: { status: "known", value: [] },
+    validation: { status: "notApplicable", value: null },
+  });
+  const reviewed = {
+    "safe-a": complete(),
+    "safe-b": complete("none"),
+    incomplete: { ...complete(), dependencies: { status: "unknown", value: null } },
+    "manual-skill": { risk: { status: "known", value: "safe" }, source: { status: "known", value: { type: "test" } }, setup: { status: "known", value: "manual" } },
+    "unknown-source": { risk: { status: "known", value: "safe" }, source: { status: "unknown", value: null }, setup: { status: "known", value: "none" } },
+    "blocked-target": { risk: { status: "known", value: "safe" }, source: { status: "known", value: { type: "test" } }, setup: { status: "known", value: "none" }, targets: { codex: { status: "known", value: "blocked" } } },
+  };
+  const metadataPath = path.join(root, "tools", "lib", "aas-v1");
+  fs.mkdirSync(metadataPath, { recursive: true });
+  fs.writeFileSync(path.join(metadataPath, "metadata-overrides.v1.json"), JSON.stringify({ skills: reviewed }));
+  for (const id of Object.keys(reviewed)) {
+    const skillRoot = path.join(root, "skills", id);
+    fs.mkdirSync(skillRoot, { recursive: true });
+    fs.writeFileSync(path.join(skillRoot, "SKILL.md"), `# ${id}\n${id === "safe-b" ? "larger fixture\n" : ""}`);
+  }
+  assert.deepEqual(selectBackupSkillIds(root, "unused-primary", 2), ["safe-b", "safe-a"]);
 });

--- a/verification/aas-v1/verifier/tests/transaction-evidence.test.mjs
+++ b/verification/aas-v1/verifier/tests/transaction-evidence.test.mjs
@@ -5,7 +5,7 @@ import path from "node:path";
 import test from "node:test";
 import { fileURLToPath } from "node:url";
 import { loadReceiptValidator } from "../lib/receipt.mjs";
-import { classifyConcurrencyOutcomes, corruptPrefixIsFailClosed, faultFixtureProfile, nativeObservationLineage, portableTreeDigest, raceFixtureProfile, selectBackupSkillIds, walBoundaryIsValid } from "../lib/transaction-controller.mjs";
+import { classifyConcurrencyOutcomes, corruptPrefixIsFailClosed, faultFixtureProfile, faultObservationSkillId, nativeObservationLineage, portableTreeDigest, raceFixtureProfile, selectBackupSkillIds, walBoundaryIsValid } from "../lib/transaction-controller.mjs";
 
 const here = path.dirname(fileURLToPath(import.meta.url));
 const validate = loadReceiptValidator(path.resolve(here, "..", "..", "schemas", "product-transaction-evidence.schema.json"));
@@ -174,6 +174,12 @@ test("write faults use a policy-safe corpus to expose the transient staging boun
     desired: true,
     additionalSkills: [],
   });
+});
+
+test("rename faults observe the first deterministic staged publication", () => {
+  const corpus = ["frontend-dev-guidelines", "agent-tool-builder", "tailwind-design-system"];
+  assert.equal(faultObservationSkillId("rename", "react-best-practices", corpus), "agent-tool-builder");
+  assert.equal(faultObservationSkillId("write", "react-best-practices", corpus), "react-best-practices");
 });
 
 test("concurrency races keep the externally observed target lock contended", () => {

--- a/verification/aas-v1/verifier/tests/transaction-evidence.test.mjs
+++ b/verification/aas-v1/verifier/tests/transaction-evidence.test.mjs
@@ -164,6 +164,11 @@ test("write faults use a policy-safe corpus to expose the transient staging boun
     desired: false,
     additionalSkills: corpus,
   });
+  assert.deepEqual(faultFixtureProfile("rename", corpus), {
+    installed: false,
+    desired: true,
+    additionalSkills: corpus,
+  });
   assert.deepEqual(faultFixtureProfile("commit", corpus), {
     installed: false,
     desired: true,


### PR DESCRIPTION
## Summary
- generate transaction evidence from the packed production `aas` binary instead of accepting a missing/self-authored fixture
- inject seven kill boundaries and six race classes through external process/filesystem observation
- bind candidate, native observer/job, plan, command, trace, recovery and final-state evidence with fail-closed semantic validation
- run the generator in the protected six-job product verifier before receipt creation
- update the frozen verifier baseline and bump verifier Ajv to 8.20.0, fixing GHSA-2g4f-4pwh-qvx6

## Safety properties
- no `onBoundary` or production test hook
- unmanaged/outside canaries must remain byte-identical
- overshoot, ambiguous lineage, observer overflow, partial state, duplicate evidence and forged summaries fail closed
- malformed evidence maps to the public schema error

## Validation
- verifier tests: 31/31
- `npm run freeze:check` (`sha256-a234fcab5b987a8c444c4c9e65bf06775a6a6ec0ac4ff0baf04a2035e8ab802e`)
- `npm run check:schemas`
- `npm run check:structure`
- `npm run check:freeze-ready`
- `npm run lint:workflows`
- root `npm run validate`
- root `npm run security:docs`
- `git diff --check`

The local macOS native run failed closed because passwordless `sudo fs_usage` is unavailable outside the hosted runner. After this PR is opened, the branch workflow will be dispatched manually against product PR #887 for the real Linux/macOS/Windows matrix.

## Quality Bar Checklist
- [x] Verifier remains independent of the candidate tarball
- [x] Production binary only; no mocks or internal hooks
- [x] Frozen baseline updated reproducibly
- [x] No canonical skill content changed
- [x] No npm, GitHub Release, MCP config or Pages publication performed