### PR TITLE
test: distinguish macOS process streams

### DIFF
--- a/verification/aas-v1/baseline/v1/freeze-manifest.json
+++ b/verification/aas-v1/baseline/v1/freeze-manifest.json
@@ -8,7 +8,7 @@
     "verifier/node_modules/",
     "baseline/v1/legacy/14.6.0/_work/"
   ],
-  "rootDigest": "sha256-a7b09f915cc3879a97d477dac9f38022ca8d9496aff70bc5ca5a182b452b27d9",
+  "rootDigest": "sha256-694a4b44bddf6a355ccc2a4b13910d775adf11bb8c4b85bbe98913141bc0b084",
   "fileCount": 764,
   "files": [
     {
@@ -3723,8 +3723,8 @@
     },
     {
       "path": "verifier/lib/observer.mjs",
-      "bytes": 29472,
-      "sha256": "6e06406954eccb37202410e301b8c50cece0904fdd0e0da5b04ecfe612abcefe"
+      "bytes": 30490,
+      "sha256": "49f11af533cd36785c8ea0d85360ddf44b9672c0c1f083be28f9c55bfba52717"
     },
     {
       "path": "verifier/lib/prng.mjs",
@@ -3808,8 +3808,8 @@
     },
     {
       "path": "verifier/tests/observer.test.mjs",
-      "bytes": 5730,
-      "sha256": "3c8111741f33dc100ffc752d456c29264d970e38823a5ab1d137573e011f0c77"
+      "bytes": 7244,
+      "sha256": "68a3f0dffb3faa72675c15d367709c7b518c5f914fc0064c21532a245162664d"
     },
     {
       "path": "verifier/tests/runtime.test.mjs",

--- a/verification/aas-v1/verifier/lib/observer.mjs
+++ b/verification/aas-v1/verifier/lib/observer.mjs
@@ -117,6 +117,25 @@ function fsUsageTimestamp(line) {
   return ((Number(match[1]) * 60 + Number(match[2])) * 60 + Number(match[3])) * 1000 + fraction * 1000;
 }
 
+function macFsUsageCall(line) {
+  return line.match(/^\d{2}:\d{2}:\d{2}\.\d+\s+(\S+)/)?.[1] ?? "";
+}
+
+export function isMacPersistentWriteLine(line, zones = {}) {
+  const call = macFsUsageCall(line);
+  const normalizedCall = call.replace(/\[.*$/u, "").toLowerCase();
+  const descriptor = line.match(/\bF=(?:0x)?([0-9a-f]+)\b/iu)?.[1]?.toLowerCase() ?? null;
+  const namesObservedPath = Object.values(zones).some((root) => typeof root === "string" && root.length > 0 && line.includes(root));
+  // fs_usage reports writes to the candidate's inherited stdout/stderr pipes
+  // as `write F=1|2`. Those are process streams, which the frozen contract
+  // explicitly excludes from persistent filesystem writes. Physical WrData
+  // events remain mutations even when their displayed descriptor is 1 or 2,
+  // so reopening a stream descriptor onto a file is still observed.
+  if (["write", "writev"].includes(normalizedCall)
+    && ["1", "2"].includes(descriptor) && !namesObservedPath) return false;
+  return /^(?:wrdata|wrmeta|write|writev|write_nocancel|writev_nocancel|pwrite|pwritev|rename|unlink|mkdir|rmdir|truncate|ftruncate|chmod|chown|fsync|fdatasync|setattr|setxattr)$/u.test(normalizedCall);
+}
+
 const FS_USAGE_DAY_MS = 24 * 60 * 60 * 1000;
 const FS_USAGE_MAX_INTERVAL_MS = 15 * 60 * 1000;
 
@@ -128,7 +147,7 @@ export function parseMacFsUsage(filesystemText, networkText, execText, zones = {
   const events = [];
   for (const line of fsUsageLines(networkText)) events.push({ kind: "network", targetDigest: redactToken(line, zones) });
   for (const line of fsUsageLines(filesystemText)) {
-    if (/\b(?:WrData|WrMeta|write|pwrite|rename|unlink|mkdir|rmdir|truncate|chmod|chown|fsync|fdatasync|setattr|setxattr)\b/i.test(line)) {
+    if (isMacPersistentWriteLine(line, zones)) {
       events.push({ kind: "write", targetDigest: redactToken(line, zones) });
     }
   }
@@ -146,7 +165,7 @@ export function parseMacCombinedFsUsage(text, zones = {}, readinessToken = "", c
     const timestamp = fsUsageTimestamp(line);
     if (/\b(?:socket|connect|bind|listen|accept|sendto|sendmsg|recvfrom|recvmsg|getaddrinfo)\b/i.test(line)) {
       classified.push({ timestamp, kind: "network", line });
-    } else if (/\b(?:WrData|WrMeta|write|pwrite|rename|unlink|mkdir|rmdir|truncate|chmod|chown|fsync|fdatasync|setattr|setxattr)\b/i.test(line)) {
+    } else if (isMacPersistentWriteLine(line, zones)) {
       if (readinessToken && line.includes(readinessToken)) readinessTimestamps.push(timestamp);
       else if (candidateToken && line.includes(candidateToken)) candidateTimestamps.push(timestamp);
       else classified.push({ timestamp, kind: "write", line });

--- a/verification/aas-v1/verifier/tests/observer.test.mjs
+++ b/verification/aas-v1/verifier/tests/observer.test.mjs
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import { macObserverBudgets, parseDelimitedObserver, parseLinuxStrace, parseMacCombinedFsUsage, parseMacFsUsage, rewriteMacObservedNodeInput, windowsObserverBudgets } from "../lib/observer.mjs";
+import { isMacPersistentWriteLine, macObserverBudgets, parseDelimitedObserver, parseLinuxStrace, parseMacCombinedFsUsage, parseMacFsUsage, rewriteMacObservedNodeInput, windowsObserverBudgets } from "../lib/observer.mjs";
 import { runProcess } from "../lib/process.mjs";
 
 test("process runner distinguishes observer cleanup kills from timeouts", async () => {
@@ -69,6 +69,27 @@ test("macOS fs_usage parser separates network, writes, and child execs", () => {
   assert.equal(result.networkAttempts, 1);
   assert.equal(result.writeAttempts, 1);
   assert.equal(result.childProcesses, 1);
+});
+
+test("macOS fs_usage excludes only inherited process-stream writes", () => {
+  assert.equal(isMacPersistentWriteLine("12:00:00.100 write F=1 B=0x20 aasobs.1"), false);
+  assert.equal(isMacPersistentWriteLine("12:00:00.110 writev F=2 B=0x20 aasobs.1"), false);
+  assert.equal(isMacPersistentWriteLine("12:00:00.120 write F=3 B=0x20 aasobs.1"), true);
+  assert.equal(isMacPersistentWriteLine("12:00:00.130 WrData[A] F=1 /tmp/reopened-output aasobs.1"), true);
+  assert.equal(isMacPersistentWriteLine("12:00:00.140 WrMeta[A] F=2 /tmp/reopened-error aasobs.1"), true);
+  assert.equal(isMacPersistentWriteLine("12:00:00.150 rename F=1 /tmp/renamed aasobs.1"), true);
+  assert.equal(isMacPersistentWriteLine("12:00:00.160 fsync F=2 aasobs.1"), true);
+  assert.equal(isMacPersistentWriteLine("12:00:00.170 write F=10 B=0x20 aasobs.1"), true);
+  assert.equal(isMacPersistentWriteLine("12:00:00.180 write_nocancel F=1 B=0x20 aasobs.1"), true);
+  assert.equal(isMacPersistentWriteLine("12:00:00.190 write F=1 /tmp/project/rebound.log aasobs.1", { project: "/tmp/project" }), true);
+  const result = parseMacCombinedFsUsage([
+    "12:00:00.005 WrData[A] F=3 /tmp/aas-ready-1 aasobs.1",
+    "12:00:00.010 WrData[A] F=3 /tmp/aas-start-1 aasobs.1",
+    "12:00:00.020 write F=1 B=0x20 aasobs.1",
+    "12:00:00.030 write F=2 B=0x20 aasobs.1",
+    "12:00:00.040 WrData[A] F=1 /tmp/reopened-output aasobs.1",
+  ].join("\n"), {}, "aas-ready-1", "aas-start-1");
+  assert.equal(result.writeAttempts, 1);
 });
 
 test("combined macOS fs_usage parser enforces canary ordering and classifies candidate calls", () => {


### PR DESCRIPTION
## Summary

- distinguish macOS process stdout/stderr pipe writes from persistent filesystem writes in the verifier
- keep physical data/metadata writes, non-stream descriptors, durable operations, and writes naming observed zones fail-closed
- cover the boundary with regression tests and refresh the frozen verifier baseline

## Why

The macOS product-verifier leg in run 29624709857 reported `AAS_VERIFIER_MCP_WRITE_ATTEMPT` and `AAS_VERIFIER_HOSTILE_WRITE` even though the monitored zone digests were unchanged. `fs_usage` exposes the child process JSON output as `write F=1` / `writev F=2`; these are the stdout/stderr pipes deliberately captured by the verifier, not persistent writes.

The filter is intentionally narrow: only `write`/`writev` on descriptor 1 or 2 without a monitored-zone pathname are ignored. `WrData`, `WrMeta`, `fsync`, rename operations, descriptor 3+, `write_nocancel`, and any operation containing an observed-zone path remain observable failures.

## Validation

- verifier tests: 46/46 passing
- `npm run freeze:check`
- `npm run validate`
- `npm run validate:references`
- `npm run security:docs`
- `npm run test`
- `git diff --check`
- verifier dependency audit: 0 vulnerabilities

## Quality Bar Checklist

- [x] Change is narrowly scoped and fail-closed
- [x] Regression tests cover accepted and rejected macOS events
- [x] Frozen verifier digest was regenerated and checked
- [x] Full repository validation and test suite pass
- [x] No generated catalog artifacts or skill content changed
- [x] No npm, release, tag, Pages, or other publication action performed
