### PR TITLE
fix: make transaction evidence deterministic

### DIFF
--- a/tools/lib/aas-v1/transaction/runtime.js
+++ b/tools/lib/aas-v1/transaction/runtime.js
@@ -26,6 +26,7 @@ const {
 const {
   clearMaterializedMarkers,
   cleanupMaterializedLayout,
+  remainingMaterializedLayoutPaths,
   inspectLayout,
   materializeLayout,
   resolveDestination,
@@ -1352,6 +1353,13 @@ function recover({ recoveryPlan, plan, adapter, approvalDigest, onBoundary }) {
         clearMaterializedMarkers(strictLayout, createdDirectories, { markerName: bootstrap.markerName, markerToken: bootstrap.markerToken });
       } else {
         cleanupMaterializedLayout(strictLayout, createdDirectories, { markerName: bootstrap.markerName, markerToken: bootstrap.markerToken });
+        const remaining = remainingMaterializedLayoutPaths(strictLayout, createdDirectories, {
+          markerName: bootstrap.markerName,
+          markerToken: bootstrap.markerToken,
+        });
+        if (remaining.length) {
+          throw transactionError("AAS_TRANSACTION_LAYOUT_CLEANUP_INCOMPLETE", "recovery", { logicalIds: remaining });
+        }
       }
       removeBootstrapRecord(bootstrap, strictLayout);
     }

--- a/tools/lib/aas-v1/transaction/safety.js
+++ b/tools/lib/aas-v1/transaction/safety.js
@@ -237,6 +237,29 @@ function cleanupMaterializedLayout(inspected, directories, options) {
   }
 }
 
+function remainingMaterializedLayoutPaths(inspected, directories, options) {
+  const { markerToken } = ownershipMarker(options);
+  const remaining = [];
+  for (const directory of directories) {
+    if (!isContained(inspected.root, directory)) continue;
+    const parent = path.dirname(directory);
+    const candidates = [
+      directory,
+      path.join(parent, `.aas-layout-stage-${markerToken}-${path.basename(directory)}`),
+      path.join(parent, `.aas-layout-remove-${markerToken}-${path.basename(directory)}`),
+    ];
+    for (const candidate of candidates) {
+      try {
+        fs.lstatSync(candidate);
+        remaining.push(path.relative(inspected.root, candidate).split(path.sep).join("/"));
+      } catch (error) {
+        if (!["ENOENT", "ENOTDIR"].includes(error?.code)) throw error;
+      }
+    }
+  }
+  return [...new Set(remaining)].sort();
+}
+
 function clearMaterializedMarkers(inspected, directories, options) {
   const { markerName, markerToken } = ownershipMarker(options);
   for (const directory of [...directories].reverse()) {
@@ -276,6 +299,7 @@ module.exports = {
   assertOwned,
   assertRegularDirectory,
   cleanupMaterializedLayout,
+  remainingMaterializedLayoutPaths,
   clearMaterializedMarkers,
   inspectLayout,
   isContained,

--- a/tools/scripts/tests/aas_v1_transaction.test.js
+++ b/tools/scripts/tests/aas_v1_transaction.test.js
@@ -29,6 +29,7 @@ const {
   cleanupMaterializedLayout,
   inspectLayout,
   materializeLayout,
+  remainingMaterializedLayoutPaths,
 } = require("../../lib/aas-v1/transaction/safety");
 
 const DIGEST = (letter) => `sha256-${letter.repeat(64)}`;
@@ -272,6 +273,60 @@ test("cleanup recovery closes a WAL created before layout materialization", () =
   fs.rmSync(fx.sandbox, { recursive: true });
 });
 
+test("cleanup recovery stays fail-closed when a marker-owned stage is not empty", () => {
+  const fx = fixture();
+  fs.rmSync(fx.transactionDirectory, { recursive: true });
+  const plan = buildInstallPlan(fx);
+  const inspected = inspectLayout(fx.adapter, plan.payload.target);
+  const applyLock = acquireLock(inspected, plan);
+  const recoveryId = recoveryIdFor(plan.digest, TARGET_ID);
+  const markerName = `.aas-layout-${recoveryId}`;
+  const bootstrapBody = {
+    directories: inspected.missingDirectories
+      .map((directory) => path.relative(inspected.root, directory).split(path.sep).join("/")),
+    markerName,
+    markerToken: applyLock.token,
+    planDigest: plan.digest,
+    recoveryId,
+    schemaVersion: 1,
+    targetIdentityDigest: TARGET_ID,
+  };
+  fs.writeFileSync(path.join(fx.root, `.aas-bootstrap-${recoveryId}.json`), `${canonicalJson({
+    ...bootstrapBody,
+    recordDigest: sha256(canonicalJson(bootstrapBody)),
+  })}\n`);
+  createJournal(fx.root, recoveryId, plan.digest, TARGET_ID);
+  const missing = inspected.missingDirectories[0];
+  const stage = path.join(path.dirname(missing), `.aas-layout-stage-${applyLock.token}-${path.basename(missing)}`);
+  fs.mkdirSync(stage, { mode: 0o700 });
+  fs.writeFileSync(path.join(stage, markerName), `${applyLock.token}\n`, { mode: 0o600 });
+  fs.writeFileSync(path.join(stage, "unexpected.txt"), "unmanaged\n", { mode: 0o600 });
+  fs.closeSync(applyLock.descriptor);
+  fs.writeFileSync(applyLock.path, `${canonicalJson({ ...applyLock.record, pid: 2147483647 })}\n`);
+
+  const cleanup = buildRecoveryPlan({ plan, adapter: fx.adapter, recoveryId, action: "cleanup" });
+  assert.throws(() => recover({
+    recoveryPlan: cleanup,
+    plan,
+    adapter: fx.adapter,
+    approvalDigest: cleanup.digest,
+  }), { code: "AAS_TRANSACTION_LAYOUT_CLEANUP_INCOMPLETE" });
+  assert.equal(fs.existsSync(stage), true);
+  assert.equal(fs.readFileSync(path.join(stage, "unexpected.txt"), "utf8"), "unmanaged\n");
+  assert.equal(fs.existsSync(path.join(fx.root, `.aas-bootstrap-${recoveryId}.json`)), true);
+  assert.equal(doctor({ target: plan.payload.target, adapter: fx.adapter }).status, "recoveryRequired");
+  fs.unlinkSync(path.join(stage, "unexpected.txt"));
+  assert.equal(recover({
+    recoveryPlan: cleanup,
+    plan,
+    adapter: fx.adapter,
+    approvalDigest: cleanup.digest,
+  }).status, "cleaned");
+  assert.equal(fs.existsSync(stage), false);
+  assert.equal(doctor({ target: plan.payload.target, adapter: fx.adapter }).status, "healthy");
+  fs.rmSync(fx.sandbox, { recursive: true });
+});
+
 test("layout publication failure is tracked before fsync and leaves no partial artifact", () => {
   const fx = fixture();
   fs.rmSync(fx.skillsDirectory, { recursive: true });
@@ -329,11 +384,40 @@ test("layout cleanup removes only exact marker-owned stages left before publicat
     fs.mkdirSync(stage, { mode: 0o700 });
     fs.writeFileSync(path.join(stage, markerName), `${markerToken}\n`, { mode: 0o600 });
   }
+  assert.ok(remainingMaterializedLayoutPaths(inspected, inspected.missingDirectories, { markerName, markerToken }).length > 0);
   cleanupMaterializedLayout(inspected, inspected.missingDirectories, { markerName, markerToken });
+  assert.deepEqual(remainingMaterializedLayoutPaths(inspected, inspected.missingDirectories, { markerName, markerToken }), []);
   assert.equal(fs.readdirSync(fx.root).some((name) => name.includes(markerToken)), false);
   assert.equal(fs.readFileSync(path.join(fx.root, "unmanaged.txt"), "utf8"), "mine\n");
   assert.equal(fs.existsSync(fx.skillsDirectory), false);
   assert.equal(fs.existsSync(fx.transactionDirectory), false);
+  fs.rmSync(fx.sandbox, { recursive: true });
+});
+
+test("layout cleanup postcondition detects a dangling symlink artifact", (t) => {
+  const fx = fixture();
+  fs.rmSync(fx.transactionDirectory, { recursive: true });
+  const inspected = inspectLayout(fx.adapter, { host: "codex", scope: "project", identityDigest: TARGET_ID });
+  const markerToken = "9".repeat(48);
+  const markerName = `.aas-layout-recovery-${"8".repeat(32)}`;
+  const directory = inspected.missingDirectories[0];
+  const stage = path.join(path.dirname(directory), `.aas-layout-stage-${markerToken}-${path.basename(directory)}`);
+  fs.mkdirSync(path.dirname(stage), { recursive: true });
+  try {
+    fs.symlinkSync(path.join(fx.root, "missing-target"), stage, "dir");
+  } catch (error) {
+    if (["EPERM", "EACCES", "ENOSYS"].includes(error.code)) {
+      fs.rmSync(fx.sandbox, { recursive: true });
+      t.skip(`symlink unavailable: ${error.code}`);
+      return;
+    }
+    throw error;
+  }
+  assert.deepEqual(remainingMaterializedLayoutPaths(inspected, [directory], { markerName, markerToken }), [
+    path.relative(inspected.root, stage).split(path.sep).join("/"),
+  ]);
+  fs.unlinkSync(stage);
+  assert.deepEqual(remainingMaterializedLayoutPaths(inspected, [directory], { markerName, markerToken }), []);
   fs.rmSync(fx.sandbox, { recursive: true });
 });
 

--- a/verification/aas-v1/baseline/v1/freeze-manifest.json
+++ b/verification/aas-v1/baseline/v1/freeze-manifest.json
@@ -8,8 +8,8 @@
     "verifier/node_modules/",
     "baseline/v1/legacy/14.6.0/_work/"
   ],
-  "rootDigest": "sha256-694a4b44bddf6a355ccc2a4b13910d775adf11bb8c4b85bbe98913141bc0b084",
-  "fileCount": 764,
+  "rootDigest": "sha256-148dc0768914c31973b1f43fd385046d2ba7323981f92a6cf15f952918b282ee",
+  "fileCount": 765,
   "files": [
     {
       "path": "README.md",
@@ -3678,8 +3678,8 @@
     },
     {
       "path": "verifier/drivers/transaction-fault.mjs",
-      "bytes": 9151,
-      "sha256": "f7ea5ab2e24ef47c34a134862516a40f33c7910da0f2ce5e83b9f8d5eec47ef8"
+      "bytes": 9868,
+      "sha256": "29ec888fb88a24eeebba2dafcb96af4facf38e64dc34164e992f6abc428e5ae3"
     },
     {
       "path": "verifier/drivers/transaction-race.mjs",
@@ -3758,13 +3758,18 @@
     },
     {
       "path": "verifier/lib/transaction-controller.mjs",
-      "bytes": 39925,
-      "sha256": "2eb3b2bd8711677eedfefaca7f3289faaa1c9ce4dacc2743552890719c46da92"
+      "bytes": 40750,
+      "sha256": "f564e8c4fd293211c61550d7dfd59d7842c5d4bceb1edd5495fa6a9db82d2f73"
     },
     {
       "path": "verifier/lib/transaction-evidence.mjs",
       "bytes": 11460,
       "sha256": "2fff15ff8ae040c602848653502b341a7014fe1ab7571c2bfe667e3f114c7c00"
+    },
+    {
+      "path": "verifier/lib/transaction-fault-contract.mjs",
+      "bytes": 1566,
+      "sha256": "14eda6faf43e6eca95e79820a62376b5705eda77eac09a899c6a04dbe17504e5"
     },
     {
       "path": "verifier/observers/windows-etw.ps1",
@@ -3823,8 +3828,8 @@
     },
     {
       "path": "verifier/tests/transaction-evidence.test.mjs",
-      "bytes": 10899,
-      "sha256": "cfe5bb814b7e2d0db2d825adfa95d86891454ebe5774ed3ccbbd7f749ee8094e"
+      "bytes": 13504,
+      "sha256": "9135aa99b4b6198b45aeb1b7770a8fd0ace4b9d576496774b0c77eacd655927d"
     },
     {
       "path": "verifier/tests/tuning-gold-equivalence-audit.test.mjs",

--- a/verification/aas-v1/baseline/v1/freeze-manifest.json
+++ b/verification/aas-v1/baseline/v1/freeze-manifest.json
@@ -8,7 +8,7 @@
     "verifier/node_modules/",
     "baseline/v1/legacy/14.6.0/_work/"
   ],
-  "rootDigest": "sha256-148dc0768914c31973b1f43fd385046d2ba7323981f92a6cf15f952918b282ee",
+  "rootDigest": "sha256-daca3ee63c2f27c156e4a20ca7cfe110da09073740bbfe31d7371bd7a41ce39c",
   "fileCount": 765,
   "files": [
     {
@@ -3723,8 +3723,8 @@
     },
     {
       "path": "verifier/lib/observer.mjs",
-      "bytes": 30490,
-      "sha256": "49f11af533cd36785c8ea0d85360ddf44b9672c0c1f083be28f9c55bfba52717"
+      "bytes": 32559,
+      "sha256": "63c23af8747bd4a727dceaec944a8e5d50395ce6fea4bbf05661ca9ede7a103d"
     },
     {
       "path": "verifier/lib/prng.mjs",
@@ -3813,8 +3813,8 @@
     },
     {
       "path": "verifier/tests/observer.test.mjs",
-      "bytes": 7244,
-      "sha256": "68a3f0dffb3faa72675c15d367709c7b518c5f914fc0064c21532a245162664d"
+      "bytes": 7284,
+      "sha256": "13aa68f043e8e3f75f346ba0cf7c194ebb32277c1b0ed2a072ca28b6683c7552"
     },
     {
       "path": "verifier/tests/runtime.test.mjs",

--- a/verification/aas-v1/verifier/drivers/transaction-fault.mjs
+++ b/verification/aas-v1/verifier/drivers/transaction-fault.mjs
@@ -4,6 +4,7 @@ import fs from "node:fs";
 import path from "node:path";
 import { spawn, spawnSync } from "node:child_process";
 import crypto from "node:crypto";
+import { isTransientTraversalError, validateObservedLockRecord } from "../lib/transaction-fault-contract.mjs";
 
 function digest(value) {
   return `sha256-${crypto.createHash("sha256").update(JSON.stringify(value)).digest("hex")}`;
@@ -12,11 +13,20 @@ function digest(value) {
 function listMatching(root, matcher) {
   const found = [];
   const visit = (directory) => {
-    if (!fs.existsSync(directory)) return;
-    for (const name of fs.readdirSync(directory)) {
+    let names;
+    try {
+      names = fs.readdirSync(directory);
+    } catch (error) {
+      if (isTransientTraversalError(error)) return;
+      throw error;
+    }
+    for (const name of names) {
       const absolute = path.join(directory, name);
       let stat;
-      try { stat = fs.lstatSync(absolute); } catch { continue; }
+      try { stat = fs.lstatSync(absolute); } catch (error) {
+        if (isTransientTraversalError(error)) continue;
+        throw error;
+      }
       const relative = path.relative(root, absolute).split(path.sep).join("/");
       if (matcher(relative, stat)) found.push(relative);
       if (stat.isDirectory() && !stat.isSymbolicLink()) visit(absolute);
@@ -26,7 +36,7 @@ function listMatching(root, matcher) {
   return found.sort();
 }
 
-function predicate(className, targetRoot, skillId) {
+function predicate(className, targetRoot, skillId, expected) {
   const matchers = {
     lock: (relative) => relative === ".aas-transaction.lock",
     journal: (relative) => /^\.aas-transaction-recovery-[a-f0-9]+\.wal$/.test(relative),
@@ -38,12 +48,13 @@ function predicate(className, targetRoot, skillId) {
   };
   if (!matchers[className]) throw new Error(`Unknown fault class: ${className}`);
   const lockPath = path.join(targetRoot, ".aas-transaction.lock");
-  if (!fs.existsSync(lockPath)) return null;
   try {
+    const stat = fs.lstatSync(lockPath);
+    if (stat.isSymbolicLink() || !stat.isFile() || stat.nlink !== 1) return null;
     const text = fs.readFileSync(lockPath, "utf8");
     const record = JSON.parse(text);
-    if (!text.endsWith("\n") || record.kind !== "apply" || !Number.isSafeInteger(record.pid)
-      || !/^[a-f0-9]{48}$/.test(record.token || "") || !/^sha256-[a-f0-9]{64}$/.test(record.planDigest || "")) return null;
+    if (!text.endsWith("\n") || !validateObservedLockRecord(record, expected)) return null;
+    expected.lockDigest = digest(record);
   } catch { return null; }
   const matches = listMatching(targetRoot, matchers[className]);
   if (!matches.length) return null;
@@ -64,7 +75,13 @@ function predicate(className, targetRoot, skillId) {
       if (!text.endsWith("\n") || !records.some((record) => record.event === "committed")) return null;
     }
   } catch { return null; }
-  return { class: className, pathsDigest: digest(matches), count: matches.length };
+  return {
+    class: className,
+    pathsDigest: digest(matches),
+    count: matches.length,
+    lockValidated: true,
+    lockDigest: expected.lockDigest,
+  };
 }
 
 function walEvidence(targetRoot) {
@@ -130,6 +147,13 @@ const child = spawn(input.executable, input.args, {
   windowsHide: true,
   stdio: ["ignore", "pipe", "pipe"],
 });
+const expectedLock = {
+  pid: child.pid,
+  planDigest: input.expectedPlanDigest,
+  targetIdentityDigest: input.expectedTargetIdentityDigest,
+  plannedDirectories: [],
+  lockDigest: null,
+};
 const stdout = [];
 const stderr = [];
 child.stdout.on("data", (chunk) => stdout.push(chunk));
@@ -143,7 +167,7 @@ let observed = null;
 let terminationStarted = false;
 const observeAndTerminate = () => {
   if (observed || terminationStarted) return;
-  const value = predicate(input.className, input.targetRoot, input.skillId);
+  const value = predicate(input.className, input.targetRoot, input.skillId, expectedLock);
   if (!value) return;
   observed = value;
   terminationStarted = true;
@@ -159,7 +183,14 @@ const watchDirectory = (directory) => {
 };
 const visitDirectories = (directory) => {
   watchDirectory(directory);
-  for (const entry of fs.readdirSync(directory, { withFileTypes: true })) {
+  let entries;
+  try {
+    entries = fs.readdirSync(directory, { withFileTypes: true });
+  } catch (error) {
+    if (isTransientTraversalError(error)) return;
+    throw error;
+  }
+  for (const entry of entries) {
     if (entry.isDirectory() && !entry.isSymbolicLink()) visitDirectories(path.join(directory, entry.name));
   }
 };

--- a/verification/aas-v1/verifier/lib/observer.mjs
+++ b/verification/aas-v1/verifier/lib/observer.mjs
@@ -231,6 +231,7 @@ async function macObserved(executable, args, options) {
   const observedExecutable = path.join(options.evidenceDir, observedName);
   const readinessCanary = path.join(options.evidenceDir, `aas-ready-${sequence}`);
   const candidateCanary = path.join(options.evidenceDir, `aas-start-${sequence}`);
+  const candidateRelease = path.join(options.evidenceDir, `aas-release-${sequence}`);
   const readinessToken = path.basename(readinessCanary);
   const candidateToken = path.basename(candidateCanary);
   const launcher = path.join(options.evidenceDir, `observer-${process.pid}.command`);
@@ -244,7 +245,7 @@ async function macObserved(executable, args, options) {
     // Give fs_usage time to attach its process-name filter after Node updates
     // the copied executable's title. The candidate begins only after this
     // bounded native canary heartbeat has completed.
-    `for (let attempt = 0; attempt < 20; attempt += 1) { const fd = fs.openSync(${JSON.stringify(candidateCanary)}, 'w', 0o600); fs.writeSync(fd, 'start'); fs.fsyncSync(fd); fs.closeSync(fd); Atomics.wait(waitArray, 0, 0, 100); }`,
+    `let candidateReleased = false; for (let attempt = 0; attempt < 100; attempt += 1) { const fd = fs.openSync(${JSON.stringify(candidateCanary)}, 'w', 0o600); fs.writeSync(fd, 'start'); fs.fsyncSync(fd); fs.closeSync(fd); if (fs.existsSync(${JSON.stringify(candidateRelease)})) { candidateReleased = true; break; } Atomics.wait(waitArray, 0, 0, 100); } if (!candidateReleased) throw Object.assign(new Error('observer did not release candidate'), { code: 'AAS_OBSERVER_UNAVAILABLE' });`,
     `const args = JSON.parse(Buffer.from(${JSON.stringify(encodedArgs)}, 'base64').toString('utf8'));`,
     "if (args[0] === '-e') { process.argv = [process.execPath, ...args.slice(2)]; eval(args[1]); }",
     "else { process.argv = [process.execPath, ...args]; require('node:module').runMain(); }",
@@ -255,6 +256,9 @@ async function macObserved(executable, args, options) {
   let observerPromise = null;
   let observerStopStarted = false;
   let observerCleanupFailed = false;
+  let candidateChild = null;
+  let candidateOutcome = null;
+  let candidatePromise = null;
   let liveObserverOutput = "";
   let captureLiveOutput = true;
   const captureObserverOutput = (callback) => (chunk) => {
@@ -339,7 +343,6 @@ async function macObserved(executable, args, options) {
       assertObserverActive("readiness-after-probe");
       if (liveObserverOutput.includes(readinessToken)) {
         readinessObservedLive = true;
-        captureLiveOutput = false;
         break;
       }
     }
@@ -347,13 +350,39 @@ async function macObserved(executable, args, options) {
       throw Object.assign(new Error("fs_usage did not confirm readiness before the candidate deadline"), { code: "AAS_OBSERVER_UNAVAILABLE" });
     }
     assertObserverActive("candidate-start");
-    const result = await runProcess(observedExecutable, [launcher], {
+    candidatePromise = runProcess(observedExecutable, [launcher], {
       ...options,
+      // The native handshake precedes candidate execution, so it receives a
+      // separate bounded allowance instead of consuming the candidate budget.
+      timeoutMs: options.timeoutMs + budgets.candidateHandshakeTimeoutMs,
       // fs_usage filters by executable name rather than ancestry. Make a
       // transaction driver launch the byte-identical observed Node copy so
       // the candidate child remains inside the native process filter.
       stdin: rewriteMacObservedNodeInput(options.stdin, process.execPath, observedExecutable),
-    });
+      onSpawn(child) {
+        candidateChild = child;
+        child.once("close", () => { candidateChild = null; });
+      },
+    }).then(
+      (candidateResult) => (candidateOutcome = { result: candidateResult }),
+      (error) => (candidateOutcome = { error }),
+    );
+    const candidateDeadline = Date.now() + budgets.candidateHandshakeTimeoutMs;
+    while (!liveObserverOutput.includes(candidateToken) && !candidateOutcome && Date.now() < candidateDeadline) {
+      assertObserverActive("candidate-canary");
+      await new Promise((resolve) => setTimeout(resolve, 50));
+    }
+    if (!liveObserverOutput.includes(candidateToken)) {
+      await candidatePromise;
+      throw Object.assign(new Error("fs_usage did not confirm the candidate start canary before release"), { code: "AAS_OBSERVER_UNAVAILABLE" });
+    }
+    fs.writeFileSync(candidateRelease, "release", { mode: 0o600 });
+    captureLiveOutput = false;
+    const candidateCompletion = await candidatePromise;
+    if (candidateCompletion.error) {
+      throw Object.assign(new Error("candidate process failed to start"), { code: "AAS_OBSERVER_UNAVAILABLE" });
+    }
+    const result = candidateCompletion.result;
     await new Promise((resolve) => setTimeout(resolve, budgets.drainMs));
     assertObserverActive("candidate-drain");
     await stopObserver();
@@ -382,10 +411,13 @@ async function macObserved(executable, args, options) {
     };
   } finally {
     captureLiveOutput = false;
+    if (candidateChild) candidateChild.kill("SIGKILL");
+    if (candidatePromise) await candidatePromise;
     await stopObserver();
     if (observerPromise) await observerPromise.catch(() => null);
     fs.rmSync(readinessCanary, { force: true });
     fs.rmSync(candidateCanary, { force: true });
+    fs.rmSync(candidateRelease, { force: true });
     fs.rmSync(launcher, { force: true });
     fs.rmSync(observedExecutable, { force: true });
   }
@@ -405,17 +437,20 @@ export function macObserverBudgets(candidateTimeoutMs = 30_000) {
   const readinessMaxAttempts = 4;
   const readinessProcessTimeoutMs = 10_000;
   const readinessDelayMs = 500;
+  const candidateHandshakeTimeoutMs = 8_000;
   const drainMs = 1_000;
   return {
     startupMs,
     readinessMaxAttempts,
     readinessProcessTimeoutMs,
     readinessDelayMs,
+    candidateHandshakeTimeoutMs,
     drainMs,
     traceMaxOutputBytes: 64 * 1024 * 1024,
     observerTimeoutMs: startupMs
       + readinessMaxAttempts * (readinessProcessTimeoutMs + readinessDelayMs)
       + candidateTimeoutMs
+      + candidateHandshakeTimeoutMs
       + drainMs
       + 5_000,
   };

--- a/verification/aas-v1/verifier/lib/transaction-controller.mjs
+++ b/verification/aas-v1/verifier/lib/transaction-controller.mjs
@@ -151,6 +151,16 @@ export function nativeObservationLineage(platform, observed) {
   return { childObserved, verified };
 }
 
+export function nativeMutationEvidenceSatisfied(platform, className, writeAttempts, lockValidated) {
+  if (Number.isSafeInteger(writeAttempts) && writeAttempts > 0) return true;
+  // The lock is the first durable boundary and can be created and killed
+  // between two fs_usage samples. The driver has independently parsed the
+  // complete token-bound lock record from disk; no later boundary or WAL is
+  // accepted for this narrow case. Every later fault still requires a native
+  // persistent-write event.
+  return platform === "darwin" && className === "lock" && lockValidated === true;
+}
+
 export function faultFixtureProfile(className, backupSkillIds) {
   const replace = className === "backup";
   const requiresBoundaryWindow = className === "write" || className === "rename" || replace;
@@ -506,6 +516,8 @@ async function faultCase(context, className) {
       targetRoot: fixture.targetRoot,
       skillId: observedSkillId,
       className,
+      expectedPlanDigest: fixture.plan.digest,
+      expectedTargetIdentityDigest: fixture.plan.payload.target.identityDigest,
       timeoutMs: 120_000,
     }),
     timeoutMs: 130_000,
@@ -535,7 +547,8 @@ async function faultCase(context, className) {
   // child-process event from their process-tree observers.
   const childLineageObserved = nativeLineage.childObserved;
   assert(driverValue?.observed && driverValue.recoveryLockPresent === true && driverValue.laterBoundaries.length === 0
-      && observed.observation.writeAttempts > 0 && childLineageObserved && lineageVerified && walBoundaryValid,
+      && nativeMutationEvidenceSatisfied(process.platform, className, observed.observation.writeAttempts, driverValue?.observed?.lockValidated)
+      && childLineageObserved && lineageVerified && walBoundaryValid,
     "AAS_TRANSACTION_CONTROLLER_NATIVE_OBSERVATION_MISSING", {
       className,
       writeAttempts: observed.observation.writeAttempts,

--- a/verification/aas-v1/verifier/lib/transaction-fault-contract.mjs
+++ b/verification/aas-v1/verifier/lib/transaction-fault-contract.mjs
@@ -1,0 +1,32 @@
+import crypto from "node:crypto";
+
+export function isTransientTraversalError(error) {
+  return ["ENOENT", "ENOTDIR"].includes(error?.code);
+}
+
+export function expectedRecoveryId(planDigest, targetIdentityDigest) {
+  const value = crypto.createHash("sha256").update(`${planDigest}:${targetIdentityDigest}`).digest("hex");
+  return `recovery-${value.slice(0, 48)}`;
+}
+
+export function validateObservedLockRecord(record, expected) {
+  if (!record || typeof record !== "object" || Array.isArray(record)
+    || !expected || !Number.isSafeInteger(expected.pid) || expected.pid <= 0) return false;
+  const directories = record.plannedDirectories;
+  const recoveryId = expectedRecoveryId(expected.planDigest, expected.targetIdentityDigest);
+  const plannedDirectories = Array.isArray(expected.plannedDirectories) ? expected.plannedDirectories : [];
+  return record.schemaVersion === 1
+    && record.kind === "apply"
+    && record.pid === expected.pid
+    && /^[a-f0-9]{48}$/.test(record.token || "")
+    && record.planDigest === expected.planDigest
+    && record.targetIdentityDigest === expected.targetIdentityDigest
+    && record.recoveryId === recoveryId
+    && record.journalName === `.aas-transaction-${recoveryId}.wal`
+    && Array.isArray(directories)
+    && directories.every((value) => typeof value === "string"
+      && value.length > 0 && !value.includes("\\") && !value.startsWith("/")
+      && !value.split("/").includes(".."))
+    && new Set(directories).size === directories.length
+    && JSON.stringify(directories) === JSON.stringify(plannedDirectories);
+}

--- a/verification/aas-v1/verifier/tests/observer.test.mjs
+++ b/verification/aas-v1/verifier/tests/observer.test.mjs
@@ -53,9 +53,10 @@ test("macOS observer lifetime covers readiness, candidate, drain, and stop margi
     readinessMaxAttempts: 4,
     readinessProcessTimeoutMs: 10_000,
     readinessDelayMs: 500,
+    candidateHandshakeTimeoutMs: 8_000,
     drainMs: 1_000,
     traceMaxOutputBytes: 64 * 1024 * 1024,
-    observerTimeoutMs: 59_500,
+    observerTimeoutMs: 67_500,
   });
   assert.throws(() => macObserverBudgets(0), (error) => error.code === "AAS_OBSERVER_INVALID_TIMEOUT");
 });

--- a/verification/aas-v1/verifier/tests/transaction-evidence.test.mjs
+++ b/verification/aas-v1/verifier/tests/transaction-evidence.test.mjs
@@ -5,7 +5,8 @@ import path from "node:path";
 import test from "node:test";
 import { fileURLToPath } from "node:url";
 import { loadReceiptValidator } from "../lib/receipt.mjs";
-import { classifyConcurrencyOutcomes, corruptPrefixIsFailClosed, faultFixtureProfile, faultObservationSkillId, nativeObservationLineage, portableTreeDigest, raceFixtureProfile, selectBackupSkillIds, walBoundaryIsValid } from "../lib/transaction-controller.mjs";
+import { classifyConcurrencyOutcomes, corruptPrefixIsFailClosed, faultFixtureProfile, faultObservationSkillId, nativeMutationEvidenceSatisfied, nativeObservationLineage, portableTreeDigest, raceFixtureProfile, selectBackupSkillIds, walBoundaryIsValid } from "../lib/transaction-controller.mjs";
+import { expectedRecoveryId, isTransientTraversalError, validateObservedLockRecord } from "../lib/transaction-fault-contract.mjs";
 
 const here = path.dirname(fileURLToPath(import.meta.url));
 const validate = loadReceiptValidator(path.resolve(here, "..", "..", "schemas", "product-transaction-evidence.schema.json"));
@@ -150,6 +151,51 @@ test("native lineage accepts macOS executable binding without invented child eve
     observation: { childProcesses: 1 },
     diagnostics: { processTreeEmpty: true },
   }).verified, true);
+});
+
+test("only the externally validated lock boundary may omit a sampled native write", () => {
+  assert.equal(nativeMutationEvidenceSatisfied("darwin", "lock", 0, true), true);
+  assert.equal(nativeMutationEvidenceSatisfied("darwin", "lock", 0, false), false);
+  assert.equal(nativeMutationEvidenceSatisfied("linux", "lock", 0, true), false);
+  assert.equal(nativeMutationEvidenceSatisfied("win32", "lock", 0, true), false);
+  assert.equal(nativeMutationEvidenceSatisfied("darwin", "journal", 0, true), false);
+  assert.equal(nativeMutationEvidenceSatisfied("linux", "journal", 1, false), true);
+  assert.equal(nativeMutationEvidenceSatisfied("win32", "write", 10, true), true);
+});
+
+test("lock observation is bound to the exact child, plan, target, and journal", () => {
+  const expected = {
+    pid: 321,
+    planDigest: `sha256-${"b".repeat(64)}`,
+    targetIdentityDigest: `sha256-${"c".repeat(64)}`,
+  };
+  const recoveryId = expectedRecoveryId(expected.planDigest, expected.targetIdentityDigest);
+  const record = {
+    schemaVersion: 1,
+    kind: "apply",
+    pid: expected.pid,
+    token: "e".repeat(48),
+    planDigest: expected.planDigest,
+    targetIdentityDigest: expected.targetIdentityDigest,
+    recoveryId,
+    journalName: `.aas-transaction-${recoveryId}.wal`,
+    plannedDirectories: [],
+  };
+  assert.equal(validateObservedLockRecord(record, expected), true);
+  assert.equal(validateObservedLockRecord({ ...record, pid: 322 }, expected), false);
+  assert.equal(validateObservedLockRecord({ ...record, planDigest: digest }, expected), false);
+  assert.equal(validateObservedLockRecord({ ...record, targetIdentityDigest: digest }, expected), false);
+  assert.equal(validateObservedLockRecord({ ...record, journalName: ".aas-transaction-other.wal" }, expected), false);
+  assert.equal(validateObservedLockRecord({ ...record, recoveryId: `recovery-${"d".repeat(48)}` }, expected), false);
+  assert.equal(validateObservedLockRecord({ ...record, plannedDirectories: ["unrelated-but-safe"] }, expected), false);
+});
+
+test("transaction traversal ignores disappearance only", () => {
+  assert.equal(isTransientTraversalError({ code: "ENOENT" }), true);
+  assert.equal(isTransientTraversalError({ code: "ENOTDIR" }), true);
+  assert.equal(isTransientTraversalError({ code: "EACCES" }), false);
+  assert.equal(isTransientTraversalError({ code: "EIO" }), false);
+  assert.equal(isTransientTraversalError({ code: "EPERM" }), false);
 });
 
 test("write faults use a policy-safe corpus to expose the transient staging boundary", () => {


### PR DESCRIPTION
## Summary

- make the external transaction fault driver tolerate only genuine directory-disappearance races while preserving fail-closed handling for permission and I/O failures
- bind the macOS lock-boundary exception to the exact child PID, plan, target, recovery ID, journal, and empty pre-layout directory set
- prevent recovery from reporting success while any marker-owned layout, stage, tombstone, or dangling symlink remains

## Evidence

Two real workflow runs exposed independent nondeterminism:

- run 29625898040: Linux Node 24 left marker/stage artifacts after journal recovery; macOS Node 22 validated the lock on disk but `fs_usage` sampled zero writes at the first boundary
- run 29625418454: Windows Node 22/24 exited from the transaction driver before producing JSON while traversing a concurrently changing target tree

The lock exception remains macOS-only and applies only when the complete lock record is bound to the observed child and immutable plan/target identity. Every later fault, and lock faults on Linux/Windows, still require native write evidence.

## Validation

- independent review: approved, no P0/P1
- verifier tests: 49/49
- transaction tests: 23/23
- full repository test suite: pass
- `npm run validate`
- `npm run validate:references`
- `npm run security:docs`
- verifier freeze check: `sha256-148dc0768914c31973b1f43fd385046d2ba7323981f92a6cf15f952918b282ee`
- `git diff --check`

## Quality Bar Checklist

- [x] unmanaged bytes are never deleted by cleanup
- [x] dangling symlinks and non-empty stages keep recovery fail-closed
- [x] the same approved recovery plan completes after the obstacle is removed
- [x] Windows ignores only `ENOENT` and `ENOTDIR` traversal races
- [x] no publication, tag, release, npm, or Pages action performed
