### PR TITLE
fix: accept Codex MCP request metadata

### DIFF
--- a/tools/lib/aas-v1/mcp/server.js
+++ b/tools/lib/aas-v1/mcp/server.js
@@ -402,7 +402,10 @@ class McpServer {
     const { name, arguments: args = {} } = request.params;
     if (!TOOL_NAMES.includes(name)) return this.rpcError(request.id, -32602, "Unknown tool");
     try {
-      assertExactKeys(request.params, ["name", "arguments"]);
+      assertExactKeys(request.params, ["name", "arguments", "_meta"]);
+      if (request.params._meta !== undefined && !isPlainObject(request.params._meta)) {
+        inputError("AAS_MCP_META_INVALID");
+      }
       let payload;
       if (name === "search_skills") {
         assertExactKeys(args, ["query", "target", "limit"]);

--- a/tools/lib/aas-v1/mcp/strict-json.js
+++ b/tools/lib/aas-v1/mcp/strict-json.js
@@ -1,6 +1,6 @@
 "use strict";
 
-const MAX_LINE_BYTES = 4096;
+const MAX_LINE_BYTES = 256 * 1024;
 const MAX_JSON_DEPTH = 16;
 
 class StrictJsonError extends Error {

--- a/tools/scripts/tests/aas_v1_mcp.test.js
+++ b/tools/scripts/tests/aas_v1_mcp.test.js
@@ -39,6 +39,16 @@ async function initializedServer() {
 
 test("strict JSON-lines parser rejects invalid UTF-8, duplicate keys, excess depth, batches, and oversized input", () => {
   assert.deepEqual(parseStrictJsonLine(Buffer.from('{"jsonrpc":"2.0"}')), { jsonrpc: "2.0" });
+  assert.doesNotThrow(() => parseStrictJsonLine(Buffer.from(JSON.stringify({
+    jsonrpc: "2.0",
+    id: 1,
+    method: "tools/call",
+    params: {
+      name: "search_skills",
+      arguments: { query: "android ui", target: "codex", limit: 5 },
+      _meta: { "x-codex-turn-metadata": { workspaces: { remotes: "x".repeat(6 * 1024) } } },
+    },
+  }))));
   assert.throws(
     () => parseStrictJsonLine(Buffer.from('{"key":1,"key":2}')),
     { code: "AAS_MCP_JSON_DUPLICATE_KEY" },
@@ -106,7 +116,11 @@ test("search, get, resource read, recommendation, inspection, and unavailable ve
     jsonrpc: "2.0",
     id: 10,
     method: "tools/call",
-    params: { name: "search_skills", arguments: { query: "android ui", limit: 3 } },
+    params: {
+      name: "search_skills",
+      arguments: { query: "android ui", limit: 3 },
+      _meta: { progressToken: "codex-search-1" },
+    },
   });
   assert.equal(search.result.isError, false);
   assert.equal(search.result.structuredContent.ok, true);
@@ -280,7 +294,7 @@ test("production MCP modules have no network, process-spawn, or filesystem-write
   assert.match(source, /fs\.(?:readFileSync|readSync)\(/);
 });
 
-test("stdio counts the newline in the 4096-byte boundary and bounds its pending request queue", async () => {
+test("stdio counts the newline in the byte boundary and bounds its pending request queue", async () => {
   async function exercise(bytes, server) {
     const input = new PassThrough();
     const output = new PassThrough();
@@ -292,11 +306,12 @@ test("stdio counts the newline in the 4096-byte boundary and bounds its pending 
     return Buffer.concat(chunks).toString("utf8").trim().split("\n").filter(Boolean).map((line) => JSON.parse(line));
   }
 
-  const fixtureRoot = path.join(ROOT, "verification", "aas-v1", "baseline", "v1", "hostile", "fixtures", "input", "request-byte-limit");
   const acceptingServer = { handle: async (request) => ({ jsonrpc: "2.0", id: request.id ?? null, result: {} }) };
-  const boundary = await exercise(fs.readFileSync(path.join(fixtureRoot, "boundary-control.json")), acceptingServer);
+  const base = JSON.stringify({ jsonrpc: "2.0", id: 1, method: "ping", pad: "" });
+  const framed = (length) => Buffer.from(`${base.slice(0, -2)}${"x".repeat(length - Buffer.byteLength(base) - 1)}\"}\n`);
+  const boundary = await exercise(framed(MAX_LINE_BYTES), acceptingServer);
   assert.equal(boundary[0].result !== undefined, true);
-  const exploit = await exercise(fs.readFileSync(path.join(fixtureRoot, "exploit.json")), acceptingServer);
+  const exploit = await exercise(framed(MAX_LINE_BYTES + 1), acceptingServer);
   assert.equal(exploit[0].error.data.code, "AAS_MCP_LINE_TOO_LARGE");
 
   let release;


### PR DESCRIPTION
## Summary\n\n- accept the standard MCP tools/call _meta object emitted by real Codex clients\n- raise the strict JSON-lines frame limit to 256 KiB so bounded Codex turn metadata is not rejected\n- add regression coverage for a representative request larger than 6 KiB and for the configured byte boundary\n\n## Evidence\n\n- Real Codex 0.144.5 discovered and invoked AAS MCP tools over local stdio: search_skills, get_skill, recommend_stack, inspect_stack\n- Recommendation completed with agent-tool-builder and ai-agents-architect and no uncovered goals\n- Proposed aas-stack.json passed CLI validate and preview-only plan\n- node --test tools/scripts/tests/aas_v1_mcp.test.js: 9 passed\n- npm run validate: passed\n- npm run validate:references: passed\n- npm run security:docs: passed\n- npm run test: passed\n\n## Change Classification\n\n- [ ] Skill PR\n- [ ] Docs PR\n- [x] Infra PR\n\n## Issue Link (Optional)\n\nNone.\n\n## Quality Bar Checklist ✅\n\n- [x] Standards: I have read docs/contributors/quality-bar.md and docs/contributors/security-guardrails.md.\n- [x] Metadata: Not applicable; no SKILL.md changes.\n- [x] Risk Label: Not applicable; no skill content changes.\n- [x] Triggers: Not applicable; no skill content changes.\n- [x] Limitations: Not applicable; no skill content changes.\n- [x] Security: Not applicable; no offensive skill change.\n- [x] Safety scan: npm run security:docs passed.\n- [x] Automated Skill Review: Not applicable; no SKILL.md changes.\n- [x] Manual Logic Review: Runtime failure modes and fail-closed validation were reviewed.\n- [x] Local Test: Real-client E2E smoke and regression tests passed.\n- [x] Repo Checks: npm run validate:references passed.\n- [x] Source-Only PR: No generated registry artifacts are included.\n- [x] Credits: Not applicable; no external source content.\n- [x] License provenance: Not applicable; no imported skill content.\n- [x] Maintainer Edits: Same-repository maintainer branch.\n\n## Screenshots (if applicable)\n\nNot applicable.