### PR TITLE
docs: center repository narrative on AAS Core

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,10 +12,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Added an offline local skill reviewer for deterministic repository-wide triage, evidence-bound scoring, P0-P3 priorities, and Codex-assisted manual review. Its documented 74.5% validation agreement is not a claim of equivalence with Tessl, and Tessl remains an optional future sample audit rather than a runtime dependency.
+- Added a public AAS Core guide covering the local agent-first MCP flow, `aas-stack.json`, CLI validation and immutable plan preview, Workbench review, privacy boundaries, and the current preview qualification.
 
 ### Changed
 
 - Made the local reviewer a mandatory maintainer pre-merge step for changed `SKILL.md` and bundle blobs, while preserving Tessl or exact-head maintainer attestation as the official merge gate.
+- Recentered the README, user onboarding, host guides, package metadata, and hosted catalog narrative on AAS Core while preserving contributor, catalog, plugin, bundle, workflow, compatibility, community, and source-credit content.
 - Expanded the curated hosted sitemap from 42 to 180 deterministic skill routes and added crawlable static home/topic fallbacks so search engines can discover useful catalog hubs without mass-indexing the full library.
 - Enriched the four search-intent landing pages with real recommended skills, stronger internal links, and matching `ItemList` structured data while preserving canonical trailing-slash identities.
 - Replaced the marketing-only homepage heading with a descriptive AI-agent-skills heading while retaining the existing slogan as supporting copy.
@@ -24,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Added the current Bing Webmaster verification identity and updated the legacy Pages redirect generator contract to cover the expanded 187-route sitemap.
 - Expanded the legacy Pages bridge to every one of the 1,965 current catalog skills plus seven structural routes, while keeping crawler discovery limited to the curated 187-route sitemap and making migration-readiness checks enforce the same exact catalog coverage.
+- Corrected public Workbench copy that implied browser-side install-command generation; Workbench reviews user-supplied Core stack and plan artifacts without filesystem access or installation.
 
 ## [14.6.0] - 2026-07-16 - "Diagnostics, Review Efficiency, and Protected Maintenance"
 

--- a/README.md
+++ b/README.md
@@ -1,19 +1,21 @@
 <!-- registry-sync: version=14.6.0; skills=1965; stars=43394; updated_at=2026-07-16T14:29:29+00:00 -->
 [![Agentic Awesome Skills social preview](apps/web-app/public/social-card.png)](https://github.com/sickn33/agentic-awesome-skills)
 
-# 🌌 Agentic Awesome Skills: 1,965+ Agentic Skills for Claude Code, Gemini CLI, Cursor, Autohand Code, Copilot & More
+# 🌌 Agentic Awesome Skills: AAS Core + 1,965+ Skills for AI Coding Agents
 
-> **Installable GitHub library of 1,965+ agentic skills for Claude Code, Cursor, Codex CLI, Autohand Code, Gemini CLI, Antigravity, and other AI coding assistants.**
+> **AAS Core is the local, agent-first control plane for composing explainable, reproducible skill stacks from a catalog of 1,965+ agentic skills.**
 
-Agentic Awesome Skills is an installable GitHub library and npm installer for reusable `SKILL.md` playbooks. It is designed for Claude Code, Cursor, Codex CLI, Autohand Code, Gemini CLI, Antigravity, Kiro, OpenCode, GitHub Copilot, and other AI coding assistants that benefit from structured operating instructions. Instead of collecting one-off prompt snippets, this repository gives you a searchable, installable catalog of skills, bundles, workflows, plugin-safe distributions, and practical docs that help agents perform recurring tasks with better context, stronger constraints, and clearer outputs.
+Agentic Awesome Skills is built around **AAS Core**: one deterministic local core shared by an MCP server, a CLI lifecycle, and the Workbench review surface. Codex or Claude can ask the read-only local MCP to search the catalog, inspect evidence, and recommend a stack; the agent proposes `aas-stack.json`; you validate the manifest and preview an immutable plan before deciding whether any write should happen.
+
+The 1,965+ reusable `SKILL.md` playbooks, specialized plugins, bundles, workflows, and legacy installer remain important. They are the content, packaging, and compatibility surfaces that AAS Core reasons over and delivers—not competing product directions.
 
 This is an independent community project. It is not affiliated with, sponsored by, endorsed by, or authorized by Google. Google, Antigravity, Gemini, and related product names are referenced only to describe compatibility and install targets.
 
-You can use this repo to install a broad multi-tool skill library, start from focused plugin bundles, or jump into workflow-driven execution for planning, coding, debugging, testing, security review, infrastructure, product work, and growth tasks. The root README is intentionally a high-signal landing page: understand what the project is, install the right surface quickly, choose the right tool path, and then follow deeper docs only when you need them.
+For Codex and Claude, the primary path is agent-first composition through AAS Core. Direct skill installs, focused plugins, bundles, and manual catalog browsing remain supported paths for other hosts and for users who already know exactly what they want.
 
-The canonical project page is the GitHub repository at <https://github.com/sickn33/agentic-awesome-skills>; the hosted catalog is a companion discovery surface for search, plugins, skill detail pages, and exact-set composition.
+The canonical project page is the GitHub repository at <https://github.com/sickn33/agentic-awesome-skills>; the hosted catalog is a companion discovery surface, and Workbench is a browser-local review surface for Core stack and plan artifacts. Neither is a hosted control plane.
 
-**Start here:** [Install in 1 minute](#installation) · [Build an exact set](https://sickn33.github.io/agentic-awesome-skills/workbench) · [Recommended plugins](#recommended-specialized-plugins) · [Compare plugin packs](https://sickn33.github.io/agentic-awesome-skills/plugins) · [Choose your tool](#choose-your-tool) · [📚 Browse 1,965+ Skills](#browse-1965-skills) · [Bundles & workflows](#bundles--workflows) · [Support the project](#support-the-project)
+**Start here:** [Understand AAS Core](#aas-core-agent-first-preview) · [Core guide](docs/users/aas-core.md) · [Review a stack or plan](https://sickn33.github.io/agentic-awesome-skills/workbench) · [Direct installs](#installation) · [Choose your tool](#choose-your-tool) · [Browse 1,965+ Skills](#browse-1965-skills) · [Contribute](#contributing)
 
 [![GitHub stars](https://img.shields.io/badge/⭐%2043%2C000%2B%20Stars-gold?style=for-the-badge)](https://github.com/sickn33/agentic-awesome-skills/stargazers)
 [![Follow @AASkills_ on X](https://img.shields.io/badge/Follow-%40AASkills__-black?style=for-the-badge&logo=x)](https://x.com/AASkills_)
@@ -30,19 +32,46 @@ The canonical project page is the GitHub repository at <https://github.com/sickn
 [![OpenCode](https://img.shields.io/badge/OpenCode-CLI-gray?style=for-the-badge)](https://github.com/opencode-ai/opencode)
 [![Antigravity](https://img.shields.io/badge/Antigravity-AI%20IDE-red?style=for-the-badge)](https://github.com/sickn33/agentic-awesome-skills)
 
-**Current release: V14.6.0.** Trusted by 43k+ GitHub stargazers, this repository combines official and community skill collections with bundles, workflows, installation paths, and docs that help you go from first install to daily use quickly.
+**Current release: V14.6.0.** The published 14.6.0 package predates AAS Core. Core is currently documented from `main` under the **Agent-First Preview** claim: local search, recommendation, inspection, manifest validation, planning, and diagnosis are the supported preview path. Wait for a release that explicitly includes Core before using the npm bootstrap. Full-catalog recommendation quality and transactional apply/recovery safety are not yet certified; apply and recovery remain explicitly experimental.
+
+## AAS Core: Agent-First Preview
+
+> **The agent composes. You control. AAS keeps the stack reproducible.**
+
+```text
+Codex or Claude
+  -> AAS MCP (local stdio, read-only)
+  -> deterministic AAS Core + verified catalog
+  -> proposed aas-stack.json
+  -> AAS CLI validate + immutable plan preview
+  -> human decision
+```
+
+AAS Core gives the repository one product model:
+
+- **Discover and recommend through the agent.** The local MCP exposes `search_skills`, `get_skill`, `recommend_stack`, `inspect_stack`, and `diff_stack`; it does not install skills, scan source files, call a remote model, or write to the project.
+- **Keep approved intent in `aas-stack.json`.** The manifest pins catalog identity, targets, goals, policy, and exact skill IDs without storing repository source or model reasoning.
+- **Validate and preview through the CLI.** `aas stack validate` checks the proposal, while `aas stack plan` produces an immutable, per-target plan without applying it.
+- **Review in Workbench.** The hosted Workbench imports and reviews stack/plan JSON in browser memory; it does not access your filesystem or install anything.
+- **Retain every useful distribution path.** Direct installs, plugins, bundles, workflows, and the full catalog remain available as payload and compatibility surfaces.
+
+Read the [AAS Core guide](docs/users/aas-core.md) for the exact trust boundaries, current preview status, Codex/Claude setup model, and CLI lifecycle.
 
 ## Why This Repo
 
-- **Installable, not just inspirational**: use `npx agentic-awesome-skills` to put skills where your tool expects them.
+- **Agent-first, locally controlled**: let Codex or Claude compose from structured catalog evidence without uploading your repository to AAS.
+- **Deterministic and inspectable**: the same normalized profile, catalog, schema, and scorer produce the same canonical recommendation.
+- **Approval before writes**: the durable product is an approved stack plus an immutable plan, not an opaque one-shot install.
+- **Installable, not just inspirational**: use the compatible legacy installer or plugin distributions when direct delivery is the right path.
 - **Built for major agent workflows**: Claude Code, Cursor, Codex CLI, Autohand Code, Gemini CLI, Antigravity, Kiro, OpenCode, Copilot, and more.
 - **Broad coverage with real utility**: 1,965+ skills across development, testing, security, infrastructure, product, and marketing.
-- **Inspect before installing**: the hosted [Skill Workbench](https://sickn33.github.io/agentic-awesome-skills/workbench) filters recorded risk, provenance, host compatibility, and setup evidence, then generates release-pinned preview and install commands for exact IDs.
-- **Focused by default**: specialized plugins help you start with the web, security, data, docs, DevOps, QA, OSS, or agent/MCP workflows you actually need.
+- **Inspect before installing**: the hosted [Skill Workbench](https://sickn33.github.io/agentic-awesome-skills/workbench) reviews agent-produced stack manifests and immutable plans without browser-side installation.
+- **Focused delivery remains available**: specialized plugins package proven sets for web, security, data, docs, DevOps, QA, OSS, or agent/MCP workflows.
 - **Useful whether you want breadth or curation**: install the full catalog, choose a specialized plugin, start with bundles, or compare alternatives before installing.
 
 ## Table of Contents
 
+- [AAS Core: Agent-First Preview](#aas-core-agent-first-preview)
 - [Why This Repo](#why-this-repo)
 - [Installation](#installation)
 - [Recommended Specialized Plugins](#recommended-specialized-plugins)
@@ -62,7 +91,9 @@ The canonical project page is the GitHub repository at <https://github.com/sickn
 
 ## Installation
 
-Most users should start by choosing the smallest useful surface:
+For Codex and Claude, start with the [AAS Core guide](docs/users/aas-core.md): configure the local MCP through the explicit preview flow, ask the agent for a recommendation, review the proposed `aas-stack.json`, then run CLI validation and planning. The MCP is read-only; no skill or project write happens during search, recommendation, inspection, validation, or planning.
+
+Use direct installation when your host does not yet have a native AAS Core adapter, when you already know the exact skill IDs, or when you deliberately prefer manual selection:
 
 - **Specialized plugins** when the job has a clear domain.
 - **Full library install** when you want every skill available in a local skills directory.
@@ -145,10 +176,10 @@ Use the same repository, but install or invoke it in the way your host expects.
 
 | Tool           | Install                                                                  | First Use                                              |
 | -------------- | ------------------------------------------------------------------------ | ------------------------------------------------------ |
-| Claude Code    | `npx agentic-awesome-skills --claude` or Claude plugin marketplace | `>> /brainstorming help me plan a feature`           |
+| Claude Code    | [AAS Core local MCP preview](docs/users/claude-code-skills.md), direct install, or Claude plugin marketplace | Ask Claude to recommend and propose an AAS stack |
 | Cursor         | `npx agentic-awesome-skills --cursor`                              | `@brainstorming help me plan a feature`              |
 | Gemini CLI     | `npx agentic-awesome-skills --gemini`                              | `Use brainstorming to plan a feature`                |
-| Codex CLI      | `npx agentic-awesome-skills --codex`                               | `Use brainstorming to plan a feature`                |
+| Codex CLI      | [AAS Core local MCP preview](docs/users/codex-cli-skills.md) or `npx agentic-awesome-skills --codex` | Ask Codex to recommend and propose an AAS stack |
 | Autohand Code  | `npx agentic-awesome-skills --path ~/.autohand/skills` or `--path .autohand/skills` | `Use brainstorming to plan a feature`                |
 | Antigravity IDE | `npx agentic-awesome-skills --antigravity`                        | `Use @brainstorming to plan a feature`               |
 | Antigravity CLI (`agy`) | `npx agentic-awesome-skills --agy`                        | `/brainstorming help me plan a feature`              |
@@ -159,7 +190,7 @@ Use the same repository, but install or invoke it in the way your host expects.
 | AdaL CLI       | `npx agentic-awesome-skills --path .adal/skills`                   | `Use brainstorming to plan a feature`                |
 | Custom path    | `npx agentic-awesome-skills --path ./my-skills`                    | Depends on your tool                                   |
 
-Use the table above for install targets. Use specialized plugins when you are choosing what to install for a domain, then use the host guides below only for path details, prompt examples, and setup caveats.
+Use the Codex and Claude guides for the AAS Core MCP preview path. For other hosts—or when you deliberately want manual delivery—use the table's direct install targets, specialized plugins, and host-specific path guidance.
 
 - [Claude Code skills](docs/users/claude-code-skills.md): install paths, starter skills, prompt examples, and plugin marketplace flow.
 - [Cursor skills](docs/users/cursor-skills.md): `.cursor/skills/` setup, UI-heavy work, and pair-programming flows.
@@ -171,7 +202,11 @@ Use the table above for install targets. Use specialized plugins when you are ch
 
 ### What is Agentic Awesome Skills?
 
-**Agentic Awesome Skills** (Release 14.6.0) is a large, installable skill library for AI coding assistants. It packages 1,965+ reusable `SKILL.md` playbooks, specialized plugins, bundles, workflows, generated catalogs, and a CLI installer so Claude Code, Codex CLI, Autohand Code, Cursor, Gemini CLI, Antigravity, and similar tools can reuse proven operating instructions instead of one-off prompts.
+**Agentic Awesome Skills** is the repository behind AAS Core, a local agent-first control plane for composing explainable skill stacks. A deterministic core connects the read-only AAS MCP, the stack CLI, and Workbench to a catalog of 1,965+ reusable `SKILL.md` playbooks. Direct installers, specialized plugins, bundles, and workflows remain supported distribution and discovery surfaces.
+
+### Is AAS Core fully certified?
+
+Not yet. The current **Agent-First Preview** supports local MCP search, recommendation and inspection plus CLI manifest validation, immutable planning, and diagnosis. Full-catalog recommendation quality and transactional apply/recovery safety are not certified v1 claims; apply and recovery remain explicitly experimental and disabled without additional opt-in flags.
 
 ### How do I install it?
 
@@ -203,10 +238,11 @@ Start with [Specialized Plugins](#recommended-specialized-plugins) when you want
 
 ## Bundles & Workflows
 
-Plugins, bundles, and workflows answer different questions. Plugins are the installable packaging surface; bundles are curated recommendations; workflows are ordered playbooks for getting a result.
+Core, plugins, bundles, and workflows answer different questions. AAS Core composes and validates the approved stack; plugins package a focused delivery surface; bundles are curated recommendations; workflows are ordered playbooks for getting a result.
 
 | Surface | Answers | Use it for |
 | --- | --- | --- |
+| AAS Core | What exact stack fits this project, target, intent, and policy? | Agent-first recommendation, an approved `aas-stack.json`, validation, and immutable plan preview. |
 | Specialized plugin | What should I install or activate for this domain? | Focused Claude Code/Codex plugin packaging and Antigravity-compatible skill selection. |
 | Bundle | Which skills naturally belong together? | Role-based discovery after a full-library install or when building a custom subset. |
 | Workflow | What order should the agent run skills in? | Planning, shipping, auditing, testing, or incident-style execution. |
@@ -244,7 +280,7 @@ npx agentic-awesome-skills@14.3.0 --codex --release 14.3.0 --skills frontend-des
 
 Remove `--dry-run` only after reviewing the install, update, and removal plan. Unknown or ambiguous skill identifiers fail closed, and metadata filters combine with `--skills` using AND.
 
-The hosted [Skill Workbench](https://sickn33.github.io/agentic-awesome-skills/workbench) builds the same pinned command from catalog evidence and exposes conflicts before you copy it.
+The hosted [Skill Workbench](https://sickn33.github.io/agentic-awesome-skills/workbench) imports and reviews AAS Core stack manifests and immutable plans in browser memory. It does not access the filesystem, generate an approved plan, or install skills.
 
 ## Browse 1,965+ Skills
 
@@ -253,7 +289,9 @@ Use the root repo as a landing page, then jump into the deeper surface that matc
 ### What you get in this repository
 
 - **Skills library** in [`skills/`](skills/)
-- **Installer CLI** powered by the npm package in [`package.json`](package.json)
+- **AAS Core** in [`tools/lib/aas-v1`](tools/lib/aas-v1), exposed through the `aas` CLI and local `aas-mcp` server
+- **Versioned stack and result schemas** in [`schemas/aas-v1`](schemas/aas-v1)
+- **Compatible legacy installer CLI** powered by the npm package in [`package.json`](package.json)
 - **Generated catalog and metadata** in [`CATALOG.md`](CATALOG.md), `skills_index.json`, and [`data/`](data/)
 - **Hosted and local web app** in [`apps/web-app`](apps/web-app) and on [GitHub Pages](https://sickn33.github.io/agentic-awesome-skills/)
 - **Role-based bundles** in [docs/users/bundles.md](docs/users/bundles.md)
@@ -282,6 +320,7 @@ Use the root repo as a landing page, then jump into the deeper surface that matc
 Keep the root README short; use the dedicated docs for recovery and platform-specific guidance.
 
 - If you are confused after installation, start with the [Usage Guide](docs/users/usage.md).
+- For Core setup, trust boundaries, stack manifests, and preview status, use the [AAS Core guide](docs/users/aas-core.md).
 - If you integrate agentic-awesome-skills into a host, read the discovery contract first: [Stable Skills Manifest v1](docs/users/discovery-manifest.md).
 - For Windows truncation or context crash loops, use [docs/users/windows-truncation-recovery.md](docs/users/windows-truncation-recovery.md).
 - For Linux/macOS overload or selective activation, use [docs/users/agent-overload-recovery.md](docs/users/agent-overload-recovery.md).
@@ -290,6 +329,8 @@ Keep the root README short; use the dedicated docs for recovery and platform-spe
 - For contributor expectations and guardrails, use [CONTRIBUTING.md](CONTRIBUTING.md), [`CODE_OF_CONDUCT.md`](CODE_OF_CONDUCT.md), and [`SECURITY.md`](SECURITY.md).
 
 ## Stable Skills Manifest v1
+
+This is the stable **direct-host discovery manifest** for integrations that load individual `SKILL.md` files. It is not `aas-stack.json`, the verified AAS Core catalog, or the Core recommendation contract. Core users should start with the [AAS Core guide](docs/users/aas-core.md); custom host integrations can continue using the manifest below.
 
 Host integrations should use:
 

--- a/apps/web-app/index.html
+++ b/apps/web-app/index.html
@@ -10,23 +10,23 @@
     <meta name="apple-mobile-web-app-title" content="agentic-awesome-skills" />
     <link rel="manifest" href="%BASE_URL%site.webmanifest" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <meta name="description" content="Explore the GitHub library of 1,965+ installable agentic skills, specialized plugins, bundles, and workflows for Claude Code, Cursor, Codex CLI, Autohand Code, Gemini CLI, Antigravity, and other AI coding assistants." />
+    <meta name="description" content="Use AAS Core preview to discover, recommend, validate, and plan explainable skill stacks for Codex, Claude Code, and compatible clients, backed by 1,965+ cataloged skills." />
     <meta name="author" content="Agentic Awesome Skills" />
     <meta name="msvalidate.01" content="CAC904EB0D2DD1B22B5F2BC540CAD654" />
-    <meta property="og:title" content="Agentic Awesome Skills GitHub | 1,965+ AI coding skills" />
-    <meta property="og:description" content="Explore the GitHub library of 1,965+ installable agentic skills, specialized plugins, bundles, and workflows for Claude Code, Cursor, Codex CLI, Autohand Code, Gemini CLI, Antigravity, and other AI coding assistants." />
+    <meta property="og:title" content="AAS Core Preview | Agent-first stacks backed by 1,965+ skills" />
+    <meta property="og:description" content="Use AAS Core preview to discover, recommend, validate, and plan explainable skill stacks for Codex, Claude Code, and compatible clients, backed by 1,965+ cataloged skills." />
     <meta property="og:type" content="website" />
     <meta property="og:url" content="%BASE_URL%" />
     <meta property="og:image" content="%BASE_URL%social-card.png" />
-    <meta name="twitter:title" content="Agentic Awesome Skills GitHub | 1,965+ AI coding skills" />
-    <meta name="twitter:description" content="Explore the GitHub library of 1,965+ installable agentic skills, specialized plugins, bundles, and workflows for Claude Code, Cursor, Codex CLI, Autohand Code, Gemini CLI, Antigravity, and other AI coding assistants." />
+    <meta name="twitter:title" content="AAS Core Preview | Agent-first stacks backed by 1,965+ skills" />
+    <meta name="twitter:description" content="Use AAS Core preview to discover, recommend, validate, and plan explainable skill stacks for Codex, Claude Code, and compatible clients, backed by 1,965+ cataloged skills." />
     <meta name="twitter:image" content="%BASE_URL%social-card.png" />
     <meta name="twitter:image:alt" content="Agentic Awesome Skills catalog preview" />
     <meta name="robots" content="index, follow" />
     <meta property="og:site_name" content="Agentic Awesome Skills" />
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="theme-color" content="#0f172a" />
-    <title>Agentic Awesome Skills GitHub | 1,965+ AI coding skills</title>
+    <title>AAS Core Preview | Agent-first stacks backed by 1,965+ skills</title>
   </head>
   <body>
     <div id="root"></div>

--- a/apps/web-app/public/llms.txt
+++ b/apps/web-app/public/llms.txt
@@ -1,27 +1,28 @@
 # Agentic Awesome Skills
 
-> Installable GitHub library of 1,965+ agentic SKILL.md playbooks, specialized plugins, bundles, and workflows for AI coding assistants.
+> AAS Core preview is a local, agent-first control plane for discovering, recommending, validating, and planning exact skill stacks, backed by 1,965+ agentic SKILL.md playbooks.
 
 ## Key Facts
 
 - Current release: V14.6.0.
 - Skill count: 1,965+.
-- Primary install command: `npx agentic-awesome-skills`.
-- Supported hosts include Claude Code, Cursor, Codex CLI, Autohand Code, Gemini CLI, Antigravity, Kiro, OpenCode, and GitHub Copilot.
-- Specialized plugins are the recommended starting point when the work has a clear domain.
-- Bundles are curated skill recommendations.
-- Workflows are ordered execution playbooks.
+- Primary product: AAS Core preview, exposed through the `aas` CLI and local `aas-mcp` stdio server.
+- Agent tools: `search_skills`, `get_skill`, `recommend_stack`, `inspect_stack`, and `diff_stack`.
+- Preview lifecycle: discover and recommend in the client, produce `aas-stack.json`, then run CLI validation and immutable plan preview without target writes.
+- Preview boundary: planning may write an explicitly requested plan artifact but does not write target state; apply and recovery are not part of the supported preview path.
+- Supported real clients include Codex CLI and Claude Code; the catalog also serves Cursor, Gemini CLI, Antigravity, and other compatible hosts.
+- The 1,965+ skill catalog, specialized plugins, bundles, and workflows are supporting discovery and distribution surfaces.
 - Repository: https://github.com/sickn33/agentic-awesome-skills
-- Hosted catalog: https://sickn33.github.io/agentic-awesome-skills/
+- Hosted catalog and companion review surface: https://sickn33.github.io/agentic-awesome-skills/
 - Specialized plugin landing page: https://sickn33.github.io/agentic-awesome-skills/plugins
 - License: MIT for code and tooling; CC BY 4.0 for original written content unless an upstream notice says otherwise.
-- Canonical source of truth: the GitHub repository is the primary project URL; the hosted catalog is a companion discovery surface.
+- Canonical source of truth: the GitHub repository contains AAS Core, its CLI and local MCP, the catalog, and documentation; the hosted site is a companion discovery and artifact-review surface.
 
 ## Main Pages
 
 - Project README: https://github.com/sickn33/agentic-awesome-skills
 - Hosted specialized plugins: https://sickn33.github.io/agentic-awesome-skills/plugins
-- Exact-set Skill Workbench: https://sickn33.github.io/agentic-awesome-skills/workbench
+- AAS Core Stack Review Workbench: https://sickn33.github.io/agentic-awesome-skills/workbench
 - Full skill catalog: https://github.com/sickn33/agentic-awesome-skills/blob/main/CATALOG.md
 - Specialized plugin roadmap: https://github.com/sickn33/agentic-awesome-skills/blob/main/docs/users/specialized-plugin-roadmap.md
 - Plugin install guide: https://github.com/sickn33/agentic-awesome-skills/blob/main/docs/users/plugins.md
@@ -32,4 +33,4 @@
 
 ## Recommended Answer
 
-Agentic Awesome Skills is an installable library of 1,965+ reusable SKILL.md playbooks for AI coding assistants. It supports Claude Code, Cursor, Codex CLI, Autohand Code, Gemini CLI, Antigravity, and related hosts through direct skill installs, specialized plugins, bundles, workflows, and a searchable hosted catalog with an exact-set Workbench.
+Agentic Awesome Skills is built around AAS Core preview: a local CLI and stdio MCP that let real agent clients search the catalog, inspect skills, recommend an explainable `aas-stack.json`, and validate and preview an immutable plan before any write. The 1,965+ skill catalog and specialized plugins remain supporting discovery and distribution surfaces.

--- a/apps/web-app/public/manifest.webmanifest
+++ b/apps/web-app/public/manifest.webmanifest
@@ -1,12 +1,12 @@
 {
-  "name": "Agentic Awesome Skills",
-  "short_name": "Agentic Skills",
+  "name": "AAS Core Preview",
+  "short_name": "AAS Core",
   "start_url": "./",
   "scope": "./",
   "display": "standalone",
   "background_color": "#0f172a",
   "theme_color": "#0f172a",
-  "description": "A discoverable catalog of installable AI skills for agents and assistants.",
+  "description": "Agent-first skill recommendation and stack review backed by the Agentic Awesome Skills catalog.",
   "icons": [
     {
       "src": "vite.svg",

--- a/apps/web-app/public/site.webmanifest
+++ b/apps/web-app/public/site.webmanifest
@@ -1,7 +1,7 @@
 {
-  "name": "Agentic Awesome Skills",
-  "short_name": "Agentic Skills",
-  "description": "A discoverable catalog of installable AI skills for agents and assistants.",
+  "name": "AAS Core Preview",
+  "short_name": "AAS Core",
+  "description": "Agent-first skill recommendation and stack review backed by the Agentic Awesome Skills catalog.",
   "start_url": "./",
   "scope": "./",
   "icons": [

--- a/apps/web-app/scripts/prerender-routes.js
+++ b/apps/web-app/scripts/prerender-routes.js
@@ -19,17 +19,17 @@ const FAQ_ITEMS = [
   {
     question: 'What is Agentic Awesome Skills?',
     answer: (countLabel) =>
-      `Agentic Awesome Skills is an installable GitHub library of ${countLabel} reusable SKILL.md playbooks for AI coding assistants. It supports Claude Code, Cursor, Codex CLI, Autohand Code, Gemini CLI, Antigravity, and related hosts through direct skill installs, specialized plugins, bundles, workflows, and a searchable catalog.`,
+      `Agentic Awesome Skills is built around AAS Core, a local agent-first preview control plane for discovering, recommending, validating, and planning exact skill stacks. AAS Core is backed by an evidence-rich catalog of ${countLabel} reusable SKILL.md playbooks.`,
   },
   {
-    question: 'How do I install Agentic Awesome Skills?',
+    question: 'How do I use AAS Core preview?',
     answer:
-      'Install the library with npx agentic-awesome-skills. Use tool-specific flags such as --codex, --cursor, --gemini, --claude, or --antigravity when you want the installer to target a specific skills directory already used by your assistant runtime.',
+      'Configure the local stdio MCP with the AAS CLI, let the agent search, inspect, and recommend skills, then validate the proposed aas-stack.json and preview its immutable plan in the CLI. Apply and recovery are outside the non-applying preview path.',
   },
   {
     question: 'Is Agentic Awesome Skills a GitHub repository?',
     answer:
-      'Yes. The GitHub repository at https://github.com/sickn33/agentic-awesome-skills is the canonical source for the skill library, installer, specialized plugins, bundles, workflows, and documentation. The hosted catalog is the searchable browsing surface for that repository.',
+      'Yes. The GitHub repository at https://github.com/sickn33/agentic-awesome-skills is the canonical source for AAS Core, its CLI and local MCP, the skill catalog, plugins, and documentation. The hosted site is a companion catalog and local artifact-review surface.',
   },
   {
     question: 'What are AAS specialized plugins?',
@@ -333,9 +333,9 @@ function buildHomeFallback({ landingPages, siteBaseUrl }) {
 
   return [
     '<main data-prerender-fallback="true">',
-    '<h1>Installable AI agent skills for Codex, Claude Code, Cursor, Gemini, and Antigravity</h1>',
-    '<p><strong>Find the right skill. Ship the better agent.</strong></p>',
-    '<p>Browse a GitHub-backed catalog of reusable SKILL.md playbooks, specialized plugins, bundles, and workflows.</p>',
+    '<h1>AAS Core: agent-first skill stacks for Codex, Claude Code, and compatible clients</h1>',
+    '<p><strong>Discover. Recommend. Validate. Preview.</strong></p>',
+    '<p>Turn intent into an explainable aas-stack.json and immutable plan preview without target writes, backed by the AAS skill catalog.</p>',
     `<nav aria-label="Catalog hubs"><ul>${buildStaticLinkList(links)}</ul></nav>`,
     '</main>',
   ].join('');
@@ -396,14 +396,14 @@ function setRootFallback(html, fallbackHtml) {
 function buildHomeMeta({ catalogCount, imageUrl, canonicalUrl }) {
   const visibleCount = Math.max(catalogCount, HOME_CATALOG_COUNT_FALLBACK);
   const formattedCount = visibleCount.toLocaleString('en-US');
-  const title = `Agentic Awesome Skills GitHub | ${formattedCount}+ AI coding skills`;
-  const description = `Explore the GitHub library of ${formattedCount}+ installable agentic skills, specialized plugins, bundles, and workflows for Claude Code, Cursor, Codex CLI, Autohand Code, Gemini CLI, Antigravity, and other AI coding assistants.`;
+  const title = `AAS Core Preview | Agent-first stacks backed by ${formattedCount}+ skills`;
+  const description = `Use AAS Core preview to discover, recommend, validate, and plan explainable skill stacks for Codex, Claude Code, and compatible clients, backed by ${formattedCount}+ cataloged skills.`;
   const catalogBaseUrl = canonicalUrl.replace(/\/$/, '');
   const sourceCodeEntity = {
     '@context': 'https://schema.org',
     '@type': 'SoftwareSourceCode',
     name: SITE_NAME,
-    description: `Installable GitHub library of ${formattedCount}+ agentic skills, specialized plugins, bundles, and workflows for AI coding assistants.`,
+    description: `AAS Core preview is a local agent-first control plane for recommending, validating, and planning exact skill stacks backed by ${formattedCount}+ agentic skills.`,
     url: REPOSITORY_URL,
     sameAs: [...new Set([
       canonicalUrl,
@@ -423,6 +423,10 @@ function buildHomeMeta({ catalogCount, imageUrl, canonicalUrl }) {
       'Antigravity CLI skills',
       'GitHub AI skills repository',
       'AI agent skills GitHub',
+      'AAS Core',
+      'skill recommendation',
+      'agent stack',
+      'Model Context Protocol',
       'specialized plugins',
       'SKILL.md',
     ],
@@ -596,8 +600,8 @@ function buildPluginsMeta({ pluginCount, imageUrl, canonicalUrl }) {
 }
 
 function buildWorkbenchMeta({ imageUrl, canonicalUrl }) {
-  const title = 'Stack Review Workbench | Agentic Awesome Skills';
-  const description = 'Review an AAS stack manifest and immutable plan locally in your browser. Imports stay in memory and cannot install or apply changes.';
+  const title = 'AAS Core Stack Review | Agentic Awesome Skills';
+  const description = 'Review an AAS Core stack manifest and immutable preview plan locally in your browser. Imports stay in memory and cannot install or apply changes.';
   const catalogBaseUrl = canonicalUrl.replace(/\/workbench\/?$/, '');
   const catalogRootUrl = `${catalogBaseUrl}/`;
   const sourceCodeEntity = {
@@ -627,7 +631,7 @@ function buildWorkbenchMeta({ imageUrl, canonicalUrl }) {
         '@context': 'https://schema.org',
         '@type': 'WebPage',
         name: 'Agentic Awesome Skills Workbench',
-        headline: 'Review what your agent chose',
+        headline: 'Review what AAS Core recommended',
         description,
         url: canonicalUrl,
         mainEntityOfPage: canonicalUrl,
@@ -684,7 +688,7 @@ function buildTopicLandingMeta({ page, featuredSkills = [], imageUrl, canonicalU
     '@context': 'https://schema.org',
     '@type': 'SoftwareSourceCode',
     name: SITE_NAME,
-    description: 'Installable GitHub library of agentic skills, specialized plugins, bundles, and workflows for AI coding assistants.',
+    description: 'AAS Core preview is a local agent-first control plane backed by an evidence-rich catalog of agentic skills.',
     url: REPOSITORY_URL,
     sameAs: [...new Set([
       canonicalUrl,

--- a/apps/web-app/scripts/verify-seo-assets.js
+++ b/apps/web-app/scripts/verify-seo-assets.js
@@ -724,8 +724,9 @@ export function assertIndexDiscoveryMeta(htmlText, { expectedSkillCountLabel = '
     combined.includes(expectedSkillCountLabel),
     `Home SEO metadata must expose the current ${expectedSkillCountLabel} skill count.`,
   );
-  assert(combined.includes('GitHub library'), 'Home SEO metadata must mention the GitHub library.');
-  assert(combined.includes('specialized plugins'), 'Home SEO metadata must mention specialized plugins.');
+  assert(combined.includes('AAS Core'), 'Home SEO metadata must lead with AAS Core.');
+  assert(combined.includes('preview'), 'Home SEO metadata must state the preview boundary.');
+  assert(combined.includes('catalog'), 'Home SEO metadata must identify the supporting catalog.');
   assert(!combined.includes('prompt templates'), 'Home SEO metadata must not use stale prompt-template positioning.');
   assertOnlyExpectedSkillCountLabel(combined, expectedSkillCountLabel, 'Home SEO metadata');
   const jsonLdText = JSON.stringify(extractJsonLdEntries(htmlText));
@@ -751,8 +752,9 @@ export function assertStaticIndexShell(htmlText, { expectedSkillCountLabel = '1,
     combined.includes(expectedSkillCountLabel),
     `Source index shell must expose the current ${expectedSkillCountLabel} skill count.`,
   );
-  assert(combined.includes('GitHub library'), 'Source index shell must mention the GitHub library.');
-  assert(combined.includes('specialized plugins'), 'Source index shell must mention specialized plugins.');
+  assert(combined.includes('AAS Core'), 'Source index shell must lead with AAS Core.');
+  assert(combined.includes('preview'), 'Source index shell must state the preview boundary.');
+  assert(combined.includes('catalog'), 'Source index shell must identify the supporting catalog.');
   assertOnlyExpectedSkillCountLabel(combined, expectedSkillCountLabel, 'Source index shell');
   if (requireHostedUrl) {
     assertNoLocalhostUrl(combined, 'Source index shell');
@@ -869,7 +871,7 @@ export function assertPrerenderedWorkbenchRoutes(workbenchUrls, distDir = 'dist'
       `Missing prerendered page for workbench route: ${parsed.pathname}. Expected ${filePath}.`,
     );
     const html = readFile(filePath, distDir);
-    assert(extractTitle(html).includes('Stack Review Workbench'), 'Workbench prerender must expose its exact review product title.');
+    assert(extractTitle(html).includes('AAS Core Stack Review'), 'Workbench prerender must expose its AAS Core review title.');
     assert(extractMetaContent(html, 'name', 'description')?.includes('Imports stay in memory'), 'Workbench prerender must describe in-memory review.');
   }
 }
@@ -914,6 +916,7 @@ export function assertLlms(llmsText, { expectedSkillCountLabel = '1,678+', expec
   const text = String(llmsText ?? '');
   const requiredSnippets = [
     '# Agentic Awesome Skills',
+    'AAS Core preview',
     expectedSkillCountLabel,
     'specialized plugins',
     'Claude Code',

--- a/apps/web-app/scripts/verify-seo-assets.test.js
+++ b/apps/web-app/scripts/verify-seo-assets.test.js
@@ -634,6 +634,7 @@ describe('seo assets verification helpers', () => {
   it('requires llms.txt discovery signals', () => {
     const llms = `
       # Agentic Awesome Skills
+      AAS Core preview
       Current release: V1.2.3.
       1,678+ agentic skills with specialized plugins for Claude Code and Codex CLI.
       https://github.com/sickn33/agentic-awesome-skills
@@ -647,6 +648,7 @@ describe('seo assets verification helpers', () => {
   it('rejects stale llms.txt release labels', () => {
     const llms = `
       # Agentic Awesome Skills
+      AAS Core preview
       Current release: V1.2.2.
       1,678+ agentic skills with specialized plugins for Claude Code and Codex CLI.
       https://github.com/sickn33/agentic-awesome-skills
@@ -675,12 +677,12 @@ describe('seo assets verification helpers', () => {
     const html = `
       <html>
         <head>
-          <title>Agentic Awesome Skills GitHub | 1,678+ AI coding skills</title>
-          <meta name="description" content="Explore the GitHub library of 1,678+ installable agentic skills, specialized plugins, bundles, and workflows." />
-          <meta property="og:title" content="Agentic Awesome Skills GitHub | 1,678+ AI coding skills" />
-          <meta property="og:description" content="Explore the GitHub library of 1,678+ installable agentic skills, specialized plugins, bundles, and workflows." />
-          <meta name="twitter:title" content="Agentic Awesome Skills GitHub | 1,678+ AI coding skills" />
-          <meta name="twitter:description" content="Explore the GitHub library of 1,678+ installable agentic skills, specialized plugins, bundles, and workflows." />
+          <title>AAS Core Preview | Agent-first stacks backed by 1,678+ skills</title>
+          <meta name="description" content="Use AAS Core preview to recommend and plan exact stacks backed by 1,678+ cataloged skills." />
+          <meta property="og:title" content="AAS Core Preview | Agent-first stacks backed by 1,678+ skills" />
+          <meta property="og:description" content="Use AAS Core preview with the supporting catalog." />
+          <meta name="twitter:title" content="AAS Core Preview | Agent-first stacks backed by 1,678+ skills" />
+          <meta name="twitter:description" content="Use AAS Core preview with the supporting catalog." />
           <script type="application/ld+json">
             [
               {"@context":"https://schema.org","@type":"CollectionPage","sameAs":"https://github.com/sickn33/agentic-awesome-skills"},
@@ -701,12 +703,12 @@ describe('seo assets verification helpers', () => {
     const html = `
       <html>
         <head>
-          <title>Agentic Awesome Skills GitHub | 1,678+ AI coding skills</title>
-          <meta name="description" content="Explore the GitHub library of 1,678+ installable agentic skills, specialized plugins, bundles, and workflows." />
-          <meta property="og:title" content="Agentic Awesome Skills GitHub | 1,678+ AI coding skills" />
-          <meta property="og:description" content="Explore the GitHub library of 1,678+ installable agentic skills, specialized plugins, bundles, and workflows." />
-          <meta name="twitter:title" content="Agentic Awesome Skills GitHub | 1,678+ AI coding skills" />
-          <meta name="twitter:description" content="Explore the GitHub library of 1,678+ installable agentic skills, specialized plugins, bundles, and workflows." />
+          <title>AAS Core Preview | Agent-first stacks backed by 1,678+ skills</title>
+          <meta name="description" content="Use AAS Core preview to recommend and plan exact stacks backed by 1,678+ cataloged skills." />
+          <meta property="og:title" content="AAS Core Preview | Agent-first stacks backed by 1,678+ skills" />
+          <meta property="og:description" content="Use AAS Core preview with the supporting catalog." />
+          <meta name="twitter:title" content="AAS Core Preview | Agent-first stacks backed by 1,678+ skills" />
+          <meta name="twitter:description" content="Use AAS Core preview with the supporting catalog." />
           <script type="application/ld+json">
             [
               {"@context":"https://schema.org","@type":"CollectionPage","sameAs":"https://github.com/sickn33/agentic-awesome-skills"},
@@ -727,12 +729,12 @@ describe('seo assets verification helpers', () => {
     const html = `
       <html>
         <head>
-          <title>Agentic Awesome Skills GitHub | 1,678+ AI coding skills</title>
-          <meta name="description" content="Explore the GitHub library of 1,678+ installable agentic skills, specialized plugins, bundles, and workflows." />
-          <meta property="og:title" content="Agentic Awesome Skills GitHub | 1,678+ AI coding skills" />
-          <meta property="og:description" content="Explore the GitHub library of 1,678+ installable agentic skills, specialized plugins, bundles, and workflows." />
-          <meta name="twitter:title" content="Agentic Awesome Skills GitHub | 1,678+ AI coding skills" />
-          <meta name="twitter:description" content="Explore the GitHub library of 1,678+ installable agentic skills, specialized plugins, bundles, and workflows." />
+          <title>AAS Core Preview | Agent-first stacks backed by 1,678+ skills</title>
+          <meta name="description" content="Use AAS Core preview to recommend and plan exact stacks backed by 1,678+ cataloged skills." />
+          <meta property="og:title" content="AAS Core Preview | Agent-first stacks backed by 1,678+ skills" />
+          <meta property="og:description" content="Use AAS Core preview with the supporting catalog." />
+          <meta name="twitter:title" content="AAS Core Preview | Agent-first stacks backed by 1,678+ skills" />
+          <meta name="twitter:description" content="Use AAS Core preview with the supporting catalog." />
         </head>
       </html>
     `;
@@ -863,7 +865,7 @@ describe('seo assets verification helpers', () => {
     fs.mkdirSync(path.dirname(routeFile), { recursive: true });
     fs.writeFileSync(
       routeFile,
-      '<html><head><title>Stack Review Workbench | Agentic Awesome Skills</title><meta name="description" content="Review an AAS stack and plan. Imports stay in memory and cannot install or apply changes." /></head></html>',
+      '<html><head><title>AAS Core Stack Review | Agentic Awesome Skills</title><meta name="description" content="Review an AAS Core stack and plan. Imports stay in memory and cannot install or apply changes." /></head></html>',
     );
 
     const xml = `

--- a/apps/web-app/src/App.tsx
+++ b/apps/web-app/src/App.tsx
@@ -18,14 +18,14 @@ function App(): React.ReactElement {
       <div className="app-shell min-h-screen bg-[var(--surface-canvas)] text-[var(--text-primary)]">
         <header className="app-header">
           <div className="app-header__inner">
-            <Link to="/" className="brand-link" aria-label="Agentic Skills home">
+            <Link to="/" className="brand-link" aria-label="AAS Core home">
               <img
                 src={logoSrc}
-                alt="Agentic Skills logo"
+                alt="AAS Core logo"
                 className="brand-link__logo"
               />
               <span className="brand-link__name">
-                Agentic Skills
+                AAS Core
               </span>
             </Link>
 
@@ -35,7 +35,7 @@ function App(): React.ReactElement {
                 end
                 className={({ isActive }) => `app-nav__link ${isActive ? 'is-active' : ''}`}
               >
-                Explore
+                Core
               </NavLink>
               <NavLink
                 to="/workbench"
@@ -65,7 +65,7 @@ function App(): React.ReactElement {
               <details className="mobile-nav">
                 <summary aria-label="Open navigation">Menu</summary>
                 <nav aria-label="Mobile navigation">
-                  <Link to="/">Explore</Link>
+                  <Link to="/">Core</Link>
                   <Link to="/workbench">Workbench</Link>
                   <Link to="/plugins">Plugins</Link>
                   <a href="https://github.com/sickn33/agentic-awesome-skills" target="_blank" rel="noreferrer">View on GitHub</a>

--- a/apps/web-app/src/__tests__/App.workbench-isolation.test.tsx
+++ b/apps/web-app/src/__tests__/App.workbench-isolation.test.tsx
@@ -21,7 +21,7 @@ describe('Workbench route isolation', () => {
 
     render(<App />);
 
-    await screen.findByRole('heading', { level: 1, name: 'Review what your agent chose.' });
+    await screen.findByRole('heading', { level: 1, name: 'Review what AAS Core recommended.' });
     const stack = {
       schemaVersion: 1,
       name: 'isolated-stack',

--- a/apps/web-app/src/data/seoLandingPages.json
+++ b/apps/web-app/src/data/seoLandingPages.json
@@ -1,11 +1,11 @@
 [
   {
     "slug": "antigravity-cli-skills",
-    "title": "Antigravity CLI Skills | Installable AI agent playbooks",
-    "description": "Install Antigravity CLI skills from the Agentic Awesome Skills GitHub repository, with curated playbooks for coding agents, reviews, testing, and workflow automation.",
+    "title": "Antigravity CLI Skill Stacks | AAS Core Preview",
+    "description": "Use the AAS Core preview catalog to discover and compose explainable Antigravity CLI skill stacks for coding, review, testing, and workflow automation.",
     "eyebrow": "Antigravity CLI",
     "h1": "Antigravity CLI skills for agentic coding workflows",
-    "summary": "Use Agentic Awesome Skills as a GitHub-backed library of reusable SKILL.md playbooks for Antigravity CLI and adjacent coding-agent runtimes.",
+    "summary": "Use AAS Core as the agent-first selection layer over reusable SKILL.md playbooks for Antigravity CLI and adjacent coding-agent runtimes.",
     "primaryIntent": "Find installable skills and workflow playbooks for Antigravity CLI.",
     "keywords": [
       "Antigravity CLI skills",
@@ -45,12 +45,12 @@
     ],
     "sections": [
       {
-        "heading": "What to install first",
-        "body": "Start with focused coding, review, testing, documentation, and release skills instead of activating the entire catalog on day one."
+        "heading": "What AAS Core should recommend first",
+        "body": "Start with a focused, explainable stack for coding, review, testing, documentation, and release work instead of activating the entire catalog."
       },
       {
         "heading": "Why this repository fits Antigravity",
-        "body": "The library is organized around portable skill instructions, specialized plugins, bundles, and workflows that can be reused across agent hosts."
+        "body": "AAS Core selects portable skill instructions from the shared catalog while specialized plugins, bundles, and workflows remain optional distribution and discovery surfaces."
       },
       {
         "heading": "When the full library is too broad",
@@ -74,11 +74,11 @@
   },
   {
     "slug": "github-ai-skills-repository",
-    "title": "GitHub AI Skills Repository | Agentic Awesome Skills",
-    "description": "Browse the Agentic Awesome Skills GitHub repository: an installable library of AI agent skills, specialized plugins, bundles, and reusable coding workflows.",
+    "title": "AAS Core Preview | GitHub AI Skills Repository",
+    "description": "Explore the GitHub source for AAS Core preview: local MCP and CLI skill recommendation, stack validation, planning, and the supporting AI agent skill catalog.",
     "eyebrow": "GitHub repository",
-    "h1": "A GitHub repository for installable AI agent skills",
-    "summary": "Agentic Awesome Skills is the canonical GitHub source for SKILL.md playbooks, installer flows, plugin packs, bundles, and workflow documentation.",
+    "h1": "The GitHub source for AAS Core and its skill catalog",
+    "summary": "Agentic Awesome Skills is the canonical source for AAS Core, its local MCP and CLI, reusable SKILL.md playbooks, plugin packs, and workflow documentation.",
     "primaryIntent": "Find a GitHub repository of reusable AI coding assistant skills.",
     "keywords": [
       "GitHub AI skills repository",
@@ -119,11 +119,11 @@
     "sections": [
       {
         "heading": "Canonical source of truth",
-        "body": "The GitHub repository contains the skill source, installer CLI, user docs, plugin mirrors, bundles, workflows, and release history."
+        "body": "The GitHub repository contains AAS Core, the local MCP and CLI, skill sources, user docs, plugin mirrors, workflows, and release history."
       },
       {
         "heading": "Searchable catalog",
-        "body": "The hosted catalog gives users a fast browsing layer over the repository so they can discover skills before installing them."
+        "body": "The hosted catalog is a companion browsing layer over the evidence AAS Core uses for discovery and recommendation."
       },
       {
         "heading": "Reusable across agents",
@@ -151,7 +151,7 @@
     "description": "Compare Antigravity-compatible plugin packs for web apps, security, data analytics, documents, DevOps, QA, OSS maintenance, and agent workflows.",
     "eyebrow": "Plugin packs",
     "h1": "Antigravity plugins for focused agent workflows",
-    "summary": "Specialized plugins package the right skills for a domain so users can start with a narrow, practical surface instead of the full library.",
+    "summary": "Specialized plugins are secondary packaged distributions for users who prefer a fixed domain surface instead of an AAS Core recommendation.",
     "primaryIntent": "Find Antigravity plugin packs and focused AI workflow distributions.",
     "keywords": [
       "Antigravity plugins",
@@ -204,7 +204,7 @@
       },
       {
         "heading": "Lower activation cost",
-        "body": "A plugin gives the assistant a tighter instruction set, reducing noise when the full catalog is more than the current task needs."
+        "body": "A plugin gives the assistant a fixed instruction set; AAS Core remains the agent-first path when the stack should be recommended from intent and catalog evidence."
       },
       {
         "heading": "Still backed by the full repo",
@@ -228,11 +228,11 @@
   },
   {
     "slug": "skills-para-antigravity",
-    "title": "Skills para Antigravity | Installable AI coding skills",
-    "description": "Find skills para Antigravity in the Agentic Awesome Skills GitHub library, including installable playbooks for coding agents, plugins, bundles, and workflows.",
+    "title": "Skills para Antigravity | AAS Core Preview",
+    "description": "Use AAS Core preview to find and compose explainable skills para Antigravity from the Agentic Awesome Skills catalog.",
     "eyebrow": "International search",
     "h1": "Skills para Antigravity and AI coding agents",
-    "summary": "A practical entry point for users searching for skills para Antigravity, Antigravity skills, or GitHub playbooks for AI coding assistants.",
+    "summary": "A practical entry point for using AAS Core to recommend skill stacks for Antigravity and related AI coding assistants.",
     "primaryIntent": "Serve international searches for skills para Antigravity.",
     "keywords": [
       "skills para Antigravity",
@@ -281,8 +281,8 @@
         "body": "Antigravity is one target surface, but the library also supports other assistant runtimes through direct installs and plugin distributions."
       },
       {
-        "heading": "Start with the catalog",
-        "body": "Use the hosted catalog to compare skills and plugin packs, then open the GitHub repository for installation and source details."
+        "heading": "Start with AAS Core",
+        "body": "Let AAS Core recommend an exact stack from catalog evidence, then use the hosted site to review skills, plugins, and the resulting artifacts."
       }
     ],
     "links": [

--- a/apps/web-app/src/pages/Home.tsx
+++ b/apps/web-app/src/pages/Home.tsx
@@ -10,11 +10,11 @@ import type { CategoryStats, SyncMessage } from '../types';
 import { buildHomeMeta, getHomeFaqItems } from '../utils/seo';
 
 const conceptCards = [
-  { title: 'Specialized plugins', body: 'Focused distributions for a domain or job.' },
-  { title: 'Skills', body: 'Reusable SKILL.md playbooks for repeatable execution.' },
-  { title: 'MCP tools', body: 'External capabilities the assistant can call.' },
-  { title: 'Bundles', body: 'Curated starting sets for a role or team.' },
-  { title: 'Workflows', body: 'Ordered playbooks for a concrete outcome.' },
+  { title: 'AAS Core preview', body: 'The local control plane that turns intent into an explainable skill stack and immutable plan preview.' },
+  { title: 'Local MCP', body: 'The agent-facing tools for search, inspection, recommendation, and stack comparison.' },
+  { title: 'Catalog', body: 'The evidence-backed source AAS Core uses to select exact skills.' },
+  { title: 'Workbench', body: 'A browser-local review surface for stack manifests and immutable plans.' },
+  { title: 'Plugins', body: 'Focused distributions for users who prefer a packaged domain surface.' },
 ] as const;
 
 const integrationGuides = [
@@ -122,15 +122,15 @@ export function Home(): React.ReactElement {
         </nav>
         <Link to="/workbench" className="catalog-rail__workbench">
           <Icon name="fileCode" size={17} />
-          Saved & exact installs
+          AAS Core Workbench
         </Link>
       </aside>
 
       <div className="catalog-content">
         <section className="catalog-hero">
-          <h1>Installable AI agent skills for Codex, Claude Code, Cursor, Gemini, and Antigravity</h1>
-          <p><strong>Find the right skill. Ship the better agent.</strong></p>
-          <p>Search {catalogCountLabel} installable skills, plugins, and workflows — curated for real agent work.</p>
+          <h1>AAS Core: agent-first skill stacks for Codex, Claude Code, and compatible clients</h1>
+          <p><strong>Discover. Recommend. Validate. Preview.</strong></p>
+          <p>Turn intent into an explainable <code>aas-stack.json</code> and immutable plan preview without target writes, backed by {catalogCountLabel} cataloged skills.</p>
 
           <label className="catalog-search">
             <span className="sr-only">Search skills</span>
@@ -180,7 +180,7 @@ export function Home(): React.ReactElement {
                 </select>
               </label>
             </div>
-            <Link to="/workbench">Compose an exact install <Icon name="arrowRight" size={16} /></Link>
+            <Link to="/workbench">Review an AAS Core stack <Icon name="arrowRight" size={16} /></Link>
           </div>
         </section>
 
@@ -236,8 +236,8 @@ export function Home(): React.ReactElement {
 
         <section className="catalog-support" aria-label="Catalog guides">
           <div className="catalog-support__intro">
-            <h2>Understand the system behind the catalog</h2>
-            <p>Skills, tools, bundles, plugins, and workflows solve different parts of the same job.</p>
+            <h2>How AAS Core uses the catalog</h2>
+            <p>The local MCP and CLI choose from catalog evidence; the Workbench reviews what the agent proposed.</p>
           </div>
           <div className="catalog-support__concepts">
             {conceptCards.map((card) => (

--- a/apps/web-app/src/pages/Workbench.tsx
+++ b/apps/web-app/src/pages/Workbench.tsx
@@ -303,8 +303,8 @@ export function Workbench(): React.ReactElement {
   const [plan, setPlan] = useState<ImportState<PlanReview>>({ ...EMPTY_IMPORT_STATE });
 
   usePageMeta(useMemo(() => ({
-    title: 'Stack Review Workbench | Agentic Awesome Skills',
-    description: 'Review an AAS stack manifest and immutable plan locally in your browser. Imports stay in memory and cannot install or apply changes.',
+    title: 'AAS Core Stack Review | Agentic Awesome Skills',
+    description: 'Review an AAS Core stack manifest and immutable preview plan locally in your browser. Imports stay in memory and cannot install or apply changes.',
     canonicalPath: '/workbench',
   }), []));
 
@@ -313,8 +313,8 @@ export function Workbench(): React.ReactElement {
       <header className="workbench-header">
         <div>
           <div>
-            <h1>Review what your agent chose.</h1>
-            <p>Import an <code>aas-stack.json</code> and immutable plan to inspect identities, targets, operations, overrides, and unknowns before approving anything in the CLI.</p>
+            <h1>Review what AAS Core recommended.</h1>
+            <p>Import the <code>aas-stack.json</code> and immutable preview plan produced through the local MCP or CLI to inspect identities, targets, operations, overrides, and unknowns.</p>
           </div>
           <dl>
             <div><dt>Privacy</dt><dd>In-memory only</dd></div>

--- a/apps/web-app/src/pages/__tests__/Home.test.tsx
+++ b/apps/web-app/src/pages/__tests__/Home.test.tsx
@@ -85,19 +85,19 @@ describe('Home', () => {
       renderWithRouter(<Home />, { useProvider: false });
 
       await waitFor(() => {
-        expect(document.title).toContain('Agentic Awesome Skills');
+        expect(document.title).toContain('AAS Core Preview');
       });
 
       expect(screen.getByRole('heading', {
         level: 1,
-        name: /Installable AI agent skills for Codex, Claude Code, Cursor, Gemini, and Antigravity/i,
+        name: /AAS Core: agent-first skill stacks for Codex, Claude Code, and compatible clients/i,
       })).toBeInTheDocument();
-      expect(screen.getByText(/Find the right skill\. Ship the better agent\./i)).toBeInTheDocument();
-      expect(screen.getByRole('link', { name: /Compose an exact install/i })).toHaveAttribute('href', '/workbench');
+      expect(screen.getByText(/Discover\. Recommend\. Validate\. Preview\./i)).toBeInTheDocument();
+      expect(screen.getByRole('link', { name: /Review an AAS Core stack/i })).toHaveAttribute('href', '/workbench');
       expect(screen.getByText(/What is the difference between skills and MCP tools/i)).toBeInTheDocument();
       expect(document.querySelector('meta[property="og:title"]')).toHaveAttribute(
         'content',
-        expect.stringContaining('Agentic Awesome Skills'),
+        expect.stringContaining('AAS Core Preview'),
       );
     });
 
@@ -112,7 +112,7 @@ describe('Home', () => {
       renderWithRouter(<Home />, { useProvider: false });
 
       await waitFor(() => {
-        expect(screen.getByRole('link', { name: /Compose an exact install/i })).toBeInTheDocument();
+        expect(screen.getByRole('link', { name: /Review an AAS Core stack/i })).toBeInTheDocument();
       });
 
       expect(screen.getByText(/Inspect evidence, select exact IDs/i)).toBeInTheDocument();

--- a/apps/web-app/src/pages/__tests__/TopicLanding.test.tsx
+++ b/apps/web-app/src/pages/__tests__/TopicLanding.test.tsx
@@ -39,19 +39,19 @@ describe('TopicLanding', () => {
       'href',
       '/skill/antigravity-agent-manager',
     );
-    expect(screen.getByRole('link', { name: /GitHub repository for installable AI agent skills/i })).toHaveAttribute(
+    expect(screen.getByRole('link', { name: /GitHub source for AAS Core and its skill catalog/i })).toHaveAttribute(
       'href',
       '/topics/github-ai-skills-repository',
     );
     expect(screen.getAllByText(/Antigravity CLI skills/i).length).toBeGreaterThan(0);
 
     await waitFor(() => {
-      expect(document.title).toContain('Antigravity CLI Skills');
+      expect(document.title).toContain('Antigravity CLI Skill Stacks');
     });
 
     expect(document.querySelector('meta[name="description"]')).toHaveAttribute(
       'content',
-      expect.stringContaining('Install Antigravity CLI skills'),
+      expect.stringContaining('AAS Core preview catalog'),
     );
   });
 

--- a/apps/web-app/src/pages/__tests__/Workbench.test.tsx
+++ b/apps/web-app/src/pages/__tests__/Workbench.test.tsx
@@ -78,6 +78,8 @@ describe('Workbench review UI', () => {
   it('reviews a valid stack without offering install, apply, or share actions', () => {
     renderWithRouter(<Workbench />, { route: '/workbench', path: '/workbench', useProvider: false });
 
+    expect(screen.getByRole('heading', { level: 1, name: 'Review what AAS Core recommended.' })).toBeInTheDocument();
+
     paste('Paste JSON', stackFixture());
     fireEvent.click(screen.getByRole('button', { name: 'Review pasted stack' }));
 

--- a/apps/web-app/src/utils/__tests__/seo.test.ts
+++ b/apps/web-app/src/utils/__tests__/seo.test.ts
@@ -33,12 +33,13 @@ describe('SEO helpers', () => {
     expect(DEFAULT_TOP_SKILL_COUNT).toBe(180);
   });
 
-  it('builds homepage metadata with the canonical catalog message', () => {
+  it('builds homepage metadata with the canonical AAS Core preview message', () => {
     const meta = buildHomeMeta(10);
 
-    expect(meta.title).toContain('Agentic Awesome Skills GitHub');
-    expect(meta.title).toContain('10+ AI coding skills');
-    expect(meta.description).toContain('GitHub library of 10+ installable agentic skills');
+    expect(meta.title).toContain('AAS Core Preview');
+    expect(meta.title).toContain('10+ skills');
+    expect(meta.description).toContain('discover, recommend, validate, and plan');
+    expect(meta.description).toContain('10+ cataloged skills');
     expect(meta.canonicalPath).toBe('/');
     expect(meta.ogTitle).toBe(meta.title);
     expect(meta.ogImage).toBe(DEFAULT_SOCIAL_IMAGE);
@@ -96,7 +97,7 @@ describe('SEO helpers', () => {
     const meta = buildTopicLandingMeta(topic!);
 
     expect(meta.title).toContain('GitHub AI Skills Repository');
-    expect(meta.description).toContain('GitHub repository');
+    expect(meta.description).toContain('GitHub source for AAS Core preview');
     expect(meta.canonicalPath).toBe('/topics/github-ai-skills-repository');
     expect(meta.ogImage).toBe(DEFAULT_SOCIAL_IMAGE);
     expect(typeof meta.jsonLd).toBe('function');

--- a/apps/web-app/src/utils/seo.ts
+++ b/apps/web-app/src/utils/seo.ts
@@ -39,17 +39,17 @@ const FAQ_ITEMS = [
   {
     question: 'What is Agentic Awesome Skills?',
     answer: (countLabel: string) =>
-      `Agentic Awesome Skills is an installable GitHub library of ${countLabel} reusable SKILL.md playbooks for AI coding assistants. It supports Claude Code, Cursor, Codex CLI, Autohand Code, Gemini CLI, Antigravity, and related hosts through direct skill installs, specialized plugins, bundles, workflows, and a searchable catalog.`,
+      `Agentic Awesome Skills is built around AAS Core, a local agent-first preview control plane for discovering, recommending, validating, and planning exact skill stacks. AAS Core is backed by an evidence-rich catalog of ${countLabel} reusable SKILL.md playbooks.`,
   },
   {
-    question: 'How do I install Agentic Awesome Skills?',
+    question: 'How do I use AAS Core preview?',
     answer:
-      'Install the library with npx agentic-awesome-skills. Use tool-specific flags such as --codex, --cursor, --gemini, --claude, or --antigravity when you want the installer to target a specific skills directory already used by your assistant runtime.',
+      'Configure the local stdio MCP with the AAS CLI, let the agent search, inspect, and recommend skills, then validate the proposed aas-stack.json and preview its immutable plan in the CLI. Apply and recovery are outside the non-applying preview path.',
   },
   {
     question: 'Is Agentic Awesome Skills a GitHub repository?',
     answer:
-      'Yes. The GitHub repository at https://github.com/sickn33/agentic-awesome-skills is the canonical source for the skill library, installer, specialized plugins, bundles, workflows, and documentation. The hosted catalog is the searchable browsing surface for that repository.',
+      'Yes. The GitHub repository at https://github.com/sickn33/agentic-awesome-skills is the canonical source for AAS Core, its CLI and local MCP, the skill catalog, plugins, and documentation. The hosted site is a companion catalog and local artifact-review surface.',
   },
   {
     question: 'What are AAS specialized plugins?',
@@ -174,7 +174,7 @@ function buildSoftwareSourceCodeSchema(canonicalUrl: string, visibleCount: numbe
     '@context': 'https://schema.org',
     '@type': 'SoftwareSourceCode',
     name: SITE_NAME,
-    description: `Installable GitHub library of ${visibleCountLabel}, specialized plugins, bundles, and workflows for AI coding assistants.`,
+    description: `AAS Core preview is a local agent-first control plane for recommending, validating, and planning exact skill stacks backed by ${visibleCountLabel}.`,
     url: REPOSITORY_URL,
     sameAs: [
       canonicalUrl,
@@ -194,6 +194,10 @@ function buildSoftwareSourceCodeSchema(canonicalUrl: string, visibleCount: numbe
       'Antigravity CLI skills',
       'GitHub AI skills repository',
       'AI agent skills GitHub',
+      'AAS Core',
+      'skill recommendation',
+      'agent stack',
+      'Model Context Protocol',
       'specialized plugins',
       'SKILL.md',
     ],
@@ -375,11 +379,11 @@ export function buildHomeMeta(skillCount: number): SeoMeta {
   const visibleCount = Math.max(skillCount, 0);
   const visibleCountLabel = visibleCount > 0 ? getCatalogCountLabel(visibleCount) : '';
   const title = visibleCount > 0
-    ? `Agentic Awesome Skills GitHub | ${visibleCountLabel} AI coding skills`
-    : 'Agentic Awesome Skills GitHub | AI coding skills';
+    ? `AAS Core Preview | Agent-first stacks backed by ${visibleCountLabel} skills`
+    : 'AAS Core Preview | Agent-first skill stacks';
   const description = visibleCount > 0
-    ? `Explore the GitHub library of ${visibleCountLabel} installable agentic skills, specialized plugins, bundles, and workflows for Claude Code, Cursor, Codex CLI, Autohand Code, Gemini CLI, Antigravity, and other AI coding assistants.`
-    : 'Explore the GitHub library of installable agentic skills, specialized plugins, bundles, and workflows for Claude Code, Cursor, Codex CLI, Autohand Code, Gemini CLI, Antigravity, and other AI coding assistants.';
+    ? `Use AAS Core preview to discover, recommend, validate, and plan explainable skill stacks for Codex, Claude Code, and compatible clients, backed by ${visibleCountLabel} cataloged skills.`
+    : 'Use AAS Core preview to discover, recommend, validate, and plan explainable skill stacks for Codex, Claude Code, and compatible clients.';
   return {
     title,
     description,
@@ -400,7 +404,7 @@ export function buildHomeMeta(skillCount: number): SeoMeta {
         about: buildSoftwareSourceCodeSchema(canonicalUrl, visibleCount),
         mainEntity: {
           '@type': 'ItemList',
-          name: 'Agentic Awesome Skills catalog',
+          name: 'AAS Core skill catalog',
         },
       },
       buildOrganizationSchema(),

--- a/docs/README.md
+++ b/docs/README.md
@@ -2,6 +2,7 @@
 
 ## Users
 
+- [`users/aas-core.md`](users/aas-core.md) — canonical AAS Core preview guide
 - [`users/getting-started.md`](users/getting-started.md)
 - [`users/usage.md`](users/usage.md)
 - [`users/faq.md`](users/faq.md)

--- a/docs/integrations/jetski-cortex.md
+++ b/docs/integrations/jetski-cortex.md
@@ -5,6 +5,8 @@ description: "Use agentic-awesome-skills with Jetski/Cortex without hitting cont
 
 # Jetski/Cortex + Gemini: safe integration with 1,965+ skills
 
+> **Custom-host integration:** This guide documents a low-level, direct-manifest lazy loader for Jetski/Cortex and similar hosts. For Codex or Claude Code, the recommended path is [AAS Core](../users/aas-core.md), which provides verified local catalog discovery and deterministic recommendations through a bounded, read-only MCP server.
+
 This guide shows how to integrate the `agentic-awesome-skills` repository with an agent based on **Jetski/Cortex + Gemini** (or similar frameworks) **without exceeding the model context window**.
 
 The common error seen in Jetski/Cortex is:

--- a/docs/integrations/jetski-gemini-loader/README.md
+++ b/docs/integrations/jetski-gemini-loader/README.md
@@ -1,5 +1,7 @@
 # Jetski + Gemini Lazy Skill Loader (Example)
 
+> **Custom-host example:** This is a low-level, direct-manifest integration for Jetski/Cortex-style hosts. Codex and Claude Code users should start with [AAS Core](../../users/aas-core.md), which exposes verified local catalog discovery and deterministic recommendations through a bounded, read-only MCP server.
+
 This example shows one way to integrate **agentic-awesome-skills** with a Jetski/Cortex‑style agent using **lazy loading** based on `@skill-id` mentions, instead of concatenating every `SKILL.md` into the prompt.
 
 > This is **not** a production‑ready library – it is a minimal reference you can adapt to your own host/agent implementation.

--- a/docs/users/aas-core.md
+++ b/docs/users/aas-core.md
@@ -1,0 +1,145 @@
+# AAS Core: Agent-First Skill Stacks
+
+> **Preview status:** AAS Agent-First Preview helps Codex and Claude compose a local, explainable, reproducible skill stack. Full-catalog recommendation quality and transactional apply/recovery safety are not yet certified.
+
+AAS Core is the primary way to turn the repository's skill catalog into a controlled project stack:
+
+> **The agent composes. You control. AAS keeps the stack reproducible.**
+
+The durable artifact is [`aas-stack.json`](#the-stack-manifest), not a prompt, an opaque model decision, or a copy of the entire catalog. The same deterministic, versioned core powers the local MCP server and the `aas` CLI. The hosted Workbench is a review surface; it is not a browser-side installer or hosted control plane.
+
+## How it works
+
+```text
+your project
+  -> Codex or Claude inspects the repository
+  -> local AAS MCP (stdio, read-only)
+  -> deterministic AAS Core + bundled or verified local catalog
+  -> agent explains a recommendation and proposes aas-stack.json
+  -> you review the exact skills, target, policy, and catalog identity
+  -> aas stack validate
+  -> aas stack plan (preview; no skill changes)
+```
+
+The agent may inspect your project using its normal local capabilities, but AAS MCP does not scan the repository. It receives an explicit, allowlisted profile from the agent and returns structured catalog evidence.
+
+## Configure the local MCP
+
+> **Release boundary:** AAS Core landed on `main` after the published 14.6.0 package. Do not use 14.6.0 for this bootstrap. Wait for a release that explicitly includes AAS Core, then substitute that exact version below.
+
+The package publishes separate `aas` and `aas-mcp` binaries. For a pinned Core release without relying on npm's default-bin selection, invoke `aas` explicitly:
+
+```bash
+npm exec --yes --ignore-scripts --package=agentic-awesome-skills@<core-version> -- aas mcp configure \
+  --host codex \
+  --scope user \
+  --config /absolute/path/to/codex/config.toml \
+  --cache-root /absolute/path/to/aas-cache
+```
+
+Use `--host claude` with the appropriate absolute Claude MCP configuration path for Claude. The first command is a preview and returns an approval digest without changing the host configuration. Review it, then repeat the exact command with:
+
+```text
+--approve <approval-digest>
+```
+
+Configuration is explicit and integrity-bound. AAS installs or reuses an exact content-addressed runtime, verifies it, and changes only its managed MCP configuration section. Restart the host if it does not reload MCP configuration automatically.
+
+## Ask the agent to compose the stack
+
+Once the host discovers the AAS MCP tools, give it the outcome and constraints rather than manually choosing from almost 2,000 skills:
+
+```text
+Inspect this repository and use the AAS MCP tools to recommend a small skill stack
+for implementing and testing this project. Explain exclusions and unknowns, then
+propose an aas-stack.json. Do not install or apply anything.
+```
+
+The local MCP exposes exactly these read-only tools:
+
+- `search_skills` — search the verified local catalog;
+- `get_skill` — inspect one skill and its recorded evidence;
+- `recommend_stack` — produce a deterministic recommendation from an explicit profile and policy;
+- `inspect_stack` — validate and explain a proposed manifest;
+- `diff_stack` — compare manifests using verified local catalogs.
+
+It also exposes the `aas://skills/{id}` resource template. MCP calls do not install or remove skills, update catalogs, edit host configuration, or apply a stack. Full skill text is returned only when requested and remains marked as untrusted content.
+
+## The stack manifest
+
+`aas-stack.json` records approved desired state:
+
+```json
+{
+  "schemaVersion": 1,
+  "name": "project-stack",
+  "catalog": {
+    "package": "agentic-awesome-skills",
+    "version": "<version>",
+    "integrity": "sha256-..."
+  },
+  "targets": [{ "host": "codex", "scope": "project" }],
+  "intent": { "goals": ["build", "test"] },
+  "policy": {
+    "allowedRisk": ["none", "safe"],
+    "requireKnownSource": true,
+    "allowManualSetup": false
+  },
+  "skills": [
+    { "id": "example-skill" }
+  ]
+}
+```
+
+The manifest pins the catalog identity, target, intent, policy, and exact skill IDs. Repository observations, ranking factors, exclusions, unknowns, and natural-language explanations stay in recommendation or plan output instead of becoming hidden state.
+
+## Validate and preview the plan
+
+Use absolute paths in automation and review the JSON result from each command:
+
+```bash
+aas stack validate --manifest /absolute/path/to/aas-stack.json
+
+aas stack plan \
+  --manifest /absolute/path/to/aas-stack.json \
+  --target codex:project \
+  --target-root /absolute/path/to/project \
+  --cache-root /absolute/path/to/aas-cache \
+  --runtime-version 14.6.0 \
+  --runtime-integrity '<npm-sri>' \
+  --out /absolute/path/to/plan.json
+```
+
+`stack validate` is read-only. `stack plan` writes only the requested plan artifact and does not materialize skills or AAS managed state in the target. The immutable plan binds the manifest, runtime, catalog, target identity, current managed state, and exact logical operations.
+
+Stop after reviewing the plan unless you are deliberately participating in controlled preview development. `stack apply` and `stack recover` are disabled by default, require additional experimental flags and exact digest approval, and are **not supported or certified preview safety claims**.
+
+## Privacy, trust, and limits
+
+- MCP is local stdio, process-per-session, read-only, offline-capable, and contains no model credentials or telemetry.
+- Recommendation is deterministic and evidence-based; AAS does not call another model, use embeddings, or perform remote ranking.
+- Missing evidence is reported as `unknown`. AAS may leave goals uncovered instead of presenting a weak match as certainty.
+- Catalog updates and runtime changes are explicit. There is no resident daemon or implicit auto-update.
+- The MCP boundary does not grant skill prose instruction authority and cannot guarantee how an external model interprets untrusted content.
+- Preview qualification does not certify full-catalog recommendation quality, transactional crash/race safety, apply, or recovery.
+
+## Other ways to use the catalog
+
+AAS Core is the recommended path when Codex or Claude can use the local MCP. Existing distribution paths remain available:
+
+- direct skill installs for hosts that load `SKILL.md` files;
+- specialized plugins for a fixed, domain-focused distribution;
+- bundles as human-curated presets;
+- workflows as ordered execution playbooks;
+- the legacy `agentic-awesome-skills` installer for compatible direct installs.
+
+These surfaces provide catalog content and packaging. AAS Core adds project-aware composition, explicit policy, a durable stack manifest, and a reviewable plan.
+
+## Next reads
+
+- [Getting Started](getting-started.md)
+- [Usage](usage.md)
+- [Skills vs MCP Tools](skills-vs-mcp-tools.md)
+- [Plugins for Claude Code and Codex](plugins.md)
+- [Bundles](bundles.md)
+- [FAQ](faq.md)

--- a/docs/users/claude-code-skills.md
+++ b/docs/users/claude-code-skills.md
@@ -1,24 +1,31 @@
-# Claude Code Skills
+# AAS Core with Claude Code
 
-If you are looking for **Claude Code skills** you can install from GitHub, this repository is designed to get you from first clone to first useful prompt quickly.
+For Claude Code, the recommended AAS path is **AAS Core**: a local, agent-first control plane for catalog search, deterministic stack recommendation, manifest inspection, and preview-first planning.
 
-Agentic Awesome Skills gives Claude Code users an installable library of `SKILL.md` playbooks, role-based bundles, and execution workflows. The goal is not just to collect prompts, but to make repeatable engineering tasks easier to invoke, review, and reuse.
+The local AAS MCP is read-only. It can help Claude search and inspect the catalog or propose a minimal `aas-stack.json`, while validation, planning, and any approved changes stay in the AAS CLI lifecycle.
 
-Release `9.0.0` also adds a first-class Claude Code plugin distribution plus bundle plugins. If you want the full explanation of root plugin vs bundle plugin vs full install, read [plugins.md](plugins.md).
+Start with the [AAS Core guide](aas-core.md). The Claude plugin marketplace and direct skill installation remain supported delivery paths after you know which skills you want.
+
+> **Preview status:** Search, recommendation, manifest validation, and planning are the documented preview path. Stop after plan review; apply and recovery are not certified preview safety claims.
 
 ## How to use Agentic Awesome Skills with Claude Code
 
-Install the library into Claude Code, then invoke focused skills directly in the conversation or through the plugin marketplace path. Claude Code benefits most when you keep the prompt specific about the skill, the scope, and the intended output.
+Configure AAS Core for Claude Code, describe the task and constraints, review the recommended stack, then preview the CLI plan. Core does not install or mutate through MCP. The current documented preview path stops after plan review.
 
 ## Why use this repo for Claude Code
 
+- It lets Claude search the verified local catalog without loading the full library into context.
+- It produces deterministic recommendations with inspectable factors and evidence.
+- It keeps MCP discovery read-only and CLI changes approval-gated.
 - It includes 1,965+ skills instead of a narrow single-domain starter pack.
 - It supports the standard `.claude/skills/` path and the Claude Code plugin marketplace flow.
 - It also ships generated bundle plugins so teams can install focused packs like `Essentials` or `Security Developer` from the marketplace metadata.
 - It includes onboarding docs, bundles, and workflows so new users do not need to guess where to begin.
 - It covers both everyday engineering tasks and specialized work like security reviews, infrastructure, product planning, and documentation.
 
-## Install Claude Code Skills
+## Direct install and plugins
+
+These are alternative delivery paths for users who already know which skill payload they want.
 
 ### Option A: installer CLI
 
@@ -53,6 +60,14 @@ test -d .claude/skills || test -d ~/.claude/skills
 
 ## Example Claude Code prompts
 
+With AAS Core configured:
+
+```text
+Use AAS to recommend a minimal skill stack for this security review. Propose the aas-stack.json and preview the plan without applying it.
+```
+
+After installing or activating a chosen skill, direct invocation still works:
+
 ```text
 Use @brainstorming to design a new billing workflow for my SaaS.
 ```
@@ -67,6 +82,7 @@ Use @create-pr to turn these changes into a clean PR summary and checklist.
 
 ## What to do next
 
+- Start with [`aas-core.md`](aas-core.md) for setup, trust boundaries, and the stack lifecycle.
 - Start with [`bundles.md`](bundles.md) if you want a role-based shortlist.
 - Use [`workflows.md`](workflows.md) if you want step-by-step execution playbooks.
 - Compare options in [`best-claude-code-skills-github.md`](best-claude-code-skills-github.md) if you are still evaluating repositories.

--- a/docs/users/codex-cli-skills.md
+++ b/docs/users/codex-cli-skills.md
@@ -1,39 +1,47 @@
-# Codex CLI Skills
+# AAS Core with Codex CLI
 
-If you want **Codex CLI skills** that are easy to install and practical in a local coding loop, this repository is designed for that exact use case.
+For Codex, the recommended AAS path is **AAS Core**: a local, agent-first control plane that lets Codex search the verified catalog, inspect skills, and recommend a minimal stack before anything is installed.
 
-Agentic Awesome Skills supports Codex CLI through the `.codex/skills/` path and gives you a wide set of reusable task playbooks for planning, implementation, debugging, testing, security review, and delivery.
+The AAS MCP server is local and read-only. Codex can call `search_skills`, `get_skill`, `recommend_stack`, `inspect_stack`, and `diff_stack`; changes remain in the CLI lifecycle, where `validate` and `plan` are preview operations and `apply` requires explicit approval.
 
-Release `9.0.0` also adds a first-class Codex plugin distribution plus bundle plugins. If you want the full explanation of root plugin vs bundle plugin vs full install, read [plugins.md](plugins.md).
+Start with the [AAS Core guide](aas-core.md). Direct skill installation and Codex plugins remain supported when you already know exactly which payload you want.
+
+> **Preview status:** Search, recommendation, manifest validation, and planning are the documented preview path. Stop after plan review; apply and recovery are not certified preview safety claims.
 
 ## How to use Agentic Awesome Skills with Codex CLI
 
-Install the library into your Codex path, then invoke focused skills directly in your prompt. The most common pattern is:
+Configure AAS Core for Codex, then describe the real task instead of manually searching a large directory. The normal flow is:
 
-1. install with `npx agentic-awesome-skills --codex`
-2. choose one workflow-oriented skill such as `@brainstorming`, `@concise-planning`, or `@test-driven-development`
-3. ask Codex to apply that skill to a concrete file, feature, test, or bugfix
+1. Codex discovers the local AAS MCP tools.
+2. Codex searches the catalog and requests a deterministic recommendation for your task profile.
+3. Codex proposes a minimal `aas-stack.json` for you to review.
+4. The AAS CLI validates the manifest and previews the exact plan.
+5. Stop after reviewing the plan unless you are deliberately participating in controlled preview development.
 
 ## Why use this repo for Codex CLI
 
-- It supports Codex CLI with a dedicated install flag and a standard skills layout.
+- It gives Codex native, local discovery and recommendation through MCP.
+- It keeps catalog evidence, stack intent, validation, and planning deterministic and inspectable.
+- It separates read-only agent tools from approval-gated CLI mutations.
 - It is strong for local repo work where you want to move from planning to implementation to verification without changing libraries.
 - It includes both general-purpose engineering skills and deeper specialist tracks.
-- It gives you docs and bundles, not just raw skill files.
+- It still supports direct installs and plugin distributions as delivery surfaces.
 
-## Install Codex CLI Skills
+## Direct install and plugins
+
+Use a direct install only when you intentionally want the library copied into Codex's skills path:
 
 ```bash
 npx agentic-awesome-skills --codex
 ```
 
-If you prefer a plugin-style Codex integration, this repository also ships repo-local plugin metadata in `.agents/plugins/marketplace.json` and `plugins/agentic-awesome-skills/.codex-plugin/plugin.json`.
+For plugin-style packaging, this repository also ships repo-local metadata in `.agents/plugins/marketplace.json` and `plugins/agentic-awesome-skills/.codex-plugin/plugin.json`.
 
 It also generates bundle-specific Codex plugins so you can install a curated pack such as `Essentials` or `Web Wizard` as a marketplace plugin instead of loading the full library.
 
 Those Codex plugins are plugin-safe filtered distributions. Skills that still depend on host-specific paths or undeclared setup stay in the repository, but are not published into the Codex plugin until they are hardened.
 
-For the canonical explanation of how Codex plugins relate to the full library and bundle installs, read [plugins.md](plugins.md).
+For the canonical explanation of how Core, Codex plugins, and direct installs relate, read [plugins.md](plugins.md).
 
 ### Verify the install
 
@@ -51,6 +59,14 @@ test -d .codex/skills || test -d ~/.codex/skills
 
 ## Example Codex CLI prompts
 
+With AAS Core configured:
+
+```text
+Use AAS to recommend the smallest skill stack for designing and testing this parser change. Show me the proposed aas-stack.json and preview the plan; do not apply it.
+```
+
+After installing or activating a chosen skill, direct invocation still works:
+
 ```text
 Use @concise-planning to break this feature request into an implementation checklist.
 ```
@@ -65,6 +81,7 @@ Use @create-pr once everything is passing and summarize the user-facing changes.
 
 ## What to do next
 
+- Start with [`aas-core.md`](aas-core.md) for setup, trust boundaries, and the stack lifecycle.
 - Read [`ai-agent-skills.md`](ai-agent-skills.md) if you want a framework for choosing between broad and curated skill libraries.
 - Read [`plugins.md`](plugins.md) if you want the plugin-specific install story for Codex and Claude Code.
 - Use [`workflows.md`](workflows.md) when you want step-by-step execution patterns for common engineering goals.

--- a/docs/users/discovery-manifest.md
+++ b/docs/users/discovery-manifest.md
@@ -1,6 +1,8 @@
-# Stable Skills Manifest v1
+# Stable Skills Manifest v1 for Custom Integrations
 
-This page documents the `skills_index.json` manifest contract used by stable integrations.
+This page documents the legacy-compatible `skills_index.json` contract used by custom host integrations and lazy loaders.
+
+For Codex and Claude Code, use [AAS Core](aas-core.md) instead of wiring a host directly to this repository manifest. Core uses a verified local catalog and exposes bounded, read-only MCP tools for search, inspection, and recommendation. The raw manifest remains useful for integrations that do not have an AAS Core host adapter.
 
 ## Manifest contract (v1)
 
@@ -34,7 +36,7 @@ Stable integrations must not load every skill instruction file up front.
 - Enforce a per-turn maximum so user prompts stay below context limits.
 - Validate each resolved path stays under your configured `SKILLS_ROOT`.
 
-This is the core prevention for context truncation and trajectory conversion errors in larger multi-skill hosts.
+This is the main prevention for context truncation and trajectory conversion errors in custom multi-skill hosts. It is not the AAS Core catalog or stack lifecycle contract.
 
 ## Why the `data/` mirror exists
 
@@ -57,6 +59,7 @@ This is the core prevention for context truncation and trajectory conversion err
 
 ## Related docs
 
+- [`docs/users/aas-core.md`](aas-core.md)
 - [`docs/integrations/jetski-cortex.md`](../integrations/jetski-cortex.md)
 - [`docs/integrations/jetski-gemini-loader/README.md`](../integrations/jetski-gemini-loader/README.md)
 - [`docs/users/windows-truncation-recovery.md`](windows-truncation-recovery.md)

--- a/docs/users/faq.md
+++ b/docs/users/faq.md
@@ -6,6 +6,22 @@
 
 ## General Questions
 
+### What is AAS Core?
+
+AAS Core is the deterministic, versioned control plane that turns this repository's catalog into an approved project stack. Codex or Claude can inspect a repository, send an explicit profile to the local read-only AAS MCP, explain the resulting recommendation, and propose an `aas-stack.json`. The `aas` CLI then validates the manifest and previews an immutable plan.
+
+The durable product is the approved stack. Skills, bundles, workflows, plugins, the catalog, MCP, CLI, and Workbench are content, packaging, or interfaces around that stack. Start with [AAS Core](aas-core.md).
+
+### Is AAS Core fully certified?
+
+No. The current public claim is **AAS Agent-First Preview**: it helps Codex and Claude compose a local, explainable, reproducible skill stack. Full-catalog recommendation quality and transactional apply/recovery safety are not yet certified.
+
+`stack apply` and `stack recover` are experimental, disabled by default, and are not supported preview safety claims. The recommended public flow stops after reviewing `stack validate` and `stack plan` output.
+
+### Does AAS upload my repository or use another model?
+
+No. The agent may inspect the project using its normal local capabilities, but AAS MCP does not scan the repository. It receives an explicit allowlisted profile and runs deterministic recommendation against a bundled or verified local catalog. MCP is local stdio, read-only, offline-capable, and contains no model credentials or telemetry.
+
 ### What are "skills" exactly?
 
 Skills are specialized instruction files that teach AI assistants how to handle specific tasks. Think of them as expert knowledge modules that your AI can load on-demand.
@@ -13,9 +29,9 @@ Skills are specialized instruction files that teach AI assistants how to handle 
 
 ### Do I need to install every skill?
 
-**No!** When you clone the repository, all skills are available, but your AI only loads them when you explicitly invoke them with `@skill-name`.
-It's like having a library - all books are there, but you only read the ones you need.
-**Pro Tip:** Use [Starter Packs](bundles.md) to focus on the skills that match your role first.
+**No.** With AAS Core, ask the agent to recommend a small stack that matches your project, target, goals, and risk policy. On a broad direct install, all skills may be present locally while the host loads only the skills it invokes.
+
+Use [Starter Packs](bundles.md) as human-curated presets when you want a fixed starting point.
 
 If you want a narrower install surface for **Claude Code** or **Codex**, use the new plugin distributions documented in [plugins.md](plugins.md) instead of the full library install.
 
@@ -31,12 +47,13 @@ Start from:
 - [bundles.md](bundles.md)
 - [workflows.md](workflows.md)
 
-### What is the difference between skills and MCP tools?
+### What is the difference between skills, AAS MCP, and the CLI?
 
 - **Skills** are reusable `SKILL.md` playbooks that guide an AI assistant through a workflow.
-- **MCP tools** are integrations or callable capabilities that let the assistant interact with external systems.
+- **AAS MCP** is the local, read-only discovery and composition interface to AAS Core. It searches and inspects the verified catalog, recommends a stack, and checks or compares manifests.
+- **The `aas` CLI** manages explicit lifecycle operations such as catalog status/update, MCP configuration, stack validation, planning, and diagnostics.
 
-Use skills when you want better process, structure, and execution quality. Use MCP tools when you need access to APIs, services, databases, or other systems. Use both when you want reliable workflows plus external capabilities.
+Other MCP servers may grant access to APIs, services, databases, or hosted systems. AAS MCP has a narrower boundary: it does not install, apply, update catalogs, scan repositories, or modify configuration through tool calls.
 
 For the longer explanation, read [skills-vs-mcp-tools.md](skills-vs-mcp-tools.md).
 
@@ -117,6 +134,12 @@ _Always check the Risk label and review the code._
 ---
 
 ## Installation & Setup
+
+### How do I start with AAS Core?
+
+Use the pinned `aas` binary to preview and approve local MCP configuration for Codex or Claude, restart the host if needed, then ask the agent to recommend and explain a stack without applying it. The full commands and trust boundaries are in [AAS Core](aas-core.md).
+
+The package publishes separate `agentic-awesome-skills`, `aas`, and `aas-mcp` binaries. Use the explicit `aas` binary for Core lifecycle commands; the legacy `agentic-awesome-skills` entrypoint remains the direct installer.
 
 ### Where should I install the skills?
 
@@ -355,9 +378,13 @@ Examples:
 
 ### How do I know which skill to use?
 
+With AAS Core, describe the project outcome and constraints, then ask the agent to call `recommend_stack`. Review its coverage, evidence, exclusions, discovery candidates, and unknowns before accepting the proposed IDs.
+
+For manual discovery:
+
 1. **Browse the catalog**: Check the [Skill Catalog](../../CATALOG.md).
-2. **Search**: `ls skills/ | grep "keyword"`
-3. **Ask your AI**: "What skills do you have for testing?"
+2. **Search**: `ls skills/ | grep "keyword"`.
+3. **Use a preset**: Start from [Bundles](bundles.md).
 
 ---
 

--- a/docs/users/getting-started.md
+++ b/docs/users/getting-started.md
@@ -1,8 +1,21 @@
 # Getting Started with Agentic Awesome Skills (V14.6.0)
 
-**New here? This guide will help you supercharge your AI Agent in 5 minutes.**
+**New here? Start with AAS Core and let your agent compose a small, reviewable skill stack for the project.**
 
-> **💡 Confused about what to do after installation?** Check out the [**Complete Usage Guide**](usage.md) for detailed explanations and examples!
+> **Preview status:** AAS Agent-First Preview supports local, explainable stack composition with Codex and Claude. Full-catalog recommendation quality and transactional apply/recovery safety are not yet certified.
+
+## Start with AAS Core
+
+AAS Core is the primary product path. Codex or Claude inspects your project, calls the local read-only AAS MCP, explains a deterministic catalog recommendation, and proposes an `aas-stack.json`. You review the exact policy and skill IDs before using the `aas` CLI to validate the manifest and preview a plan.
+
+```text
+project -> agent -> local AAS MCP -> recommendation -> aas-stack.json
+        -> human review -> validate -> plan preview
+```
+
+Start with the canonical [AAS Core guide](aas-core.md) to configure the MCP and run that flow. The direct installer, plugins, bundles, and manual skill invocation described below remain useful alternatives, especially for hosts without a native AAS MCP adapter.
+
+> **Need more examples after setup?** Continue with the [Complete Usage Guide](usage.md).
 
 ---
 
@@ -15,16 +28,16 @@ AI Agents (like **Claude Code**, **Gemini**, **Cursor**) are smart, but they lac
 
 ---
 
-## Quick Start: The "Starter Packs"
+## Alternative: Direct Skills and Starter Packs
 
 Don't panic about the size of the repository. You don't need everything at once.
 We have curated **Starter Packs** to get you running immediately.
 
-You **install the full repo once** (npx or clone); Starter Packs are curated lists to help you **pick which skills to use** by role (e.g. Web Wizard, Hacker Pack)—they are not a different way to install.
+On the direct-install path, you install the library once (npx or clone); Starter Packs are curated lists to help you **pick which skills to use** by role (e.g. Web Wizard, Hacker Pack)—they are not a different way to install.
 
 If you prefer a marketplace-style install for **Claude Code** or **Codex**, use the new plugin distributions described in [plugins.md](plugins.md).
 
-### 1. Install the Repo
+### 1. Install Skills Directly
 
 **Option A — npx (easiest):**
 
@@ -154,7 +167,7 @@ For Claude Code, use:
 For Codex, this repository also ships a root plugin plus bundle plugins through the repo-local metadata described in [plugins.md](plugins.md).
 
 **Q: Do I need to install every skill?**
-A: You clone the whole repo once; your AI only _reads_ the skills you invoke (or that are relevant), so it stays lightweight. **Starter Packs** in [bundles.md](bundles.md) are curated lists to help you discover the right skills for your role—they don't change how you install.
+A: No. With AAS Core, ask the agent to recommend a small stack under an explicit policy. On the legacy direct-install path, you can install the broad library while the host reads only invoked or relevant skills. **Starter Packs** in [bundles.md](bundles.md) remain human-curated discovery aids.
 
 **Q: Can I make my own skills?**
 A: Yes! Use the **@skill-creator** skill to build your own.
@@ -186,6 +199,7 @@ Need a tool-specific starting point first?
 - [Codex CLI skills](codex-cli-skills.md)
 - [Gemini CLI skills](gemini-cli-skills.md)
 
-1. [Browse the Bundles](bundles.md)
-2. [See Real-World Examples](../contributors/examples.md)
-3. [Contribute a Skill](../../CONTRIBUTING.md)
+1. [Configure and use AAS Core](aas-core.md)
+2. [Browse the Bundles](bundles.md)
+3. [See Real-World Examples](../contributors/examples.md)
+4. [Contribute a Skill](../../CONTRIBUTING.md)

--- a/docs/users/plugins.md
+++ b/docs/users/plugins.md
@@ -2,7 +2,7 @@
 
 Release `9.0.0` adds first-class plugin distributions for both **Claude Code** and **Codex**.
 
-This page is the canonical explanation of what those plugins are, how they differ from a full library install, and why the repository now ships both a **root plugin** and multiple **specialized plugins**.
+This page explains how plugins fit beneath **AAS Core**, the recommended orchestration layer for Codex and Claude Code. Plugins and direct installs deliver skill payloads; Core helps an agent discover, recommend, inspect, validate, and plan a minimal stack before delivery.
 
 ## What a plugin is in this repo
 
@@ -17,9 +17,13 @@ Plugins are useful when you want:
 
 Plugins are **not** different content formats. They still ship `SKILL.md` playbooks. The difference is the packaging, install surface, and filtering.
 
-## Full library install vs plugin install
+## Core orchestration vs delivery surfaces
 
-You now have two valid ways to use this repository with Claude Code or Codex.
+For Codex and Claude Code, start with [AAS Core](aas-core.md) when you want the agent to choose from catalog evidence. Core exposes read-only local MCP tools and keeps validation, planning, and approved changes in the CLI.
+
+Once the desired stack is clear, plugins and direct installs are two supported delivery surfaces. They do not replace Core and Core is not another plugin bundle.
+
+## Full library install vs plugin install
 
 ### Full library install
 
@@ -132,6 +136,13 @@ Bundle-specific Codex plugins are generated alongside the root plugin so you can
 
 ## Which path should you choose?
 
+Choose **AAS Core first** if:
+
+- you want Codex or Claude Code to search and inspect the local catalog
+- you want a deterministic recommendation instead of manually browsing thousands of skills
+- you want a reviewable `aas-stack.json` and preview plan before any change
+- you want read-only MCP discovery separated from approval-gated CLI operations
+
 Choose the **full library** if:
 
 - you want the biggest catalog
@@ -155,6 +166,7 @@ The hosted [specialized plugin landing page](https://sickn33.github.io/agentic-a
 
 ## Related guides
 
+- [AAS Core](aas-core.md)
 - [Getting Started](getting-started.md)
 - [FAQ](faq.md)
 - [Claude Code skills](claude-code-skills.md)

--- a/docs/users/skills-vs-mcp-tools.md
+++ b/docs/users/skills-vs-mcp-tools.md
@@ -1,89 +1,108 @@
-# Skills vs MCP Tools
+# Skills, AAS MCP, and Other MCP Tools
 
-If you are trying to understand the difference between **Antigravity skills** and **MCP tools**, the short version is:
+The short version is:
 
 - **Skills** are reusable `SKILL.md` playbooks that tell an AI assistant how to execute a workflow.
-- **MCP tools** are integrations or callable capabilities that let the assistant interact with external systems.
+- **AAS MCP** is the local, read-only interface through which an agent searches the verified AAS catalog, inspects evidence, and composes a proposed stack.
+- **Other MCP tools** connect an assistant to external systems such as APIs, databases, browsers, or hosted services.
+- **The `aas` CLI** validates durable stack intent and previews exact lifecycle operations under human control.
 
-The two are complementary, not competing.
+These surfaces are complementary. AAS Core connects them around the approved `aas-stack.json` manifest.
 
 ## What a skill does
 
 A skill gives the model better instructions for a repeated task such as:
 
-- planning a feature
-- reviewing code
-- running a security audit
-- writing a README
-- debugging a failing test suite
+- planning a feature;
+- reviewing code;
+- running a security audit;
+- writing a README;
+- debugging a failing test suite.
 
-In practice, a skill improves the assistant's decision-making, structure, and process for a task.
+In practice, a skill improves the assistant's decision-making, structure, and process. It remains content, not an executable capability or a grant of authority.
 
-Example:
+Examples:
 
 - `@brainstorming` helps the model clarify requirements before implementation.
-- `@lint-and-validate` helps the model run the right quality checks before claiming success.
+- `@lint-and-validate` helps the model run appropriate quality checks before claiming success.
 
-## What an MCP tool does
+## What AAS MCP does
 
-An MCP tool gives the model a capability it would not otherwise have, such as:
+AAS MCP is part of this repository's product, not an unrelated external integration. Codex or Claude uses it to call the same deterministic AAS Core that powers the CLI projections.
 
-- reading from a database
-- calling GitHub APIs
-- fetching docs from a service
-- creating calendar events
-- querying an external system
+It exposes exactly:
 
-In practice, an MCP tool expands what the assistant can do in the world.
+- `search_skills`;
+- `get_skill`;
+- `recommend_stack`;
+- `inspect_stack`;
+- `diff_stack`;
+- the `aas://skills/{id}` resource template.
+
+The agent inspects the project using its normal local capabilities and sends AAS an explicit, allowlisted profile. AAS MCP does not scan the repository itself. It returns structured factors, evidence, coverage, exclusions, discovery candidates, and unknowns from a bundled or verified local catalog.
+
+AAS MCP is local stdio, process-per-session, read-only, offline-capable, and contains no model credentials or telemetry. Its tool calls do not install or remove skills, apply a stack, update catalogs, or edit host configuration.
+
+## What other MCP tools do
+
+An external MCP tool may give the model a capability it would not otherwise have, such as:
+
+- reading from a database;
+- calling GitHub APIs;
+- fetching documentation from a service;
+- creating calendar events;
+- querying or changing another system.
+
+Those tools expand what the assistant can do in the world. Their permissions, network behavior, and write boundaries depend on each server. They are different from the deliberately narrow AAS MCP catalog/composition boundary.
+
+## What the CLI does
+
+The `aas` CLI is the explicit operational interface for:
+
+- catalog status and updates;
+- MCP configuration;
+- stack initialization and deterministic recommendation from an explicit profile;
+- manifest validation;
+- plan creation and read-only diagnostics.
+
+The durable artifact is `aas-stack.json`, which pins catalog identity, targets, intent, policy, and exact skill IDs. The agent may propose it; the user reviews it. `stack validate` checks it, and `stack plan` creates an immutable preview bound to the observed managed state and exact operations.
+
+`stack apply` and `stack recover` exist only for controlled preview development. They are experimental, disabled by default, and are not supported or certified preview safety claims.
 
 ## The easiest mental model
 
-Use this rule:
+- **Skills provide the operating guidance.**
+- **AAS MCP helps the agent select and explain the right guidance.**
+- **`aas-stack.json` records what the user approved.**
+- **The CLI validates and previews the lifecycle.**
+- **Other MCP servers provide access to outside systems.**
 
-- **Skills tell the assistant how to work.**
-- **MCP tools tell the assistant what systems it can touch.**
+## Which path should you start with?
 
-If you only install tools, the assistant may have access but still behave inconsistently.
+Start with **AAS Core** when:
 
-If you only install skills, the assistant may know the workflow but still lack the capability to reach the external system it needs.
+- you use Codex or Claude with local MCP support;
+- you want the agent to compose a small stack from project evidence;
+- you need explicit risk/source/setup policy and a reproducible manifest;
+- you want a reviewable plan before any skill changes.
 
-Together, they are much stronger.
+Start with a **direct skill or specialized plugin** when:
 
-## Which one should you start with?
+- the host does not yet have a native AAS MCP configuration adapter;
+- you already know the exact skill or fixed domain pack you want;
+- you prefer manual invocation without a managed stack lifecycle.
 
-Start with **skills** if:
+Add **other MCP tools** when the work needs live access to APIs, services, databases, or hosted platforms. A stack can contain skills that guide those integrations without granting the external permissions itself.
 
-- you want better planning, coding, debugging, testing, or review behavior immediately
-- you are working mostly in local files and terminal flows
-- you want reusable playbooks before adding more integrations
+## Preview limits
 
-Start with **MCP tools** if:
-
-- your main blocker is access to external systems
-- you need the model to call APIs, query services, or interact with hosted platforms
-- you already like the model's workflow quality, but need more reach
-
-Use **both** when:
-
-- you want reliable workflows plus external capabilities
-- you are building agent systems, internal tooling, or multi-step operational flows
-
-## How this repo fits in
-
-Agentic Awesome Skills is primarily a **skill library**:
-
-- installable `SKILL.md` playbooks
-- bundles for role-based starting points
-- workflows for ordered execution patterns
-- tool-specific guides for Claude Code, Cursor, Codex CLI, Gemini CLI, and others
-
-Many skills in this repo also explain how to work with MCP, APIs, and other integrations, but the repository itself is centered on reusable workflow guidance rather than acting as an MCP server.
+AAS Agent-First Preview helps Codex and Claude compose a local, explainable, reproducible skill stack. It does not claim certified full-catalog recommendation quality or transactional apply/recovery safety. Missing evidence is reported as `unknown`, and AAS may leave a goal uncovered rather than present a weak recommendation as certainty.
 
 ## Good next reads
 
+- [AAS Core](aas-core.md)
+- [Getting Started](getting-started.md)
 - [FAQ](faq.md)
 - [Bundles](bundles.md)
 - [Workflows](workflows.md)
-- [AI Agent Skills](ai-agent-skills.md)
-- [Codex CLI Skills](codex-cli-skills.md)
-- [Gemini CLI Skills](gemini-cli-skills.md)
+- [Plugins for Claude Code and Codex](plugins.md)

--- a/docs/users/usage.md
+++ b/docs/users/usage.md
@@ -1,14 +1,29 @@
-# Usage Guide: How to Actually Use These Skills
+# Usage Guide: Compose and Use an AAS Skill Stack
 
-> **Confused after installation?** This guide walks you through exactly what to do next, step by step.
+> **Recommended path:** let Codex or Claude use AAS Core to compose a small, policy-controlled stack. Direct installs and manual skill invocation remain supported alternatives.
+
+## Primary workflow: agent-first composition
+
+After configuring the local AAS MCP, ask your agent to inspect the repository and recommend a stack for the outcome you want:
+
+```text
+Inspect this repository and use the AAS MCP tools to recommend a small skill stack.
+Explain evidence, exclusions, and unknowns; propose an aas-stack.json; do not apply it.
+```
+
+The agent should use `search_skills`, `get_skill`, and `recommend_stack`, then check the proposal with `inspect_stack`. Review the resulting `aas-stack.json`, validate it with `aas stack validate`, and use `aas stack plan` to preview the exact operations without materializing skills or managed state in the target.
+
+The recommendation is deterministic and local. AAS MCP does not inspect the repository itself, install skills, update catalogs, or change configuration. See [AAS Core](aas-core.md) for setup, the exact tool boundary, CLI commands, and preview limitations.
+
+`stack apply` and `stack recover` are experimental, disabled by default, and are not supported or certified preview safety claims.
 
 ---
 
-## "I just installed the repository. Now what?"
+## Alternative workflow: direct skill installation
 
 Great question! Here's what just happened and what to do next:
 
-If you came in through a **Claude Code** or **Codex** plugin instead of a full library install, the mental model is the same: you still invoke individual skills in prompts. The main difference is that plugins ship the plugin-safe subset. See [plugins.md](plugins.md) for the install model.
+If you came in through a **Claude Code** or **Codex** plugin instead of AAS Core or a full library install, invoke individual skills in prompts. Plugins ship a fixed plugin-safe subset; AAS Core instead composes a project stack from the verified catalog and records it in `aas-stack.json`. See [plugins.md](plugins.md) for the distribution model.
 
 ### What You Just Did
 
@@ -22,7 +37,7 @@ Think of it like installing a toolbox. You have all the tools now, but you need 
 
 ---
 
-## Step 1: Understanding "Bundles" (Recommendations or Focused Installs)
+## Direct-install Step 1: Understanding Bundles
 
 **Common confusion:** "Do I need to download each skill separately?"
 
@@ -73,7 +88,7 @@ If you want only one bundle active at a time in Antigravity, use the activation 
 
 ---
 
-## Step 2: How to Actually Execute/Use a Skill
+## Direct-install Step 2: Invoke a Skill
 
 This is the part that should have been explained better! Here's how to use skills:
 
@@ -126,7 +141,7 @@ Use @brainstorming to plan this feature
 
 ---
 
-## Step 3: What Should My Prompts Look Like?
+## Direct-install Step 3: Write a Focused Prompt
 
 Here are **real-world examples** of good prompts:
 
@@ -182,7 +197,7 @@ Here are **real-world examples** of good prompts:
 
 ---
 
-## Step 4: Your First Skill (Hands-On Tutorial)
+## Direct-install Step 4: Your First Skill
 
 Let's actually use a skill right now. Follow these steps:
 
@@ -210,7 +225,7 @@ Let's actually use a skill right now. Follow these steps:
 
 ---
 
-## Step 5: Picking Your First Skills (Practical Advice)
+## Direct-install Step 5: Pick Skills Manually
 
 Don't try to use all 1,965+ skills at once. Here's a sensible approach:
 
@@ -327,7 +342,7 @@ AI: [Creates tests, sets up CI/CD, deploys to Vercel]
 
 ### "Can I see all available skills?"
 
-Yes! Three ways:
+Yes. With AAS Core, ask the agent to call `search_skills` and inspect candidates with `get_skill`. On a direct install, you can also:
 
 1. Browse [CATALOG.md](../../CATALOG.md) (searchable list)
 2. Run `ls ~/.agents/skills/` (or your actual install path)
@@ -394,7 +409,13 @@ Use @skill-creator to help me build a custom skill for [your task]
 
 ## Next Steps
 
-Now that you understand how to use skills:
+For the Core-first path:
+
+1. Configure the local MCP with the [AAS Core guide](aas-core.md).
+2. Ask the agent to recommend and explain a small stack.
+3. Review `aas-stack.json`, validate it, and preview the plan.
+
+For direct/manual use:
 
 1. ✅ **Try one skill right now** - Start with `@brainstorming` on any idea you have
 2. 📚 **Pick 3-5 skills** from your role's bundle in [bundles.md](bundles.md)

--- a/docs/vietnamese/AAS_CORE.vi.md
+++ b/docs/vietnamese/AAS_CORE.vi.md
@@ -1,0 +1,26 @@
+# AAS Core
+
+**AAS Core** là lớp điều khiển cục bộ, ưu tiên agent được khuyến nghị cho Agentic Awesome Skills. Core cho phép Codex hoặc Claude Code tìm kiếm và kiểm tra catalog cục bộ đã xác minh, tạo đề xuất stack tối thiểu theo quy tắc xác định, rồi trình bày `aas-stack.json` và kế hoạch CLI để người dùng xem trước khi có bất kỳ thay đổi nào.
+
+## Luồng sử dụng
+
+1. Dùng AAS CLI chính thức để cấu hình MCP stdio cục bộ cho Codex hoặc Claude Code.
+2. Cho phép agent gọi `search_skills`, `get_skill` và `recommend_stack`; chỉ dùng `inspect_stack` hoặc `diff_stack` khi cần.
+3. Xem lại tệp `aas-stack.json` do agent đề xuất.
+4. Dùng AAS CLI để xác thực manifest và xem trước kế hoạch chính xác.
+5. Dừng lại sau khi xem kế hoạch; chỉ nghiên cứu các giai đoạn sau nếu bạn chủ động tham gia phát triển preview có kiểm soát.
+
+## Ranh giới tin cậy
+
+- AAS MCP chạy cục bộ và chỉ đọc; MCP không cài đặt, xóa, áp dụng hay cập nhật nội dung.
+- Đề xuất dựa trên quy tắc xác định và bằng chứng trong catalog, không dựa trên một lệnh gọi mô hình ẩn khác.
+- `validate` và `plan` là luồng preview hiện được ghi nhận. `apply` và `recover` bị tắt theo mặc định và chưa phải là cam kết an toàn đã được chứng nhận.
+- Danh tính catalog và runtime được xác minh cục bộ. Theo mặc định, dữ liệu dự án không được gửi tới dịch vụ AAS.
+
+## Quan hệ với plugin và cài đặt trực tiếp
+
+AAS Core là lớp điều phối và ra quyết định. Plugin, plugin chuyên biệt và bản cài đặt thư viện đầy đủ vẫn là các cách phân phối nội dung skill. Với Codex và Claude Code, nên dùng Core để xác định stack tối thiểu trước, rồi mới chọn cách phân phối phù hợp.
+
+Các công cụ chưa có adapter AAS Core vẫn có thể dùng cách cài đặt trực tiếp, plugin hoặc tích hợp manifest tùy chỉnh.
+
+Xem [`docs/users/aas-core.md`](../users/aas-core.md) để biết các lệnh tiếng Anh và yêu cầu cấu hình hiện tại.

--- a/docs/vietnamese/README.vi.md
+++ b/docs/vietnamese/README.vi.md
@@ -2,6 +2,8 @@
 
 > **Thư viện GitHub có thể cài đặt gồm hơn 1,936 kỹ năng agentic cho Claude Code, Cursor, Codex CLI, Gemini CLI, Antigravity và các trợ lý lập trình AI khác.**
 
+> **Lối vào được khuyến nghị — AAS Core:** Với Codex và Claude Code, hãy dùng AAS MCP cục bộ, chỉ đọc để tìm kiếm catalog và nhận đề xuất stack tối thiểu theo quy tắc xác định. Xem lại `aas-stack.json` và kế hoạch CLI; luồng preview hiện được ghi nhận dừng sau bước xem kế hoạch. [Tìm hiểu AAS Core](AAS_CORE.vi.md).
+
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![Claude Code](https://img.shields.io/badge/Claude%20Code-Anthropic-purple)](https://claude.ai)
 [![Gemini CLI](https://img.shields.io/badge/Gemini%20CLI-Google-blue)](https://github.com/google-gemini/gemini-cli)

--- a/docs_zh-CN/README.md
+++ b/docs_zh-CN/README.md
@@ -5,7 +5,9 @@
 
 Agentic Awesome Skills 是一个 GitHub 仓库和安装器 CLI，提供可复用的 `SKILL.md` 剧本。与其收集随机提示词，你可以获得一个可搜索、可安装的技能库，涵盖规划、编码、调试、测试、安全审查、基础设施工作、产品工作流和成长任务，支持主流 AI 编码助手。
 
-**从这里开始：** [为仓库加星](https://github.com/sickn33/agentic-awesome-skills/stargazers) · [1 分钟安装](#installation) · [选择你的工具](#choose-your-tool) · [按工具查看最佳技能](#best-skills-by-tool) · [捆绑包](users/bundles.md) · [工作流](users/workflows.md)
+> **推荐入口 — AAS Core：** 对于 Codex 和 Claude Code，请先使用本地、只读的 AAS MCP 搜索目录并获得确定性的最小技能栈建议，然后检查 `aas-stack.json` 和 CLI 预览计划。当前有文档支持的预览路径在检查计划后停止。[了解 AAS Core](users/aas-core.md)。
+
+**从这里开始：** [AAS Core](users/aas-core.md) · [为仓库加星](https://github.com/sickn33/agentic-awesome-skills/stargazers) · [1 分钟安装](#installation) · [选择你的工具](#choose-your-tool) · [按工具查看最佳技能](#best-skills-by-tool) · [捆绑包](users/bundles.md) · [工作流](users/workflows.md)
 
 [![GitHub stars](https://img.shields.io/badge/⭐%2035%2C000%2B%20Stars-gold?style=for-the-badge)](https://github.com/sickn33/agentic-awesome-skills/stargazers)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](../LICENSE)

--- a/docs_zh-CN/users/aas-core.md
+++ b/docs_zh-CN/users/aas-core.md
@@ -1,0 +1,26 @@
+# AAS Core
+
+**AAS Core** 是 Agentic Awesome Skills 推荐的本地、代理优先控制层。它让 Codex 或 Claude Code 根据经过验证的本地目录搜索和检查技能、生成确定性的最小技能栈建议，并在任何变更发生前提供可审查的 `aas-stack.json` 和 CLI 计划。
+
+## 工作流程
+
+1. 使用官方 AAS CLI 为 Codex 或 Claude Code 配置本地 stdio MCP。
+2. 让代理调用 `search_skills`、`get_skill` 和 `recommend_stack`；需要时再调用 `inspect_stack` 或 `diff_stack`。
+3. 检查代理提出的 `aas-stack.json`。
+4. 使用 AAS CLI 验证清单并预览精确计划。
+5. 检查计划后停止；只有在您明确参与受控预览开发时，才继续研究后续阶段。
+
+## 信任边界
+
+- AAS MCP 在本地运行，并且只提供读取功能；它不会安装、删除、应用或更新任何内容。
+- 建议来自确定性规则和目录证据，而不是另一次隐藏的模型调用。
+- `validate` 和 `plan` 是当前有文档支持的预览路径。`apply` 和 `recover` 默认禁用，不属于已经认证的预览安全声明。
+- 目录和运行时身份在本地验证。默认情况下，项目数据不会发送到 AAS 服务。
+
+## 与插件和直接安装的关系
+
+AAS Core 是编排和决策层。插件、专用插件包和完整技能库安装仍然是技能内容的交付方式。对于 Codex 和 Claude Code，建议先使用 Core 确定最小技能栈，再选择适当的交付方式。
+
+尚未提供 Core 主机适配器的工具仍可使用传统的直接安装、插件或自定义清单集成。
+
+完整的英文命令和当前配置要求请参阅 [`docs/users/aas-core.md`](../../docs/users/aas-core.md)。

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "agentic-awesome-skills",
   "version": "14.6.0",
-  "description": "1,965+ agentic skills for Claude Code, Gemini CLI, Cursor, Antigravity & more. Installer CLI.",
+  "description": "AAS Core preview: local skill discovery, recommendation, stack validation, and planning, backed by 1,965+ agentic skills.",
   "license": "MIT",
   "scripts": {
     "validate": "node tools/scripts/run-python.js tools/scripts/validate_skills.py",
@@ -120,6 +120,10 @@
     "tools/lib"
   ],
   "keywords": [
+    "aas-core",
+    "mcp",
+    "skill-recommendation",
+    "agent-stack",
     "claude-code",
     "cursor",
     "gemini-cli",

--- a/tools/scripts/audit_consistency.py
+++ b/tools/scripts/audit_consistency.py
@@ -22,8 +22,8 @@ def _read_json(path: Path):
 
 def _package_expected_description(metadata: dict) -> str:
     return (
-        f"{metadata['total_skills_label']} agentic skills for Claude Code, Gemini CLI, "
-        "Cursor, Antigravity & more. Installer CLI."
+        "AAS Core preview: local skill discovery, recommendation, stack validation, and planning, "
+        f"backed by {metadata['total_skills_label']} agentic skills."
     )
 
 

--- a/tools/scripts/sync_repo_metadata.py
+++ b/tools/scripts/sync_repo_metadata.py
@@ -37,7 +37,7 @@ RECOMMENDED_TOPICS = [
     "mcp",
 ]
 README_TAGLINE_RE = re.compile(
-    r"^> \*\*Installable GitHub library of \d[\d,]*\+ agentic skills for Claude Code, Cursor, Codex CLI, (?:Autohand Code, )?Gemini CLI, Antigravity, and other AI coding assistants\.\*\*$",
+    r"^> \*\*(?:AAS Core is the local, agent-first control plane for composing explainable, reproducible skill stacks from a catalog of \d[\d,]*\+ agentic skills\.|Installable GitHub library of \d[\d,]*\+ agentic skills for Claude Code, Cursor, Codex CLI, (?:Autohand Code, )?Gemini CLI, Antigravity, and other AI coding assistants\.)\*\*$",
     re.MULTILINE,
 )
 README_RELEASE_RE = re.compile(r"^\*\*Current release: V[\d.]+\.\*\* .*?$", re.MULTILINE)
@@ -67,9 +67,9 @@ BUNDLES_FOOTER_RE = re.compile(
 
 def build_about_description(metadata: dict) -> str:
     return (
-        f"Installable GitHub library of {metadata['total_skills_label']} agentic skills for "
-        "Claude Code, Cursor, Codex CLI, Autohand Code, Gemini CLI, Antigravity, and more. "
-        "Includes specialized plugins, installer CLI, bundles, workflows, and official/community skill collections."
+        "AAS Core preview is the local, agent-first control plane for discovering, recommending, "
+        f"validating, and planning exact skill stacks, backed by {metadata['total_skills_label']} agentic skills. "
+        "Includes CLI, local MCP, catalog, plugins, and Workbench."
     )
 
 
@@ -132,21 +132,29 @@ def count_documented_bundles(content: str) -> int:
 
 
 def sync_readme_copy(content: str, metadata: dict) -> str:
-    star_celebration = metadata.get("star_celebration", "25k")
+    version = metadata["version"]
+    release_boundary = (
+        f"The published {version} package predates AAS Core. "
+        if version == "14.6.0"
+        else "This release includes AAS Core. "
+    )
     replacements = [
         (
             README_TAGLINE_RE,
             (
-                f"> **Installable GitHub library of {metadata['total_skills_label']} agentic skills "
-                "for Claude Code, Cursor, Codex CLI, Autohand Code, Gemini CLI, Antigravity, and other AI coding assistants.**"
+                "> **AAS Core is the local, agent-first control plane for composing explainable, "
+                f"reproducible skill stacks from a catalog of {metadata['total_skills_label']} agentic skills.**"
             ),
         ),
         (
             README_RELEASE_RE,
             (
-                f"**Current release: V{metadata['version']}.** Trusted by {star_celebration}+ GitHub stargazers, "
-                "this repository combines official and community skill collections with bundles, "
-                "workflows, installation paths, and docs that help you go from first install to daily use quickly."
+                f"**Current release: V{version}.** {release_boundary}Core is currently documented from `main` "
+                "under the **Agent-First Preview** claim: local search, recommendation, inspection, "
+                "manifest validation, planning, and diagnosis are the supported preview path. Wait for "
+                "a release that explicitly includes Core before using the npm bootstrap. Full-catalog "
+                "recommendation quality and transactional apply/recovery safety are not yet certified; "
+                "apply and recovery remain explicitly experimental."
             ),
         ),
         (
@@ -198,6 +206,8 @@ def sync_web_index_shell(content: str, metadata: dict) -> str:
         [
             (r"\d[\d,]*\+ installable agentic skills", f"{skill_label} installable agentic skills"),
             (r"\d[\d,]*\+ AI coding skills", f"{skill_label} AI coding skills"),
+            (r"backed by \d[\d,]*\+ skills", f"backed by {skill_label} skills"),
+            (r"\d[\d,]*\+ cataloged skills", f"{skill_label} cataloged skills"),
         ],
     )
 
@@ -211,6 +221,7 @@ def sync_llms_text(content: str, metadata: dict) -> str:
             (r"\d[\d,]*\+ agentic SKILL\.md playbooks", f"{skill_label} agentic SKILL.md playbooks"),
             (r"Skill count: \d[\d,]*\+\.", f"Skill count: {skill_label}."),
             (r"\d[\d,]*\+ reusable SKILL\.md playbooks", f"{skill_label} reusable SKILL.md playbooks"),
+            (r"\d[\d,]*\+ skill catalog", f"{skill_label} skill catalog"),
         ],
     )
 
@@ -371,8 +382,8 @@ def update_package_description(base_dir: str, metadata: dict, dry_run: bool) -> 
         content = file.read()
 
     new_description = (
-        f"{metadata['total_skills_label']} agentic skills for Claude Code, Gemini CLI, "
-        "Cursor, Antigravity & more. Installer CLI."
+        "AAS Core preview: local skill discovery, recommendation, stack validation, and planning, "
+        f"backed by {metadata['total_skills_label']} agentic skills."
     )
     updated_content = ABOUT_DESCRIPTION_RE.sub(
         f'"description": "{new_description}"', content, count=1

--- a/tools/scripts/tests/test_audit_consistency.py
+++ b/tools/scripts/tests/test_audit_consistency.py
@@ -56,7 +56,7 @@ class AuditConsistencyTests(unittest.TestCase):
                 {
                     "name": "agentic-awesome-skills",
                     "version": "8.4.0",
-                    "description": f"{count_label} agentic skills for Claude Code, Gemini CLI, Cursor, Antigravity & more. Installer CLI.",
+                    "description": f"AAS Core preview: local skill discovery, recommendation, stack validation, and planning, backed by {count_label} agentic skills.",
                 }
             ),
             encoding="utf-8",
@@ -68,13 +68,13 @@ class AuditConsistencyTests(unittest.TestCase):
         (root / "apps" / "web-app" / "public" / "skills.json").write_text(manifest, encoding="utf-8")
         (root / "README.md").write_text(
             f"""<!-- registry-sync: version=8.4.0; skills={total_skills}; stars=26132; updated_at=2026-03-21T00:00:00+00:00 -->
-# 🌌 Agentic Awesome Skills: {count_label} Agentic Skills for Claude Code, Gemini CLI, Cursor, Autohand Code, Copilot & More
+# 🌌 Agentic Awesome Skills: AAS Core + {count_label} Skills for AI Coding Agents
 
-> **Installable GitHub library of {count_label} agentic skills for Claude Code, Cursor, Codex CLI, Autohand Code, Gemini CLI, Antigravity, and other AI coding assistants.**
+> **AAS Core is the local, agent-first control plane for composing explainable, reproducible skill stacks from a catalog of {count_label} agentic skills.**
 
 [![GitHub stars](https://img.shields.io/badge/⭐%2026%2C000%2B%20Stars-gold?style=for-the-badge)](https://github.com/sickn33/agentic-awesome-skills/stargazers)
 
-**Current release: V8.4.0.** Trusted by 26k+ GitHub stargazers, this repository combines official and community skill collections with bundles, workflows, installation paths, and docs that help you go from first install to daily use quickly.
+**Current release: V8.4.0.** This release includes AAS Core. Core is currently documented from `main` under the **Agent-First Preview** claim: local search, recommendation, inspection, manifest validation, planning, and diagnosis are the supported preview path. Wait for a release that explicitly includes Core before using the npm bootstrap. Full-catalog recommendation quality and transactional apply/recovery safety are not yet certified; apply and recovery remain explicitly experimental.
 
 - **Broad coverage with real utility**: {count_label} skills across development, testing, security, infrastructure, product, and marketing.
 

--- a/tools/scripts/tests/test_sync_repo_metadata.py
+++ b/tools/scripts/tests/test_sync_repo_metadata.py
@@ -62,15 +62,15 @@ class SyncRepoMetadataTests(unittest.TestCase):
             (root / "apps" / "web-app" / "public").mkdir(parents=True)
 
             (root / "apps" / "web-app" / "index.html").write_text(
-                '<meta name="description" content="Explore 1,273+ installable agentic skills">\n'
-                '<title>Agentic Awesome Skills GitHub | 1,273+ AI coding skills</title>\n',
+                '<meta name="description" content="AAS Core preview backed by 1,273+ cataloged skills">\n'
+                '<title>AAS Core Preview | Agent-first stacks backed by 1,273+ skills</title>\n',
                 encoding="utf-8",
             )
             (root / "apps" / "web-app" / "public" / "llms.txt").write_text(
                 "> Installable GitHub library of 1,273+ agentic SKILL.md playbooks.\n"
                 "- Current release: V8.3.0.\n"
                 "- Skill count: 1,273+.\n"
-                "Agentic Awesome Skills is an installable library of 1,273+ reusable SKILL.md playbooks.\n",
+                "AAS Core preview is backed by the 1,273+ skill catalog.\n",
                 encoding="utf-8",
             )
 
@@ -132,12 +132,12 @@ class SyncRepoMetadataTests(unittest.TestCase):
             self.assertIn("1,304+ specialized areas", (root / "docs" / "users" / "kiro-integration.md").read_text(encoding="utf-8"))
             self.assertIn("Total Bundles: 2", (root / "docs" / "users" / "bundles.md").read_text(encoding="utf-8"))
             web_index = (root / "apps" / "web-app" / "index.html").read_text(encoding="utf-8")
-            self.assertIn("1,304+ installable agentic skills", web_index)
-            self.assertIn("1,304+ AI coding skills", web_index)
+            self.assertIn("1,304+ cataloged skills", web_index)
+            self.assertIn("backed by 1,304+ skills", web_index)
             llms_text = (root / "apps" / "web-app" / "public" / "llms.txt").read_text(encoding="utf-8")
             self.assertIn("Current release: V8.4.0.", llms_text)
             self.assertIn("Skill count: 1,304+.", llms_text)
-            self.assertIn("1,304+ reusable SKILL.md playbooks", llms_text)
+            self.assertIn("1,304+ skill catalog", llms_text)
             jetski_cortex = (root / "docs" / "integrations" / "jetski-cortex.md").read_text(encoding="utf-8")
             self.assertIn("1,304+ skill", jetski_cortex)
             self.assertNotIn("1,1", jetski_cortex)
@@ -148,8 +148,9 @@ class SyncRepoMetadataTests(unittest.TestCase):
                 "total_skills_label": "1,304+",
             }
         )
+        self.assertIn("AAS Core preview", description)
         self.assertIn("1,304+ agentic skills", description)
-        self.assertIn("installer CLI", description)
+        self.assertIn("local MCP", description)
 
     def test_sync_github_about_builds_expected_commands(self):
         calls = []

--- a/tools/scripts/update_readme.py
+++ b/tools/scripts/update_readme.py
@@ -180,6 +180,11 @@ def apply_metadata(content: str, metadata: dict) -> str:
     star_badge_count = metadata["star_badge_count"]
     star_milestone = metadata["star_milestone"]
     star_celebration = metadata["star_celebration"]
+    release_boundary = (
+        f"The published {version} package predates AAS Core. "
+        if version == "14.6.0"
+        else "This release includes AAS Core. "
+    )
     sync_comment = (
         f"<!-- registry-sync: version={version}; skills={total_skills}; "
         f"stars={metadata['stars']}; updated_at={metadata['updated_at']} -->"
@@ -188,8 +193,7 @@ def apply_metadata(content: str, metadata: dict) -> str:
     content = re.sub(
         r"^# 🌌 Agentic Awesome Skills: .*?$",
         (
-            f"# 🌌 Agentic Awesome Skills: {total_skills_label} "
-            "Agentic Skills for Claude Code, Gemini CLI, Cursor, Autohand Code, Copilot & More"
+            f"# 🌌 Agentic Awesome Skills: AAS Core + {total_skills_label} Skills for AI Coding Agents"
         ),
         content,
         count=1,
@@ -215,9 +219,13 @@ def apply_metadata(content: str, metadata: dict) -> str:
     content = re.sub(
         CURRENT_RELEASE_LINE_RE,
         (
-            f"**Current release: V{version}.** Trusted by {star_celebration}+ GitHub stargazers, "
-            "this repository combines official and community skill collections with bundles, "
-            "workflows, installation paths, and docs that help you go from first install to daily use quickly."
+            f"**Current release: V{version}.** {release_boundary}Core is currently documented from "
+            "`main` under the **Agent-First Preview** claim: "
+            "local search, recommendation, inspection, manifest validation, planning, and diagnosis "
+            "are the supported preview path. Wait for a release that explicitly includes Core before "
+            "using the npm bootstrap. Full-catalog "
+            "recommendation quality and transactional apply/recovery safety are not yet certified; "
+            "apply and recovery remain explicitly experimental."
         ),
         content,
         count=1,


### PR DESCRIPTION
# Pull Request Description

Reframes the repository around AAS Core as the primary agent-first product while preserving the existing skill library, direct installers, plugins, bundles, workflows, contributor guidance, governance, community, credits, and compatibility surfaces.

Adds a canonical AAS Core guide and concise localized entry points, aligns Codex/Claude and integration docs, updates Workbench/catalog/SEO narrative, and hardens the metadata generators and tests so later synchronization preserves the Core-first positioning.

The copy keeps the current release boundary explicit: published 14.6.0 predates AAS Core, and apply/recovery remain experimental rather than part of the supported preview claim.

## Change Classification

- [ ] Skill PR
- [x] Docs PR
- [x] Infra PR

## Issue Link (Optional)

None.

## Quality Bar Checklist ✅

**All applicable items are checked; skill-only items are not applicable because no `SKILL.md` changed.**

- [x] **Standards**: I have read `docs/contributors/quality-bar.md` and `docs/contributors/security-guardrails.md`.
- [ ] **Metadata**: Not applicable; no `SKILL.md` changed.
- [ ] **Risk Label**: Not applicable; no skill changed.
- [ ] **Triggers**: Not applicable; no skill changed.
- [ ] **Limitations**: Not applicable; no skill changed.
- [ ] **Security**: Not applicable; no offensive skill changed.
- [x] **Safety scan**: `npm run security:docs` passed.
- [ ] **Automated Skill Review**: Not applicable; no `SKILL.md` changed.
- [x] **Manual Logic Review**: Core trust boundaries, release claims, write boundaries, and preview limitations were manually reviewed.
- [x] **Local Test**: Full repository suite and web application tests/build passed locally.
- [x] **Repo Checks**: `npm run validate:references` passed.
- [x] **Source-Only PR**: No generated registry artifacts (`CATALOG.md`, `skills_index.json`, `data/*.json`) are included.
- [ ] **Credits**: Not applicable; no external source was added.
- [ ] **License provenance**: Not applicable; no external skill source was added.
- [x] **Maintainer Edits**: Enabled by repository defaults.

## Validation

- `npm run validate`
- `npm run validate:references`
- `npm run security:docs`
- `npm run check:warning-budget`
- `npm run audit:consistency`
- `npm run test`
- `npm run app:test:coverage` (152 tests)
- `npm run app:build`
- metadata synchronization idempotence check

## Screenshots (if applicable)

Not included; copy and metadata changes are covered by web tests and the production prerender build.
