### PR TITLE
fix: make Core npm onboarding release-safe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Made the future AAS Core npm onboarding release-safe by linking the published README to the canonical Core guide and deriving the plan runtime version from the manifest catalog identity instead of hardcoding a release number.
 - Added the current Bing Webmaster verification identity and updated the legacy Pages redirect generator contract to cover the expanded 187-route sitemap.
 - Expanded the legacy Pages bridge to every one of the 1,965 current catalog skills plus seven structural routes, while keeping crawler discovery limited to the curated 187-route sitemap and making migration-readiness checks enforce the same exact catalog coverage.
 - Corrected public Workbench copy that implied browser-side install-command generation; Workbench reviews user-supplied Core stack and plan artifacts without filesystem access or installation.

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ For Codex and Claude, the primary path is agent-first composition through AAS Co
 
 The canonical project page is the GitHub repository at <https://github.com/sickn33/agentic-awesome-skills>; the hosted catalog is a companion discovery surface, and Workbench is a browser-local review surface for Core stack and plan artifacts. Neither is a hosted control plane.
 
-**Start here:** [Understand AAS Core](#aas-core-agent-first-preview) · [Core guide](docs/users/aas-core.md) · [Review a stack or plan](https://sickn33.github.io/agentic-awesome-skills/workbench) · [Direct installs](#installation) · [Choose your tool](#choose-your-tool) · [Browse 1,965+ Skills](#browse-1965-skills) · [Contribute](#contributing)
+**Start here:** [Understand AAS Core](#aas-core-agent-first-preview) · [Core guide](https://github.com/sickn33/agentic-awesome-skills/blob/main/docs/users/aas-core.md) · [Review a stack or plan](https://sickn33.github.io/agentic-awesome-skills/workbench) · [Direct installs](#installation) · [Choose your tool](#choose-your-tool) · [Browse 1,965+ Skills](#browse-1965-skills) · [Contribute](#contributing)
 
 [![GitHub stars](https://img.shields.io/badge/⭐%2043%2C000%2B%20Stars-gold?style=for-the-badge)](https://github.com/sickn33/agentic-awesome-skills/stargazers)
 [![Follow @AASkills_ on X](https://img.shields.io/badge/Follow-%40AASkills__-black?style=for-the-badge&logo=x)](https://x.com/AASkills_)
@@ -55,7 +55,7 @@ AAS Core gives the repository one product model:
 - **Review in Workbench.** The hosted Workbench imports and reviews stack/plan JSON in browser memory; it does not access your filesystem or install anything.
 - **Retain every useful distribution path.** Direct installs, plugins, bundles, workflows, and the full catalog remain available as payload and compatibility surfaces.
 
-Read the [AAS Core guide](docs/users/aas-core.md) for the exact trust boundaries, current preview status, Codex/Claude setup model, and CLI lifecycle.
+Read the [AAS Core guide](https://github.com/sickn33/agentic-awesome-skills/blob/main/docs/users/aas-core.md) for the exact trust boundaries, current preview status, Codex/Claude setup model, and CLI lifecycle.
 
 ## Why This Repo
 
@@ -91,7 +91,7 @@ Read the [AAS Core guide](docs/users/aas-core.md) for the exact trust boundaries
 
 ## Installation
 
-For Codex and Claude, start with the [AAS Core guide](docs/users/aas-core.md): configure the local MCP through the explicit preview flow, ask the agent for a recommendation, review the proposed `aas-stack.json`, then run CLI validation and planning. The MCP is read-only; no skill or project write happens during search, recommendation, inspection, validation, or planning.
+For Codex and Claude, start with the [AAS Core guide](https://github.com/sickn33/agentic-awesome-skills/blob/main/docs/users/aas-core.md): configure the local MCP through the explicit preview flow, ask the agent for a recommendation, review the proposed `aas-stack.json`, then run CLI validation and planning. The MCP is read-only; no skill or project write happens during search, recommendation, inspection, validation, or planning.
 
 Use direct installation when your host does not yet have a native AAS Core adapter, when you already know the exact skill IDs, or when you deliberately prefer manual selection:
 
@@ -320,7 +320,7 @@ Use the root repo as a landing page, then jump into the deeper surface that matc
 Keep the root README short; use the dedicated docs for recovery and platform-specific guidance.
 
 - If you are confused after installation, start with the [Usage Guide](docs/users/usage.md).
-- For Core setup, trust boundaries, stack manifests, and preview status, use the [AAS Core guide](docs/users/aas-core.md).
+- For Core setup, trust boundaries, stack manifests, and preview status, use the [AAS Core guide](https://github.com/sickn33/agentic-awesome-skills/blob/main/docs/users/aas-core.md).
 - If you integrate agentic-awesome-skills into a host, read the discovery contract first: [Stable Skills Manifest v1](docs/users/discovery-manifest.md).
 - For Windows truncation or context crash loops, use [docs/users/windows-truncation-recovery.md](docs/users/windows-truncation-recovery.md).
 - For Linux/macOS overload or selective activation, use [docs/users/agent-overload-recovery.md](docs/users/agent-overload-recovery.md).
@@ -330,7 +330,7 @@ Keep the root README short; use the dedicated docs for recovery and platform-spe
 
 ## Stable Skills Manifest v1
 
-This is the stable **direct-host discovery manifest** for integrations that load individual `SKILL.md` files. It is not `aas-stack.json`, the verified AAS Core catalog, or the Core recommendation contract. Core users should start with the [AAS Core guide](docs/users/aas-core.md); custom host integrations can continue using the manifest below.
+This is the stable **direct-host discovery manifest** for integrations that load individual `SKILL.md` files. It is not `aas-stack.json`, the verified AAS Core catalog, or the Core recommendation contract. Core users should start with the [AAS Core guide](https://github.com/sickn33/agentic-awesome-skills/blob/main/docs/users/aas-core.md); custom host integrations can continue using the manifest below.
 
 Host integrations should use:
 

--- a/docs/users/aas-core.md
+++ b/docs/users/aas-core.md
@@ -30,7 +30,7 @@ The agent may inspect your project using its normal local capabilities, but AAS 
 The package publishes separate `aas` and `aas-mcp` binaries. For a pinned Core release without relying on npm's default-bin selection, invoke `aas` explicitly:
 
 ```bash
-npm exec --yes --ignore-scripts --package=agentic-awesome-skills@<core-version> -- aas mcp configure \
+npm exec --yes --ignore-scripts --package=agentic-awesome-skills@latest -- aas mcp configure \
   --host codex \
   --scope user \
   --config /absolute/path/to/codex/config.toml \
@@ -105,10 +105,11 @@ aas stack plan \
   --target codex:project \
   --target-root /absolute/path/to/project \
   --cache-root /absolute/path/to/aas-cache \
-  --runtime-version 14.6.0 \
   --runtime-integrity '<npm-sri>' \
   --out /absolute/path/to/plan.json
 ```
+
+`stack plan` derives the exact runtime version from the catalog identity in `aas-stack.json`; the verified runtime integrity remains explicit. The CLI rejects a legacy `--runtime-version` override when it disagrees with the manifest, so the documented command does not need a version edit for each release.
 
 `stack validate` is read-only. `stack plan` writes only the requested plan artifact and does not materialize skills or AAS managed state in the target. The immutable plan binds the manifest, runtime, catalog, target identity, current managed state, and exact logical operations.
 

--- a/tools/lib/aas-v1/cli/main.js
+++ b/tools/lib/aas-v1/cli/main.js
@@ -283,7 +283,10 @@ async function stackPlan(options, dependencies = {}) {
     throw cliError("AAS_PLAN_CATALOG_MISMATCH", "integrity", {});
   }
   const targetBase = selectTarget(manifest, requireOption(options, "target"));
-  const runtime = await verifiedRuntimeFor(options, null, dependencies);
+  if (options["runtime-version"] !== undefined && options["runtime-version"] !== manifest.catalog.version) {
+    throw cliError("AAS_PLAN_RUNTIME_CATALOG_MISMATCH", "integrity", {});
+  }
+  const runtime = await verifiedRuntimeFor({ ...options, "runtime-version": manifest.catalog.version }, null, dependencies);
   if (runtime.identity.package !== manifest.catalog.package || runtime.identity.version !== manifest.catalog.version) {
     throw cliError("AAS_PLAN_RUNTIME_CATALOG_MISMATCH", "integrity", {});
   }
@@ -349,7 +352,7 @@ function help() {
       "stack init --goal <goal> [--catalog-digest <sha256> --cache-root <absolute>] [--preview-windows-output]",
       "stack recommend --profile <json> [--catalog-digest <sha256> --cache-root <absolute>]",
       "stack validate --manifest <aas-stack.json>",
-      "stack plan --manifest <file> --target <host:scope> --target-root <dir> --cache-root <absolute> --runtime-version <semver> --runtime-integrity <npm-sri> --out <file> [--preview-windows-output]",
+      "stack plan --manifest <file> --target <host:scope> --target-root <dir> --cache-root <absolute> --runtime-integrity <npm-sri> --out <file> [--preview-windows-output]",
       "stack apply --experimental-apply --plan <file> --target-root <dir> --cache-root <absolute> --approve <plan-digest> (EXPERIMENTAL; NOT CERTIFIED)",
       "stack doctor --plan <file> --target-root <dir> --cache-root <absolute>",
       "stack recover --experimental-recovery --plan <file> --target-root <dir> --cache-root <absolute> --id <id> --action rollback|cleanup [--approve <digest>] (EXPERIMENTAL; NOT CERTIFIED)",

--- a/tools/scripts/tests/aas_v1_cli.test.js
+++ b/tools/scripts/tests/aas_v1_cli.test.js
@@ -211,13 +211,25 @@ test("production CLI resolves and re-verifies a content-addressed runtime cache"
   const planned = spawnSync(process.execPath, [
     path.join(ROOT, "tools/bin/aas.js"), "stack", "plan",
     "--manifest", manifestPath, "--target", "codex:project", "--target-root", targetRoot,
-    "--cache-root", cacheRoot, "--runtime-version", "14.6.0", "--runtime-integrity", integrity,
+    "--cache-root", cacheRoot, "--runtime-integrity", integrity,
     "--out", planPath,
   ], { cwd: targetRoot, encoding: "utf8" });
   assert.equal(planned.status, 0, planned.stderr);
   const plan = JSON.parse(fs.readFileSync(planPath, "utf8"));
+  assert.equal(plan.payload.runtime.version, manifest.catalog.version);
   assert.equal(plan.payload.runtime.closureDigest, promoted.runtimeIdentity.closureDigest);
   assert.equal(fs.existsSync(path.join(targetRoot, ".aas")), false);
+
+  const mismatchedPlanPath = path.join(item.root, "mismatched-plan.json");
+  const mismatched = spawnSync(process.execPath, [
+    path.join(ROOT, "tools/bin/aas.js"), "stack", "plan",
+    "--manifest", manifestPath, "--target", "codex:project", "--target-root", targetRoot,
+    "--cache-root", cacheRoot, "--runtime-version", "99.0.0", "--runtime-integrity", integrity,
+    "--out", mismatchedPlanPath,
+  ], { cwd: targetRoot, encoding: "utf8" });
+  assert.equal(mismatched.status, 3, mismatched.stderr);
+  assert.equal(JSON.parse(mismatched.stderr).code, "AAS_PLAN_RUNTIME_CATALOG_MISMATCH");
+  assert.equal(fs.existsSync(mismatchedPlanPath), false);
 
   fs.writeFileSync(path.join(promoted.targetPath, "package", "skills", "ai-agents-architect", "SKILL.md"), "tampered\n");
   const rejected = spawnSync(process.execPath, [

--- a/tools/scripts/tests/npm_package_contents.test.js
+++ b/tools/scripts/tests/npm_package_contents.test.js
@@ -1,5 +1,6 @@
 const assert = require("assert");
 const { spawnSync } = require("child_process");
+const fs = require("fs");
 const path = require("path");
 const os = require("os");
 const packageJson = require(path.resolve(__dirname, "..", "..", "..", "package.json"));
@@ -67,4 +68,23 @@ assert.strictEqual(
   packageJson.dependencies?.ajv,
   "^8.20.0",
   "published package must declare ajv as a runtime dependency for v1 schema validation",
+);
+
+const coreGuide = fs.readFileSync(path.join(repoRoot, "docs", "users", "aas-core.md"), "utf8");
+const readme = fs.readFileSync(path.join(repoRoot, "README.md"), "utf8");
+assert.ok(
+  readme.includes("https://github.com/sickn33/agentic-awesome-skills/blob/main/docs/users/aas-core.md"),
+  "published README must link to the canonical AAS Core guide without relying on an unpackaged relative path",
+);
+assert.ok(
+  !readme.includes("](docs/users/aas-core.md)"),
+  "published README must not link to an AAS Core guide path excluded from the npm package",
+);
+assert.ok(
+  coreGuide.includes("--package=agentic-awesome-skills@latest"),
+  "AAS Core onboarding must resolve the current published release without a hardcoded version",
+);
+assert.ok(
+  !/^\s*--runtime-version\b/m.test(coreGuide),
+  "AAS Core onboarding command must derive the runtime version from the manifest catalog identity",
 );


### PR DESCRIPTION
# Pull Request Description

Fixes release-blocking onboarding gaps discovered by installing the exact `npm pack --ignore-scripts` tarball in an empty consumer directory:

- link the published README directly to the canonical online Core guide instead of an unpackaged relative path;
- make bootstrap resolve the current published release and make `stack plan` derive the exact runtime version from the manifest catalog identity.

This keeps AAS Core npm onboarding self-contained and release-agnostic without weakening verification: runtime integrity remains explicit, the resolved runtime identity must still match the manifest, and a conflicting legacy `--runtime-version` override fails closed.

## Change Classification

- [ ] Skill PR
- [x] Docs PR
- [x] Infra PR

## Issue Link (Optional)

None.

## Quality Bar Checklist ✅

- [x] **Standards**: Maintainer and security guidance reviewed.
- [ ] **Metadata**: Not applicable; no `SKILL.md` changed.
- [ ] **Risk Label**: Not applicable.
- [ ] **Triggers**: Not applicable.
- [ ] **Limitations**: Not applicable.
- [ ] **Security**: Not applicable.
- [x] **Safety scan**: `npm run security:docs` passed.
- [ ] **Automated Skill Review**: Not applicable; no `SKILL.md` changed.
- [x] **Manual Logic Review**: Manifest-derived runtime resolution, legacy mismatch rejection, and clean npm onboarding were reviewed.
- [x] **Local Test**: Exact tarball installed in an empty consumer directory; `aas`, bundled catalog, and recommendation executed successfully.
- [x] **Repo Checks**: `npm run validate:references` passed.
- [x] **Source-Only PR**: No generated registry artifacts are included.
- [ ] **Credits**: Not applicable.
- [ ] **License provenance**: Not applicable.
- [x] **Maintainer Edits**: Enabled by repository defaults.

## Validation

- `node tools/scripts/tests/npm_package_contents.test.js`
- `node --test tools/scripts/tests/aas_v1_cli.test.js`
- exact packed tarball inspected by the protected verifier allowlist (7,249 entries, zero failures)
- `npm run validate`
- `npm run validate:references`
- `npm run security:docs`
- `npm run check:warning-budget`
- `npm run audit:consistency`
- `git diff --check`
- black-box install of the exact packed tarball in an empty directory

## Screenshots (if applicable)

Not applicable.
