### PR TITLE
fix: keep AAS v1 catalog aligned with skill PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -190,7 +190,7 @@ jobs:
         run: npm audit --audit-level=high
 
       - name: Refresh ephemeral derived sources for tests
-        run: npm run plugin-compat:sync && npm run index && npm run bundles:sync
+        run: npm run plugin-compat:sync && npm run index && npm run bundles:sync && npm run build:aas-v1-catalog
 
       - name: Run tests
         run: npm run test

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "sync:github-about": "node tools/scripts/run-python.js tools/scripts/sync_repo_metadata.py --apply-github-about",
     "sync:contributors": "node tools/scripts/run-python.js tools/scripts/sync_contributors.py",
     "sync:web-assets": "npm run app:setup && cd apps/web-app && npm run generate:sitemap",
-    "chain": "npm run validate && npm run plugin-compat:sync && npm run index && npm run bundles:sync && npm run sync:metadata",
+    "chain": "npm run validate && npm run plugin-compat:sync && npm run index && npm run bundles:sync && npm run sync:metadata && npm run build:aas-v1-catalog",
     "sync:all": "npm run chain",
     "sync:release-state": "npm run chain && npm run catalog && npm run sync:web-assets && npm run audit:consistency && npm run check:warning-budget",
     "sync:repo-state": "npm run chain && npm run catalog && npm run sync:web-assets && npm run sync:contributors && npm run audit:consistency && npm run check:warning-budget",

--- a/tools/config/generated-files.json
+++ b/tools/config/generated-files.json
@@ -7,6 +7,7 @@
     "data/bundles.json",
     "data/plugin-compatibility.json",
     "data/aliases.json",
+    "data/aas-v1/",
     "apps/web-app/public/sitemap.xml",
     "apps/web-app/public/skills.json.backup",
     ".agents/plugins/",

--- a/tools/scripts/tests/aas_v1_offline_catalog.test.js
+++ b/tools/scripts/tests/aas_v1_offline_catalog.test.js
@@ -11,13 +11,14 @@ const ROOT = path.resolve(__dirname, "../../..");
 test("offline catalog assets are deterministic, complete, and content-addressed", () => {
   const first = buildArtifacts();
   const second = buildArtifacts();
-  assert.equal(first.manifest.skillCount, 1965);
+  const canonicalSkillCount = JSON.parse(fs.readFileSync(path.join(ROOT, "skills_index.json"), "utf8")).length;
+  assert.equal(first.manifest.skillCount, canonicalSkillCount);
   assert.equal(first.catalogDigest, second.catalogDigest);
   for (const [relativePath, bytes] of first.generated) {
     assert.equal(fs.readFileSync(path.join(ROOT, ...relativePath.split("/"))).equals(bytes), true, relativePath);
   }
   const index = JSON.parse(first.generated.get("data/aas-v1/skill-content-index.v1.json"));
-  assert.equal(Object.keys(index.entries).length, 1965);
+  assert.equal(Object.keys(index.entries).length, canonicalSkillCount);
   assert.ok(index.entries.android_ui_verification);
   assert.ok(index.entries["2d-games"]);
 });

--- a/tools/scripts/tests/automation_workflows.test.js
+++ b/tools/scripts/tests/automation_workflows.test.js
@@ -65,6 +65,11 @@ assert.match(
   /check:warning-budget/,
   "sync:repo-state should enforce the frozen validation warning budget",
 );
+assert.match(
+  packageJson.scripts.chain,
+  /build:aas-v1-catalog/,
+  "chain should refresh the offline AAS v1 catalog after skill index generation",
+);
 assert.strictEqual(
   packageJson.scripts["app:install"],
   "cd apps/web-app && npm ci",
@@ -75,6 +80,7 @@ for (const filePath of [
   "apps/web-app/public/sitemap.xml",
   "apps/web-app/public/skills.json.backup",
   "data/plugin-compatibility.json",
+  "data/aas-v1/",
   ".agents/plugins/",
   ".claude-plugin/plugin.json",
   ".claude-plugin/marketplace.json",

--- a/tools/scripts/tests/workflow_contracts.test.js
+++ b/tools/scripts/tests/workflow_contracts.test.js
@@ -105,7 +105,7 @@ assert.doesNotMatch(
 assert.match(ciWorkflow, /^permissions:\n  contents: read$/m);
 assert.match(
   ciWorkflow,
-  /source-validation:[\s\S]*?- name: Refresh ephemeral derived sources for tests\n\s+run: npm run plugin-compat:sync && npm run index && npm run bundles:sync\n[\s\S]*?- name: Run tests\n\s+run: npm run test/,
+  /source-validation:[\s\S]*?- name: Refresh ephemeral derived sources for tests\n\s+run: npm run plugin-compat:sync && npm run index && npm run bundles:sync && npm run build:aas-v1-catalog\n[\s\S]*?- name: Run tests\n\s+run: npm run test/,
   "source-only skill PRs must refresh uncommitted mirrors and indexes before tests read them",
 );
 assert.match(ciWorkflow, /name: pr-evidence-/);


### PR DESCRIPTION
## Summary

Keep the generated offline AAS v1 catalog aligned when source-only skill pull requests change canonical skill content.

- refresh the AAS v1 catalog in the canonical chain and the source-validation ephemeral step
- derive the offline-catalog test count from the generated canonical index instead of a frozen literal
- include the three offline catalog assets in the protected generated-files contract

## Change Classification

- [ ] Skill PR
- [ ] Docs PR
- [x] Infra PR

## Quality Bar Checklist ✅

- [x] Standards: Maintainer policy and protected-main workflow followed.
- [x] Metadata: No skill metadata changed.
- [x] Risk Label: Not applicable; no skill content changed.
- [x] Triggers: Not applicable.
- [x] Limitations: Not applicable.
- [x] Security: No new credential, network, or command-execution surface.
- [x] Safety scan: npm run security:docs passed.
- [x] Automated Skill Review: Not applicable; no SKILL.md changed.
- [x] Manual Logic Review: Reviewed source-only and canonical-sync boundaries.
- [x] Local Test: Full npm test suite passed.
- [x] Repo Checks: Workflow lint, reference validation, warning budget, and targeted contract tests passed.
- [x] Source-Only PR: No generated artifact is committed in this PR.
- [x] Credits: Not applicable.
- [x] License provenance: Not applicable.
- [x] Maintainer Edits: Internal maintainer branch.
