### PR TITLE
fix: manage generated review queue

### DIFF
--- a/tools/config/generated-files.json
+++ b/tools/config/generated-files.json
@@ -8,6 +8,7 @@
     "data/plugin-compatibility.json",
     "data/aliases.json",
     "data/aas-v1/",
+    "tools/lib/aas-v1/review-queue.v1.json",
     "apps/web-app/public/sitemap.xml",
     "apps/web-app/public/skills.json.backup",
     ".agents/plugins/",

--- a/tools/scripts/tests/automation_workflows.test.js
+++ b/tools/scripts/tests/automation_workflows.test.js
@@ -81,6 +81,7 @@ for (const filePath of [
   "apps/web-app/public/skills.json.backup",
   "data/plugin-compatibility.json",
   "data/aas-v1/",
+  "tools/lib/aas-v1/review-queue.v1.json",
   ".agents/plugins/",
   ".claude-plugin/plugin.json",
   ".claude-plugin/marketplace.json",


### PR DESCRIPTION
## Summary
- declare the AAS v1 review queue as canonical generated state
- cover the generated-file contract in automation tests

## Validation
- node tools/scripts/tests/automation_workflows.test.js
- node tools/scripts/generated_files.js --include-mixed
- git diff --check

## Quality Bar Checklist
- [x] Changes are focused and source-only
- [x] Relevant tests pass
- [x] No release, tag, or npm publication included