### PR TITLE
docs(aas-v1): retire stale baseline protection contract

### DIFF
--- a/.github/MAINTENANCE.md
+++ b/.github/MAINTENANCE.md
@@ -283,7 +283,7 @@ We used this flow for PRs [#220](https://github.com/sickn33/agentic-awesome-skil
 **Maintainer shortcut for batched PRs:**
 
 - Use `npm run merge:batch -- --prs 450,449,446,451` to automate the ordered maintainer flow for multiple PRs. See [docs/maintainers/merge-batch.md](../docs/maintainers/merge-batch.md) for the short usage guide.
-- Pages is release-only: ordinary pushes to `main` never deploy it. Dispatch `.github/workflows/pages.yml` explicitly only at an approved publication gate. Canonical-sync merges still use `--skip-pages` and carry `[skip pages]` as a durable audit marker; required CI, the frozen AAS baseline, and CodeQL remain enforced.
+- Pages is release-only: ordinary pushes to `main` never deploy it. Dispatch `.github/workflows/pages.yml` explicitly only at an approved publication gate. Canonical-sync merges still use `--skip-pages` and carry `[skip pages]` as a durable audit marker; the four routine app-bound checks and CodeQL remain enforced. The frozen verifier harness is separate and runs only for verifier-governance changes, not as a routine merge prerequisite.
 - The script keeps the GitHub-only squash merge rule, handles fork-run approvals and stale PR metadata refresh, waits only on fresh required checks, retries `Base branch was modified`, and runs the mandatory post-merge `sync:contributors` follow-up on `main`. The fork content allowlist applies only to external PRs; same-repository maintainer PRs may change repository-wide source while remaining subject to protected checks, trusted changed-skill evidence, exact-head review, and immutable PR identity.
 - It is intentionally not a conflict resolver. If a PR is conflicting, stop and follow the manual conflict playbook.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Updated the frozen verifier governance contract to record the retired `aas-v1-baseline` gate as historical, bind the four current app-owned checks, and remove the deleted workflow from protected-path claims without changing benchmark or gold content.
 - Made the future AAS Core npm onboarding release-safe by linking the published README to the canonical Core guide and deriving the plan runtime version from the manifest catalog identity instead of hardcoding a release number.
 - Added the current Bing Webmaster verification identity and updated the legacy Pages redirect generator contract to cover the expanded 187-route sitemap.
 - Expanded the legacy Pages bridge to every one of the 1,965 current catalog skills plus seven structural routes, while keeping crawler discovery limited to the curated 187-route sitemap and making migration-readiness checks enforce the same exact catalog coverage.

--- a/verification/aas-v1/README.md
+++ b/verification/aas-v1/README.md
@@ -6,12 +6,13 @@ code. Product changes consume this baseline; they do not rewrite it.
 
 ## Current state
 
-The Phase-0 candidate is fully authored and independently reviewed: 180
+The Phase-0 baseline is frozen and independently reviewed: 180
 held-out cases, 60 tuning cases, 30 explicit abstention cases, two
 content-addressed reviewer attestations, 32 hostile exploit/control classes,
 the 41-case registry-14.6.0 legacy corpus, fixed seeds, and the six-job runtime
-contract. It becomes immutable when the freeze manifest is generated and the
-dedicated baseline PR lands on protected `main`.
+contract. Its freeze manifest binds those bytes. Governance-only corrections
+must use a dedicated protected verifier PR and refresh that manifest; they do
+not change benchmark judgments or revive a routine pull-request gate.
 
 The complete local gate is:
 
@@ -72,16 +73,20 @@ node verification/aas-v1/verifier/bin/verify-product.mjs \
 
 ## Freeze protocol
 
-1. Land this baseline through a dedicated PR before scorer implementation.
+1. The baseline landed through a dedicated PR before scorer implementation.
 2. Independent reviewers author or approve real case inputs, coherent
    accepted-equivalent gold sets, abstention labels, seeds, hostile fixtures,
    legacy snapshots, and exact runner/observer identities.
 3. Two named reviewers approve the complete baseline. At least one reviewer
    must not implement the scorer.
-4. Protected `main` requires the `aas-v1-baseline` job from
-   `.github/workflows/aas-v1-baseline-check.yml` on every PR.
-5. The workflow produces a content-addressed freeze manifest. Any later change
-   to a protected baseline path invalidates prior product evidence.
+4. The standalone `aas-v1-baseline` workflow and required status context were
+   retired on 2026-07-18. Routine source and canonical-sync PRs require
+   `pr-policy`, `pr-evidence`, `source-validation`, and `artifact-preview`;
+   they do not execute this baseline as a merge prerequisite.
+5. Changes to this protected directory use a dedicated verifier PR, run the
+   six-leg verifier harness, and refresh the content-addressed freeze manifest.
+   Product acceptance remains a separate black-box workflow. Any changed
+   freeze digest invalidates product evidence bound to the prior digest.
 
 Candidate binaries receive normalized profiles, never case IDs, gold labels,
 fixture filenames, or test-only environment markers. Crashes, timeouts, and
@@ -90,8 +95,9 @@ used to select a favorable result.
 
 ## Protected surfaces
 
-The baseline, verifier, ownership contract, workflow, and CODEOWNERS entries
-are one protection unit. This solo-maintainer repository records two
-independent content-addressed agent reviews and enforces them through the
-required status check; it does not misrepresent those reviews as approvals by
-two separate GitHub collaborators.
+The baseline, verifier, ownership contract, verifier workflows, and CODEOWNERS
+entries are one protection unit. This solo-maintainer repository records two
+independent content-addressed agent reviews and protects verifier changes
+through dedicated PR review, the routine app-bound checks, the six-leg harness,
+and a refreshed freeze digest. It does not misrepresent those reviews as
+approvals by two separate GitHub collaborators.

--- a/verification/aas-v1/baseline/v1/freeze-manifest.json
+++ b/verification/aas-v1/baseline/v1/freeze-manifest.json
@@ -8,13 +8,13 @@
     "verifier/node_modules/",
     "baseline/v1/legacy/14.6.0/_work/"
   ],
-  "rootDigest": "sha256-daca3ee63c2f27c156e4a20ca7cfe110da09073740bbfe31d7371bd7a41ce39c",
+  "rootDigest": "sha256-ae8defc2d7ae3e4e48c9f0083822f6eedcf281e5a9659e70dd7baa2317b66c39",
   "fileCount": 765,
   "files": [
     {
       "path": "README.md",
-      "bytes": 4643,
-      "sha256": "2e22eeadd14f0ab6c8f1fecd9df5d9119af53175cb36b200f431d4fae5f6267a"
+      "bytes": 5153,
+      "sha256": "7a75d4d0148a0425f7a9420930e92d6dcdedc1c418980882d3da8cd8b1ab65db"
     },
     {
       "path": "baseline/v1/benchmark/abstention/cases/creative-content/bilingual-poetry-edit.json",
@@ -3513,8 +3513,8 @@
     },
     {
       "path": "ownership.v1.json",
-      "bytes": 3804,
-      "sha256": "7e314540c67a1612f55bcbf257c03512d795875332348fd4c67cfffc51c62220"
+      "bytes": 4433,
+      "sha256": "48cf2a3ad1cd702f146a225aba7670214f9a79e0ad9af83980043f64ec2f80ed"
     },
     {
       "path": "schemas/benchmark-case.schema.json",
@@ -3608,8 +3608,8 @@
     },
     {
       "path": "verifier/bin/check-baseline.mjs",
-      "bytes": 14454,
-      "sha256": "a0ca18471de80826593690d57aa0f7363a0201cccf1db986ca4475043970b2bc"
+      "bytes": 15521,
+      "sha256": "d6ce2f29f8ebaee3a3b4f53d7a395c9e14a58dc1fe77984db08705ac272597cd"
     },
     {
       "path": "verifier/bin/freeze-baseline.mjs",

--- a/verification/aas-v1/ownership.v1.json
+++ b/verification/aas-v1/ownership.v1.json
@@ -64,7 +64,6 @@
   ],
   "protectedPaths": [
     "verification/aas-v1/**",
-    ".github/workflows/aas-v1-baseline-check.yml",
     ".github/workflows/aas-v1-product-verifier.yml",
     ".github/workflows/aas-v1-verifier-harness.yml",
     ".github/CODEOWNERS"
@@ -74,7 +73,31 @@
     "branch": "main",
     "soloMaintainer": true,
     "requiredReviewCount": 0,
-    "requiredStatusContext": "aas-v1-baseline",
+    "requiredStatusChecks": [
+      {
+        "context": "pr-policy",
+        "appId": 15368
+      },
+      {
+        "context": "pr-evidence",
+        "appId": 15368
+      },
+      {
+        "context": "source-validation",
+        "appId": 15368
+      },
+      {
+        "context": "artifact-preview",
+        "appId": 15368
+      }
+    ],
+    "retiredStatusContexts": [
+      {
+        "context": "aas-v1-baseline",
+        "retiredAt": "2026-07-18",
+        "reason": "The standalone baseline evaluation was not reliable enough to remain a routine merge prerequisite."
+      }
+    ],
     "enforceAdmins": true,
     "allowForcePushes": false,
     "allowDeletions": false,
@@ -82,17 +105,16 @@
       "pr-policy",
       "pr-evidence",
       "source-validation",
-      "artifact-preview",
-      "aas-v1-baseline"
+      "artifact-preview"
     ],
-    "verifiedAt": "2026-07-17",
+    "verifiedAt": "2026-07-18",
     "settingsVerified": true
   },
   "verificationEnvironment": {
-    "model": "content-addressed-independent-reports-plus-protected-status",
+    "model": "content-addressed-independent-reports-plus-dedicated-verifier-pr",
     "baselineFreezeManifest": "baseline/v1/freeze-manifest.json",
     "productPullRequestsMayModifyBaseline": false,
     "requiredReviewersVerified": true,
-    "limitation": "The repository has one GitHub collaborator. Independence is enforced by two content-addressed reviewer reports, a separately frozen baseline commit, and a required status check; it is not represented as two GitHub account approvals."
+    "limitation": "The repository has one GitHub collaborator. Independence is represented by two content-addressed reviewer reports and a separately frozen baseline, not by two GitHub account approvals. The retired aas-v1-baseline context is not a routine merge prerequisite; verifier changes require a dedicated protected PR, the app-bound repository checks, the six-leg harness, and a refreshed freeze digest."
   }
 }

--- a/verification/aas-v1/verifier/bin/check-baseline.mjs
+++ b/verification/aas-v1/verifier/bin/check-baseline.mjs
@@ -126,6 +126,25 @@ requireForFreeze(legacy.status === "frozen" && legacy.fixtureRepository.treeDige
 
 const ownership = readJson("ownership.v1.json");
 assert(ownership.minimumApprovals === 2 && ownership.requireNonScorerReviewer === true, "AAS_BASELINE_OWNERSHIP_POLICY", "Two approvals including a non-scorer reviewer are required.");
+const expectedRoutineChecks = ["pr-policy", "pr-evidence", "source-validation", "artifact-preview"];
+const requiredStatusChecks = ownership.repositorySettings.requiredStatusChecks || [];
+assert(
+  JSON.stringify(requiredStatusChecks.map((entry) => entry.context)) === JSON.stringify(expectedRoutineChecks)
+    && requiredStatusChecks.every((entry) => entry.appId === 15368),
+  "AAS_BASELINE_CURRENT_PROTECTION",
+  "Ownership must record exactly the four app-bound routine checks.",
+);
+assert(
+  JSON.stringify(ownership.repositorySettings.observedRequiredStatusContexts) === JSON.stringify(expectedRoutineChecks),
+  "AAS_BASELINE_OBSERVED_PROTECTION",
+  "Observed required contexts must match the current routine checks.",
+);
+assert(
+  ownership.repositorySettings.retiredStatusContexts?.some((entry) => entry.context === "aas-v1-baseline")
+    && !ownership.protectedPaths.includes(".github/workflows/aas-v1-baseline-check.yml"),
+  "AAS_BASELINE_RETIRED_GATE",
+  "The retired baseline gate must remain historical and its deleted workflow must not be protected.",
+);
 const reviewerIdentities = new Set(ownership.reviewers.map((reviewer) => reviewer.identity));
 const reviewerReportsValid = ownership.reviewers.every((reviewer) => {
   if (!reviewer.report || !reviewer.reportSha256 || reviewer.reviewedPairs !== 270) return false;


### PR DESCRIPTION
## Summary

- record the standalone aas-v1-baseline gate as retired historical context
- bind the frozen ownership contract to the four current app-owned repository checks
- remove the deleted workflow from protected-path claims
- make the verifier enforce the current protection contract
- refresh the freeze manifest without changing benchmark, gold, scorer, or reviewer content

This is a dedicated verifier-governance correction. It does not reintroduce routine evaluation and does not change product behavior.

## Change Classification

- [x] Docs PR
- [x] Infra PR

## Quality Bar Checklist

- [x] Standards and security guardrails reviewed
- [x] No SKILL.md content changed; skill-specific gates are not applicable
- [x] npm run validate
- [x] npm run validate:references
- [x] npm run security:docs
- [x] workflow contract test
- [x] frozen verifier gate, including 49 verifier tests and freeze digest check
- [x] Source-only contract respected; the freeze manifest is the required content-addressed verifier artifact
- [x] Maintainer edits enabled

## Validation note

The full root npm test currently reaches one pre-existing failure on main: the three generated AAS offline catalog assets are stale. This branch is based on the same current main SHA, and the failure is outside this verifier-governance change.

## Coordination

Keep this PR in draft and do not merge until the separate maintenance task has finished advancing main.