### PR TITLE
fix(ci): manage Core metadata overrides

### DIFF
--- a/tools/config/generated-files.json
+++ b/tools/config/generated-files.json
@@ -8,6 +8,7 @@
     "data/plugin-compatibility.json",
     "data/aliases.json",
     "data/aas-v1/",
+    "tools/lib/aas-v1/metadata-overrides.v1.json",
     "tools/lib/aas-v1/review-queue.v1.json",
     "apps/web-app/public/sitemap.xml",
     "apps/web-app/public/skills.json.backup",

--- a/tools/scripts/tests/automation_workflows.test.js
+++ b/tools/scripts/tests/automation_workflows.test.js
@@ -82,6 +82,7 @@ for (const filePath of [
   "apps/web-app/public/skills.json.backup",
   "data/plugin-compatibility.json",
   "data/aas-v1/",
+  "tools/lib/aas-v1/metadata-overrides.v1.json",
   "tools/lib/aas-v1/review-queue.v1.json",
   ".agents/plugins/",
   ".claude-plugin/plugin.json",


### PR DESCRIPTION
# Pull Request Description

Declare `tools/lib/aas-v1/metadata-overrides.v1.json` as protected generated state. The refreshed catalog builder correctly updates it, but the canonical boundary currently rejects that update as unmanaged drift. Add the path to the generated-files contract and its regression test.

## Change Classification

- [ ] Skill PR
- [ ] Docs PR
- [x] Infra PR

## Issue Link (Optional)

N/A

## Quality Bar Checklist ✅

- [x] **Standards**: Maintainer quality and security guidance reviewed.
- [x] **Metadata**: Not applicable; no `SKILL.md` changed.
- [x] **Risk Label**: Not applicable.
- [x] **Triggers**: Not applicable.
- [x] **Limitations**: Not applicable.
- [x] **Security**: Not applicable.
- [x] **Safety scan**: Not applicable.
- [x] **Automated Skill Review**: Not applicable.
- [x] **Manual Logic Review**: Canonical generated-file boundary reviewed.
- [x] **Local Test**: Workflow contract test passes.
- [x] **Repo Checks**: `npm run validate:references` passes.
- [x] **Source-Only PR**: No generated artifacts included.
- [x] **Credits**: Not applicable.
- [x] **License provenance**: Not applicable.
- [x] **Maintainer Edits**: Enabled by repository default.

## Screenshots (if applicable)

Not applicable.