### PR TITLE
test: derive CLI runtime from package release

### DIFF
--- a/tools/scripts/tests/aas_v1_cli.test.js
+++ b/tools/scripts/tests/aas_v1_cli.test.js
@@ -10,12 +10,13 @@ const core = require("../../lib/aas-v1");
 const { execute, main, windowsOutputDurabilityDetails } = require("../../lib/aas-v1/cli/main");
 
 const ROOT = path.resolve(__dirname, "../../..");
+const PACKAGE_VERSION = require(path.join(ROOT, "package.json")).version;
 
 function fixture() {
   const root = fs.mkdtempSync(path.join(os.tmpdir(), "aas-cli-"));
   const runtime = {
     package: "agentic-awesome-skills",
-    version: "14.6.0",
+    version: PACKAGE_VERSION,
     integrity: "sha512-VTOb3O9PSYKCDO99i3h0vOn7vHQlGtO/+jSErR80g6OGaDJoBzg3q2GE9Nu890en1/Z54hBEYiVQj/1Rl95xEg==",
     closureDigest: `sha256-${"1".repeat(64)}`,
   };
@@ -189,7 +190,7 @@ test("production CLI resolves and re-verifies a content-addressed runtime cache"
   const integrity = item.runtime.integrity;
   const packageJson = {
     name: "agentic-awesome-skills",
-    version: "14.6.0",
+    version: item.runtime.version,
     bin: { "aas-mcp": "tools/bin/aas-mcp.js" },
     bundledDependencies: ["ajv", "sanitize-filename", "yaml"],
   };
@@ -210,7 +211,7 @@ test("production CLI resolves and re-verifies a content-addressed runtime cache"
     cacheRoot,
     release: {
       package: "agentic-awesome-skills",
-      version: "14.6.0",
+      version: item.runtime.version,
       integrity,
       provenance: { registryOrigin: "https://registry.npmjs.org", signaturesPresent: false, attestationsPresent: false },
     },


### PR DESCRIPTION
## Summary

- derive the AAS CLI test runtime version from the current package identity
- keep the promoted fixture package and release identity aligned with that version
- remove the accidental 14.6.0 coupling that blocked the 15.0.0-rc.1 release preparation

## Change Classification

- [x] Maintainer test infrastructure
- [x] Source-only PR
- [x] No `SKILL.md` changes

## Quality Bar Checklist ✅

- [x] exact CLI test passed on the generated 15.0.0-rc.1 release state: 8/8
- [x] `git diff --check`

No production behavior, target project, tag, or publication is changed by this PR.