### PR TITLE
fix: make prerelease metadata sync idempotent

### DIFF
--- a/tools/scripts/sync_repo_metadata.py
+++ b/tools/scripts/sync_repo_metadata.py
@@ -10,6 +10,7 @@ from pathlib import Path
 from plugin_compatibility import compatibility_by_skill_id, load_plugin_compatibility
 from sync_editorial_bundles import load_editorial_bundles, render_bundles_doc
 from update_readme import (
+    VERSION_TOKEN_PATTERN,
     configure_utf8_output,
     core_release_boundary,
     core_release_status,
@@ -51,7 +52,10 @@ README_TITLE_RE = re.compile(
     r"^# (?:🌌 Agentic Awesome Skills: .*|AAS Core — Agentic Awesome Skills)$",
     re.MULTILINE,
 )
-README_RELEASE_RE = re.compile(r"^\*\*Current release: V[\d.]+\.\*\* .*?$", re.MULTILINE)
+README_RELEASE_RE = re.compile(
+    rf"^\*\*Current release: V{VERSION_TOKEN_PATTERN}\.\*\* .*?$",
+    re.MULTILINE,
+)
 README_BROAD_COVERAGE_RE = re.compile(
     r"^- \*\*Broad coverage with real utility\*\*: \d[\d,]*\+ skills across development, testing, security, infrastructure, product, and marketing\.$",
     re.MULTILINE,
@@ -224,7 +228,7 @@ def sync_llms_text(content: str, metadata: dict) -> str:
     return sync_regex_text(
         content,
         [
-            (r"Current release: V[\d.]+\.", f"Current release: V{metadata['version']}."),
+            (r"(?m)^- Current release: V[^\n]+$", f"- Current release: V{metadata['version']}."),
             (r"Release boundary: .*", core_release_boundary(metadata)),
             (r"\d[\d,]*\+ agentic SKILL\.md playbooks", f"{skill_label} agentic SKILL.md playbooks"),
             (r"Skill count: \d[\d,]*\+\.", f"Skill count: {skill_label}."),

--- a/tools/scripts/tests/test_sync_repo_metadata.py
+++ b/tools/scripts/tests/test_sync_repo_metadata.py
@@ -179,6 +179,38 @@ class SyncRepoMetadataTests(unittest.TestCase):
         with self.assertRaises(ValueError):
             update_readme.core_release_metadata({"version": "invalid", "aasCore": {"includedFromMajor": 15}})
 
+    def test_prerelease_metadata_sync_is_idempotent_and_can_promote_to_stable(self):
+        prerelease = {
+            "version": "15.0.0-rc.1",
+            "core_included": True,
+            "core_included_from_major": 15,
+            "total_skills": 1968,
+            "total_skills_label": "1,968+",
+            "star_badge_count": "44%2C000%2B",
+            "star_milestone": "44,000+",
+            "star_celebration": "44k",
+            "stars": 43524,
+            "updated_at": "2026-07-18T00:00:00+00:00",
+        }
+        readme = "**Current release: V15.0.0-rc.1.** stale\n"
+        once = update_readme.apply_metadata(readme, prerelease)
+        twice = update_readme.apply_metadata(once, prerelease)
+        self.assertEqual(once, twice)
+        self.assertIn("V15.0.0-rc.1.**", twice)
+        self.assertNotIn("rc.1.0-rc.1", twice)
+
+        llms = "- Current release: V15.0.0-rc.1.0-rc.1.\n"
+        synced = sync_repo_metadata.sync_llms_text(llms, prerelease)
+        self.assertEqual(synced, "- Current release: V15.0.0-rc.1.\n")
+        self.assertEqual(sync_repo_metadata.sync_llms_text(synced, prerelease), synced)
+
+        stable = {**prerelease, "version": "15.0.0"}
+        self.assertIn("V15.0.0.**", update_readme.apply_metadata(twice, stable))
+        self.assertEqual(
+            sync_repo_metadata.sync_llms_text(synced, stable),
+            "- Current release: V15.0.0.\n",
+        )
+
     def test_sync_github_about_builds_expected_commands(self):
         calls = []
 

--- a/tools/scripts/update_readme.py
+++ b/tools/scripts/update_readme.py
@@ -15,7 +15,11 @@ SYNC_COMMENT_FIELDS_RE = re.compile(
     r"<!-- registry-sync: version=(?P<version>[^;]+); skills=(?P<skills>\d+); "
     r"stars=(?P<stars>\d+); updated_at=(?P<updated_at>[^ ]+) -->"
 )
-CURRENT_RELEASE_LINE_RE = re.compile(r"^\*\*Current release: V[\d.]+\.\*\* .*?$", re.MULTILINE)
+VERSION_TOKEN_PATTERN = r"[0-9A-Za-z][0-9A-Za-z.+-]*"
+CURRENT_RELEASE_LINE_RE = re.compile(
+    rf"^\*\*Current release: V{VERSION_TOKEN_PATTERN}\.\*\* .*?$",
+    re.MULTILINE,
+)
 
 
 def release_major(version: str) -> int:


### PR DESCRIPTION
## Summary

- make README release-line matching accept SemVer prereleases
- replace the complete llms.txt release line instead of matching only numeric version prefixes
- add regression coverage for repeated RC sync and RC-to-stable promotion

## Change Classification

- [x] Maintainer release infrastructure
- [x] Source-only PR; generated correction remains in the canonical sync lane
- [x] No `SKILL.md` changes

## Quality Bar Checklist ✅

- [x] prerelease metadata tests: 6/6
- [x] repeated 15.0.0-rc.1 sync is byte-idempotent
- [x] 15.0.0-rc.1 to 15.0.0 promotion is covered
- [x] `git diff --check`

This fixes the release:publish drift detected before any tag or GitHub release was created.