### PR TITLE
fix: bind maintainer instructions to current base

### DIFF
--- a/.github/MAINTENANCE.md
+++ b/.github/MAINTENANCE.md
@@ -13,6 +13,12 @@ It covers the **Quality Bar**, **Documentation Consistency**, and **Release Work
 
 **AGENTS MUST READ AND FOLLOW THIS SECTION BEFORE MARKING ANY TASK AS COMPLETE.**
 
+### Current-base instruction guard
+
+After establishing the clean task base, re-read `AGENTS.md`, this guide, the repository-canonical maintainer skill, and `package.json` from that exact base. Do not rely on repository instructions inherited from a different checkout.
+
+Every command, script, reviewer, or gate described as mandatory must exist on the current task base. If it does not, never import or run the retired implementation from another branch, worktree, stash, installed copy, or historical commit. Compare with `origin/main`, inspect the removal history, and use the current-base contract; stop and report only if the conflict cannot be resolved from repository history.
+
 There are 5 things that usually fail/get forgotten. **DO NOT FORGET THEM:**
 
 ### 1. 📤 ALWAYS PUSH (Non-Negotiable)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,6 +33,12 @@ History uses conventional-style subjects such as `feat: add ...`, `fix: refresh 
 
 Respect deeper `AGENTS.md` files inside skill subtrees. When changing canonical skill content that is mirrored under `plugins/agentic-awesome-skills/` or `plugins/agentic-awesome-skills-claude/`, check whether mirrors must be synchronized. For release work, follow the scripted `release:prepare` and `release:publish` flow rather than hand-editing version surfaces.
 
+### Current-Base Instruction Guard
+
+Repository instructions must match the exact Git base used for the task. After creating a clean clone, worktree, or topic branch, re-read that base's `AGENTS.md`, `.github/MAINTENANCE.md`, canonical maintainer skill, and `package.json`; those files supersede instructions inherited from the checkout that launched the task.
+
+Every command, script, reviewer, or gate described as mandatory must exist on the current task base. If it is absent, do not recover or execute it from another branch, worktree, stash, installed copy, or historical commit. Treat the mismatch as evidence that the procedure may have been retired, inspect `origin/main` and the relevant removal history, then follow the current-base contract or report the unresolved conflict.
+
 ### Mandatory Maintainer Workflow
 
 For every repository maintenance sweep, PR merge batch, maintainer-side PR repair, canonical synchronization, combined Security/Quality cleanup and merge, or tag/release request, **always invoke and follow the `antigravity-maintainer-batch-release` skill before triage or mutation**. If the client has not installed or discovered that skill, read and follow the repository-canonical copy at `skills/antigravity-maintainer-batch-release/SKILL.md`. This is a hard gate, including when the user asks for direct merges or a direct update to `main`; do not substitute a generic Git or GitHub workflow.

--- a/tools/scripts/tests/workflow_contracts.test.js
+++ b/tools/scripts/tests/workflow_contracts.test.js
@@ -64,6 +64,18 @@ const contract = {
   releaseManagedFiles: ["CHANGELOG.md", "package.json", "package-lock.json", "README.md"],
 };
 
+const repositoryRoot = path.resolve(__dirname, "..", "..", "..");
+const agentInstructions = fs.readFileSync(path.join(repositoryRoot, "AGENTS.md"), "utf8");
+const maintenanceGuide = fs.readFileSync(path.join(repositoryRoot, ".github", "MAINTENANCE.md"), "utf8");
+for (const instructions of [agentInstructions, maintenanceGuide]) {
+  assert.match(instructions, /current[- ]base/i);
+  assert.match(instructions, /must exist on the current task base/i);
+  assert.match(instructions, /do not|never import/i);
+  assert.match(instructions, /another branch, worktree, stash, installed copy, or historical commit/i);
+}
+assert.doesNotMatch(agentInstructions, /review:skills:local|local-skill-reviewer-policy/);
+assert.doesNotMatch(maintenanceGuide, /review:skills:local|local-skill-reviewer-policy/);
+
 const publishWorkflow = fs.readFileSync(
   path.resolve(__dirname, "..", "..", "..", ".github", "workflows", "publish-npm.yml"),
   "utf8",


### PR DESCRIPTION
## Summary

- require agents to reload repository instructions from the exact task base
- prohibit reviving retired mandatory commands or reviewers from stale branches, worktrees, installed copies, or history
- add a contract test that preserves the guard and prevents the removed local reviewer policy from returning unnoticed

## Change Classification

- [ ] Skill PR
- [x] Docs PR
- [x] Infra PR

## Quality Bar Checklist

- [x] Standards: reviewed the quality bar and security guardrails
- [x] Repo Checks: npm run validate, npm run validate:references, npm run security:docs, and npm test pass
- [x] Source-Only PR: no generated registry artifacts included
- [x] Maintainer Edits: enabled by repository default

Skill-only checklist items are not applicable because no SKILL.md content changed.

## Validation

- npm run validate
- npm run validate:references
- npm run security:docs
- npm test
- git diff --check