### PR TITLE
fix: make Core retrieval neutral

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Moved semantic skill selection fully to Codex and Claude: agents inspect the project, search and read the complete local catalog, and choose exact skill IDs using their own judgment; AAS Core no longer ranks or recommends skills.
 - Replaced the recommendation workflow with `compose_stack`, which validates and pins the agent-owned selection in `aas-stack.json` for inspection, CLI validation, and immutable plan preview.
 - Removed Core selection policy and metadata eligibility gates. Every canonical skill is searchable, readable, selectable, and usable; risk, source, setup, compatibility, review, and evidence metadata are informational only.
+- Made `search_skills` retrieval neutral: matching results preserve stable catalog order and no longer expose relevance scores or ranking while exact-ID lookup and complete pagination remain deterministic.
 - Updated the public product narrative, host guides, Workbench-facing copy sources, package metadata, and maintainer workflow to describe the agent-owned selection boundary. Released entries below remain historical descriptions of their releases.
+
+### Fixed
+
+- Corrected current public Core examples to use manifest schema 2 with `profile` and exact agent-selected IDs, with a regression test spanning English, Chinese, Vietnamese, integration, and hosted-app copy.
+- Marked all five local MCP tools explicitly read-only, non-destructive, idempotent, and closed-world so isolated non-interactive Codex clients can invoke the catalog workflow without treating the calls as approval-gated mutations.
 
 ## [15.0.0] - 2026-07-18 - "AAS Core: Local Composition and Reviewable Plans"
 

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ This is an independent community project. It is not affiliated with, sponsored b
 AAS Core gives the repository one product model:
 
 - **Let the agent choose.** The local MCP exposes `search_skills`, `get_skill`, `compose_stack`, `inspect_stack`, and `diff_stack`; Core does not rank, recommend, exclude, or hide skills.
-- **Keep the chosen stack in `aas-stack.json`.** The manifest pins catalog identity, targets, goals, and exact skill IDs without storing repository source or model reasoning.
+- **Keep the chosen stack in `aas-stack.json`.** The schema 2 manifest pins catalog identity, targets, the project profile, and exact agent-selected skill IDs without storing repository source or model reasoning.
 - **Validate and preview through the CLI.** `aas stack validate` checks the proposal, while `aas stack plan` produces an immutable, per-target plan without applying it.
 - **Review in Workbench.** The hosted Workbench imports and reviews stack/plan JSON in browser memory; it does not access your filesystem or install anything.
 - **Retain every useful distribution path.** Direct installs, plugins, bundles, workflows, and the full catalog remain available as payload and compatibility surfaces.

--- a/apps/web-app/index.html
+++ b/apps/web-app/index.html
@@ -10,16 +10,16 @@
     <meta name="apple-mobile-web-app-title" content="agentic-awesome-skills" />
     <link rel="manifest" href="%BASE_URL%site.webmanifest" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <meta name="description" content="Use AAS Core preview to discover, recommend, validate, and plan explainable skill stacks for Codex, Claude Code, and compatible clients, backed by 1,968+ cataloged skills." />
+    <meta name="description" content="Use AAS Core preview for neutral catalog retrieval, exact agent-owned selection, validation, and planning for Codex, Claude Code, and compatible clients, backed by 1,968+ cataloged skills." />
     <meta name="author" content="Agentic Awesome Skills" />
     <meta name="msvalidate.01" content="CAC904EB0D2DD1B22B5F2BC540CAD654" />
     <meta property="og:title" content="AAS Core Preview | Agent-first stacks backed by 1,968+ skills" />
-    <meta property="og:description" content="Use AAS Core preview to discover, recommend, validate, and plan explainable skill stacks for Codex, Claude Code, and compatible clients, backed by 1,968+ cataloged skills." />
+    <meta property="og:description" content="Use AAS Core preview for neutral catalog retrieval, exact agent-owned selection, validation, and planning for Codex, Claude Code, and compatible clients, backed by 1,968+ cataloged skills." />
     <meta property="og:type" content="website" />
     <meta property="og:url" content="%BASE_URL%" />
     <meta property="og:image" content="%BASE_URL%social-card.png" />
     <meta name="twitter:title" content="AAS Core Preview | Agent-first stacks backed by 1,968+ skills" />
-    <meta name="twitter:description" content="Use AAS Core preview to discover, recommend, validate, and plan explainable skill stacks for Codex, Claude Code, and compatible clients, backed by 1,968+ cataloged skills." />
+    <meta name="twitter:description" content="Use AAS Core preview for neutral catalog retrieval, exact agent-owned selection, validation, and planning for Codex, Claude Code, and compatible clients, backed by 1,968+ cataloged skills." />
     <meta name="twitter:image" content="%BASE_URL%social-card.png" />
     <meta name="twitter:image:alt" content="Agentic Awesome Skills catalog preview" />
     <meta name="robots" content="index, follow" />

--- a/apps/web-app/public/site.webmanifest
+++ b/apps/web-app/public/site.webmanifest
@@ -1,7 +1,7 @@
 {
   "name": "AAS Core Preview",
   "short_name": "AAS Core",
-  "description": "Agent-first skill recommendation and stack review backed by the Agentic Awesome Skills catalog.",
+  "description": "Neutral catalog retrieval, agent-owned skill selection, and stack review backed by the Agentic Awesome Skills catalog.",
   "start_url": "./",
   "scope": "./",
   "icons": [

--- a/apps/web-app/src/data/seoLandingPages.json
+++ b/apps/web-app/src/data/seoLandingPages.json
@@ -2,10 +2,10 @@
   {
     "slug": "antigravity-cli-skills",
     "title": "Antigravity CLI Skill Stacks | AAS Core Preview",
-    "description": "Use the AAS Core preview catalog to discover skills and compose explainable Antigravity CLI stacks for coding, review, testing, and workflow automation.",
+    "description": "Use the AAS Core preview catalog for neutral skill retrieval and to validate explainable, agent-selected Antigravity CLI stacks for coding, review, testing, and workflow automation.",
     "eyebrow": "Antigravity CLI",
     "h1": "Antigravity CLI skills for agentic coding workflows",
-    "summary": "Use AAS Core as the agent-first selection layer over reusable SKILL.md playbooks for Antigravity CLI and adjacent coding-agent runtimes.",
+    "summary": "Use AAS Core as the agent-first catalog and validation layer for exact skill IDs selected by Antigravity CLI and adjacent coding-agent runtimes.",
     "primaryIntent": "Find installable skills and workflow playbooks for Antigravity CLI.",
     "keywords": [
       "Antigravity CLI skills",
@@ -45,12 +45,12 @@
     ],
     "sections": [
       {
-        "heading": "What AAS Core should recommend first",
+        "heading": "What the coding agent should evaluate first",
         "body": "Start with a focused, explainable stack for coding, review, testing, documentation, and release work instead of activating the entire catalog."
       },
       {
         "heading": "Why this repository fits Antigravity",
-        "body": "AAS Core selects portable skill instructions from the shared catalog while specialized plugins, bundles, and workflows remain optional distribution and discovery surfaces."
+        "body": "The coding agent selects portable skill instructions from the shared catalog; AAS Core validates those exact IDs while specialized plugins, bundles, and workflows remain optional distribution and discovery surfaces."
       },
       {
         "heading": "When the full library is too broad",
@@ -75,7 +75,7 @@
   {
     "slug": "github-ai-skills-repository",
     "title": "AAS Core Preview | GitHub AI Skills Repository",
-    "description": "Explore the GitHub source for AAS Core preview: local MCP and CLI skill recommendation, stack validation, planning, and the supporting AI agent skill catalog.",
+    "description": "Explore the GitHub source for AAS Core preview: neutral local MCP retrieval, agent-owned skill selection, stack validation, planning, and the supporting AI agent skill catalog.",
     "eyebrow": "GitHub repository",
     "h1": "The GitHub source for AAS Core and its skill catalog",
     "summary": "Agentic Awesome Skills is the canonical source for AAS Core, its local MCP and CLI, reusable SKILL.md playbooks, plugin packs, and workflow documentation.",
@@ -123,7 +123,7 @@
       },
       {
         "heading": "Searchable catalog",
-        "body": "The hosted catalog is a companion browsing layer over the evidence AAS Core uses for discovery and recommendation."
+        "body": "The hosted catalog is a companion browsing layer over the evidence coding agents inspect before selecting exact skill IDs."
       },
       {
         "heading": "Reusable across agents",
@@ -151,7 +151,7 @@
     "description": "Compare Antigravity-compatible plugin packs for web apps, security, data analytics, documents, DevOps, QA, OSS maintenance, and agent workflows.",
     "eyebrow": "Plugin packs",
     "h1": "Antigravity plugins for focused agent workflows",
-    "summary": "Specialized plugins are secondary packaged distributions for users who prefer a fixed domain surface instead of an AAS Core recommendation.",
+    "summary": "Specialized plugins are secondary packaged distributions for users who prefer a fixed domain surface instead of an agent-selected AAS Core stack.",
     "primaryIntent": "Find Antigravity plugin packs and focused AI workflow distributions.",
     "keywords": [
       "Antigravity plugins",
@@ -204,7 +204,7 @@
       },
       {
         "heading": "Lower activation cost",
-        "body": "A plugin gives the assistant a fixed instruction set; AAS Core remains the agent-first path when the stack should be recommended from intent and catalog evidence."
+        "body": "A plugin gives the assistant a fixed instruction set; AAS Core remains the agent-first path when the coding agent should inspect catalog evidence and choose exact IDs from a project profile."
       },
       {
         "heading": "Still backed by the full repo",
@@ -232,7 +232,7 @@
     "description": "Use AAS Core preview to find and compose explainable skills para Antigravity from the Agentic Awesome Skills catalog.",
     "eyebrow": "International search",
     "h1": "Skills para Antigravity and AI coding agents",
-    "summary": "A practical entry point for using AAS Core to recommend skill stacks for Antigravity and related AI coding assistants.",
+    "summary": "A practical entry point for using AAS Core to preserve skill stacks selected by Antigravity and related AI coding assistants.",
     "primaryIntent": "Serve international searches for skills para Antigravity.",
     "keywords": [
       "skills para Antigravity",
@@ -282,7 +282,7 @@
       },
       {
         "heading": "Start with AAS Core",
-        "body": "Let AAS Core recommend an exact stack from catalog evidence, then use the hosted site to review skills, plugins, and the resulting artifacts."
+        "body": "Let the coding agent inspect catalog evidence and select an exact stack, then use AAS Core and the hosted site to validate and review the resulting artifacts."
       }
     ],
     "links": [

--- a/apps/web-app/src/pages/Home.tsx
+++ b/apps/web-app/src/pages/Home.tsx
@@ -10,9 +10,9 @@ import type { CategoryStats, SyncMessage } from '../types';
 import { buildHomeMeta, getHomeFaqItems } from '../utils/seo';
 
 const conceptCards = [
-  { title: 'AAS Core preview', body: 'The local control plane that turns intent into an explainable skill stack and immutable plan preview.' },
-  { title: 'Local MCP', body: 'The agent-facing tools for search, inspection, recommendation, and stack comparison.' },
-  { title: 'Catalog', body: 'The evidence-backed source AAS Core uses to select exact skills.' },
+  { title: 'AAS Core preview', body: 'The local boundary that validates an agent-selected skill stack and immutable plan preview.' },
+  { title: 'Local MCP', body: 'The agent-facing tools for neutral catalog retrieval, inspection, composition, and stack comparison.' },
+  { title: 'Catalog', body: 'The complete evidence-backed source the coding agent searches before selecting exact skills.' },
   { title: 'Workbench', body: 'A browser-local review surface for stack manifests and immutable plans.' },
   { title: 'Plugins', body: 'Focused distributions for users who prefer a packaged domain surface.' },
 ] as const;
@@ -129,8 +129,8 @@ export function Home(): React.ReactElement {
       <div className="catalog-content">
         <section className="catalog-hero">
           <h1>AAS Core: agent-first skill stacks for Codex, Claude Code, and compatible clients</h1>
-          <p><strong>Discover. Recommend. Validate. Preview.</strong></p>
-          <p>Turn intent into an explainable <code>aas-stack.json</code> and immutable plan preview without target writes, backed by {catalogCountLabel} cataloged skills.</p>
+          <p><strong>Search. Choose. Validate. Preview.</strong></p>
+          <p>Let your coding agent choose exact IDs, preserve its project profile in <code>aas-stack.json</code>, and preview an immutable plan without target writes, backed by {catalogCountLabel} cataloged skills.</p>
 
           <label className="catalog-search">
             <span className="sr-only">Search skills</span>

--- a/apps/web-app/src/pages/SkillDetail.tsx
+++ b/apps/web-app/src/pages/SkillDetail.tsx
@@ -335,7 +335,7 @@ export function SkillDetail(): React.ReactElement {
               Canonical skill ID
             </p>
             <p className="mt-2 text-sm leading-relaxed text-slate-600 dark:text-slate-300">
-              Use this exact ID when asking your agent for an AAS Core recommendation or when reviewing a proposed stack. Workbench reviews completed stack and plan artifacts; it does not compose or install them.
+              Give this exact ID to your agent when it selects an AAS Core stack, or use it when reviewing a proposed stack. Workbench reviews completed stack and plan artifacts; it does not compose or install them.
             </p>
             <div className="mt-3 flex flex-wrap items-center gap-3">
               <code className="inline-block border border-slate-800 bg-slate-900 px-3 py-2 font-mono text-sm text-slate-50">

--- a/apps/web-app/src/pages/__tests__/Home.test.tsx
+++ b/apps/web-app/src/pages/__tests__/Home.test.tsx
@@ -92,7 +92,7 @@ describe('Home', () => {
         level: 1,
         name: /AAS Core: agent-first skill stacks for Codex, Claude Code, and compatible clients/i,
       })).toBeInTheDocument();
-      expect(screen.getByText(/Discover\. Recommend\. Validate\. Preview\./i)).toBeInTheDocument();
+      expect(screen.getByText(/Search\. Choose\. Validate\. Preview\./i)).toBeInTheDocument();
       expect(screen.getByRole('link', { name: /Review an AAS Core stack/i })).toHaveAttribute('href', '/workbench');
       expect(screen.getByText(/What is the difference between skills and MCP tools/i)).toBeInTheDocument();
       expect(document.querySelector('meta[property="og:title"]')).toHaveAttribute(

--- a/apps/web-app/src/utils/__tests__/seo.test.ts
+++ b/apps/web-app/src/utils/__tests__/seo.test.ts
@@ -38,7 +38,7 @@ describe('SEO helpers', () => {
 
     expect(meta.title).toContain('AAS Core Preview');
     expect(meta.title).toContain('10+ skills');
-    expect(meta.description).toContain('discover, recommend, validate, and plan');
+    expect(meta.description).toContain('neutral catalog retrieval, exact agent-owned selection, validation, and planning');
     expect(meta.description).toContain('10+ cataloged skills');
     expect(meta.canonicalPath).toBe('/');
     expect(meta.ogTitle).toBe(meta.title);

--- a/apps/web-app/src/utils/seo.ts
+++ b/apps/web-app/src/utils/seo.ts
@@ -39,12 +39,12 @@ const FAQ_ITEMS = [
   {
     question: 'What is Agentic Awesome Skills?',
     answer: (countLabel: string) =>
-      `Agentic Awesome Skills is built around AAS Core, a local agent-first preview control plane for discovering, recommending, validating, and planning exact skill stacks. AAS Core is backed by an evidence-rich catalog of ${countLabel} reusable SKILL.md playbooks.`,
+      `Agentic Awesome Skills is built around AAS Core, a local agent-first preview boundary for neutral catalog retrieval, exact agent-owned selection, validation, and planning. AAS Core is backed by an evidence-rich catalog of ${countLabel} reusable SKILL.md playbooks.`,
   },
   {
     question: 'How do I use AAS Core preview?',
     answer:
-      'Configure the local stdio MCP with the AAS CLI, let the agent search, inspect, and recommend skills, then validate the proposed aas-stack.json and preview its immutable plan in the CLI. Apply and recovery are outside the non-applying preview path.',
+      'Configure the local stdio MCP with the AAS CLI, let the agent search and inspect the complete catalog, choose exact skill IDs itself, then validate the schema 2 aas-stack.json with its project profile and preview the immutable plan in the CLI. Apply and recovery are outside the non-applying preview path.',
   },
   {
     question: 'Is Agentic Awesome Skills a GitHub repository?',
@@ -174,7 +174,7 @@ function buildSoftwareSourceCodeSchema(canonicalUrl: string, visibleCount: numbe
     '@context': 'https://schema.org',
     '@type': 'SoftwareSourceCode',
     name: SITE_NAME,
-    description: `AAS Core preview is a local agent-first control plane for recommending, validating, and planning exact skill stacks backed by ${visibleCountLabel}.`,
+    description: `AAS Core preview is a local agent-first boundary for neutral catalog retrieval, exact agent-owned selection, validation, and planning backed by ${visibleCountLabel}.`,
     url: REPOSITORY_URL,
     sameAs: [
       canonicalUrl,
@@ -195,7 +195,7 @@ function buildSoftwareSourceCodeSchema(canonicalUrl: string, visibleCount: numbe
       'GitHub AI skills repository',
       'AI agent skills GitHub',
       'AAS Core',
-      'skill recommendation',
+      'agent-selected skill stack',
       'agent stack',
       'Model Context Protocol',
       'specialized plugins',
@@ -382,8 +382,8 @@ export function buildHomeMeta(skillCount: number): SeoMeta {
     ? `AAS Core Preview | Agent-first stacks backed by ${visibleCountLabel} skills`
     : 'AAS Core Preview | Agent-first skill stacks';
   const description = visibleCount > 0
-    ? `Use AAS Core preview to discover, recommend, validate, and plan explainable skill stacks for Codex, Claude Code, and compatible clients, backed by ${visibleCountLabel} cataloged skills.`
-    : 'Use AAS Core preview to discover, recommend, validate, and plan explainable skill stacks for Codex, Claude Code, and compatible clients.';
+    ? `Use AAS Core preview for neutral catalog retrieval, exact agent-owned selection, validation, and planning for Codex, Claude Code, and compatible clients, backed by ${visibleCountLabel} cataloged skills.`
+    : 'Use AAS Core preview for neutral catalog retrieval, exact agent-owned selection, validation, and planning for Codex, Claude Code, and compatible clients.';
   return {
     title,
     description,
@@ -473,7 +473,7 @@ export function buildTopicLandingMeta(page: SeoLandingPage, featuredSkills: Read
         keywords,
         mainEntity: {
           '@type': 'ItemList',
-          name: `${page.eyebrow} recommended skills`,
+          name: `${page.eyebrow} featured skills`,
           numberOfItems: featuredSkills.length || page.sections.length,
           itemListElement: (featuredSkills.length > 0 ? featuredSkills : page.sections).map((entry, index) => ({
             '@type': 'ListItem',

--- a/docs/integrations/jetski-cortex.md
+++ b/docs/integrations/jetski-cortex.md
@@ -5,7 +5,7 @@ description: "Use agentic-awesome-skills with Jetski/Cortex without hitting cont
 
 # Jetski/Cortex + Gemini: safe integration with 1,968+ skills
 
-> **Custom-host integration:** This guide documents a low-level, direct-manifest lazy loader for Jetski/Cortex and similar hosts. For Codex or Claude Code, the recommended path is [AAS Core](../users/aas-core.md), which provides verified local catalog discovery and deterministic recommendations through a bounded, read-only MCP server.
+> **Custom-host integration:** This guide documents a low-level, direct-manifest lazy loader for Jetski/Cortex and similar hosts. For Codex or Claude Code, the recommended path is [AAS Core](../users/aas-core.md), which provides neutral, deterministic catalog retrieval and validates exact agent-selected IDs through a bounded, read-only MCP server.
 
 This guide shows how to integrate the `agentic-awesome-skills` repository with an agent based on **Jetski/Cortex + Gemini** (or similar frameworks) **without exceeding the model context window**.
 

--- a/docs/integrations/jetski-gemini-loader/README.md
+++ b/docs/integrations/jetski-gemini-loader/README.md
@@ -1,6 +1,6 @@
 # Jetski + Gemini Lazy Skill Loader (Example)
 
-> **Custom-host example:** This is a low-level, direct-manifest integration for Jetski/Cortex-style hosts. Codex and Claude Code users should start with [AAS Core](../../users/aas-core.md), which exposes verified local catalog discovery and deterministic recommendations through a bounded, read-only MCP server.
+> **Custom-host example:** This is a low-level, direct-manifest integration for Jetski/Cortex-style hosts. Codex and Claude Code users should start with [AAS Core](../../users/aas-core.md), which exposes neutral, deterministic catalog retrieval and validates exact agent-selected IDs through a bounded, read-only MCP server.
 
 This example shows one way to integrate **agentic-awesome-skills** with a Jetski/Cortex‑style agent using **lazy loading** based on `@skill-id` mentions, instead of concatenating every `SKILL.md` into the prompt.
 

--- a/docs/maintainers/repo-growth-seo.md
+++ b/docs/maintainers/repo-growth-seo.md
@@ -6,7 +6,7 @@ This document keeps the repository's GitHub-facing discovery copy aligned with t
 
 Preferred positioning:
 
-> AAS Core is the local, deterministic engine that turns an explicit project profile into an explainable skill-stack recommendation and immutable preview plan, backed by 1,967+ cataloged skills.
+> AAS Core is the local, deterministic boundary that exposes the complete catalog, validates exact skill IDs selected by the coding agent from an explicit project profile, and produces an immutable preview plan, backed by 1,968+ cataloged skills.
 
 Key framing:
 
@@ -116,7 +116,7 @@ Start here:
 Suggested pinned discussion topics:
 
 - `Start here: compose a project stack with AAS Core`
-- `Choose between Core recommendation and direct distribution`
+- `Choose between an agent-selected Core stack and direct distribution`
 - `How the catalog, plugins, bundles, and workflows support Core`
 
 Discussion posts should:

--- a/docs/users/aas-core.md
+++ b/docs/users/aas-core.md
@@ -48,19 +48,19 @@ Give the agent the desired outcome and constraints, and leave selection judgment
 ```text
 Inspect this repository. Search and read the complete local AAS catalog, then
 choose the exact skills you judge most useful for this project. Use compose_stack
-to validate and pin those IDs in aas-stack.json, then use inspect_stack before
-presenting it. Do not install or apply anything.
+with a project profile to validate and pin those IDs in a schema 2 aas-stack.json,
+then use inspect_stack before presenting it. Do not install or apply anything.
 ```
 
 The local MCP exposes these read-only tools:
 
-- `search_skills` — search every skill in the verified local catalog;
+- `search_skills` — retrieve deterministic, paginated matches from every skill in the verified local catalog without scores or ranking;
 - `get_skill` — inspect one skill and optionally read its full content;
 - `compose_stack` — validate the agent-selected IDs and produce the pinned stack shape;
 - `inspect_stack` — validate and explain a proposed manifest;
 - `diff_stack` — compare manifests using verified local catalogs.
 
-Metadata returned by search or inspection is informational context. Core does not use risk, source, setup, compatibility, review, or evidence metadata to rank, exclude, or disable a skill.
+Search results use a stable catalog order and contain no relevance score, recommendation, or preferred ordering. Codex or Claude evaluates the returned candidates semantically and chooses exact IDs. Metadata returned by search or inspection is informational context; Core does not use risk, source, setup, compatibility, review, or evidence metadata to rank, exclude, or disable a skill.
 
 MCP calls do not install or remove skills, update catalogs, edit host configuration, or apply a stack. Full skill text is returned only when requested and remains marked as untrusted content.
 
@@ -70,7 +70,7 @@ MCP calls do not install or remove skills, update catalogs, edit host configurat
 
 ```json
 {
-  "schemaVersion": 1,
+  "schemaVersion": 2,
   "name": "project-stack",
   "catalog": {
     "package": "agentic-awesome-skills",
@@ -78,14 +78,20 @@ MCP calls do not install or remove skills, update catalogs, edit host configurat
     "integrity": "sha256-..."
   },
   "targets": [{ "host": "codex", "scope": "project" }],
-  "intent": { "goals": ["build", "test"] },
+  "profile": {
+    "goals": ["build", "test"],
+    "projectType": "web application",
+    "languages": ["typescript"],
+    "frameworks": ["react"],
+    "constraints": ["preview only"]
+  },
   "skills": [
     { "id": "example-skill" }
   ]
 }
 ```
 
-The manifest pins catalog identity, targets, goals, and exact skill IDs. It intentionally has no selection policy: Core validates identity and structure but does not overrule the agent's choice because metadata is missing, incomplete, or cautionary.
+The manifest pins catalog identity, targets, the project profile, and exact agent-selected skill IDs. It intentionally has no selection policy: Core validates identity and structure but does not overrule the agent's choice because metadata is missing, incomplete, or cautionary.
 
 ## Validate and preview the plan
 

--- a/docs/users/claude-code-skills.md
+++ b/docs/users/claude-code-skills.md
@@ -63,7 +63,7 @@ test -d .claude/skills || test -d ~/.claude/skills
 With AAS Core configured:
 
 ```text
-Inspect this security-review project, search and read the complete AAS catalog, choose the exact skills you judge most useful, and use compose_stack to propose aas-stack.json. Preview the plan without applying it.
+Inspect this security-review project, search and read the complete AAS catalog, and choose the exact skill IDs you judge most useful. Use compose_stack with a project profile, show me the schema 2 aas-stack.json, inspect it, and preview the plan without applying it.
 ```
 
 After installing or activating a chosen skill, direct invocation still works:

--- a/docs/users/codex-cli-skills.md
+++ b/docs/users/codex-cli-skills.md
@@ -21,7 +21,7 @@ Configure AAS Core for Codex, then describe the real task instead of manually se
 ## Why use this repo for Codex CLI
 
 - It gives Codex native, complete local catalog discovery through MCP.
-- It keeps the agent's exact selection, stack intent, validation, and planning inspectable.
+- It keeps the agent's exact selection, project profile, validation, and planning inspectable.
 - It separates read-only agent tools from approval-gated CLI mutations.
 - It is strong for local repo work where you want to move from planning to implementation to verification without changing libraries.
 - It includes both general-purpose engineering skills and deeper specialist tracks.
@@ -62,7 +62,7 @@ test -d .codex/skills || test -d ~/.codex/skills
 With AAS Core configured:
 
 ```text
-Use AAS to recommend the smallest skill stack for designing and testing this parser change. Show me the proposed aas-stack.json and preview the plan; do not apply it.
+Inspect this parser project, search and read the complete AAS catalog, and choose the exact skill IDs you judge most useful for designing and testing the change. Use compose_stack with a project profile, show me the schema 2 aas-stack.json, inspect it, and preview the plan; do not apply it.
 ```
 
 After installing or activating a chosen skill, direct invocation still works:

--- a/docs/users/skills-vs-mcp-tools.md
+++ b/docs/users/skills-vs-mcp-tools.md
@@ -3,9 +3,9 @@
 The short version is:
 
 - **Skills** are reusable `SKILL.md` playbooks that tell an AI assistant how to execute a workflow.
-- **AAS MCP** is the local, read-only interface through which an agent searches the verified AAS catalog, inspects evidence, and composes a proposed stack.
+- **AAS MCP** is the local, read-only interface through which an agent retrieves the verified AAS catalog without ranking, inspects evidence, and records its exact selected IDs in a proposed stack.
 - **Other MCP tools** connect an assistant to external systems such as APIs, databases, browsers, or hosted services.
-- **The `aas` CLI** validates durable stack intent and previews exact lifecycle operations under human control.
+- **The `aas` CLI** validates the durable project profile and agent-selected stack, then previews exact lifecycle operations under human control.
 
 These surfaces are complementary. AAS Core connects them around the approved `aas-stack.json` manifest.
 

--- a/docs/users/usage.md
+++ b/docs/users/usage.md
@@ -8,8 +8,8 @@ After configuring the local AAS MCP, ask your agent to inspect the repository an
 
 ```text
 Inspect this repository, search and read the complete AAS catalog, and choose the
-exact skills you judge most useful. Use compose_stack to propose aas-stack.json;
-do not apply it.
+exact skill IDs you judge most useful. Use compose_stack with a project profile,
+show me the schema 2 aas-stack.json, inspect it, and do not apply it.
 ```
 
 The agent should use `search_skills` and `get_skill` across the complete catalog, choose the exact IDs itself, call `compose_stack`, then check the proposal with `inspect_stack` before presenting it. Review the resulting `aas-stack.json`, validate it with `aas stack validate`, and use `aas stack plan` to preview the exact operations without materializing skills or managed state in the target.
@@ -22,7 +22,7 @@ Selection belongs to the coding agent. AAS MCP does not inspect the repository i
 
 ## Alternative workflow: direct skill installation
 
-If you came in through a **Claude Code** or **Codex** plugin instead of AAS Core or a full library install, invoke individual skills in prompts. Plugins ship a fixed plugin-safe subset; AAS Core instead composes a project stack from the verified catalog and records it in `aas-stack.json`. See [plugins.md](plugins.md) for the distribution model.
+If you came in through a **Claude Code** or **Codex** plugin instead of AAS Core or a full library install, invoke individual skills in prompts. Plugins ship a fixed plugin-safe subset; AAS Core instead validates and records the exact stack the agent selected from the verified catalog in `aas-stack.json`. See [plugins.md](plugins.md) for the distribution model.
 
 ### What direct distribution provides
 

--- a/docs/vietnamese/AAS_CORE.vi.md
+++ b/docs/vietnamese/AAS_CORE.vi.md
@@ -1,27 +1,27 @@
 # AAS Core
 
-**AAS Core** là lớp điều khiển cục bộ, ưu tiên agent được khuyến nghị cho Agentic Awesome Skills. Core cho phép Codex hoặc Claude Code tìm kiếm và kiểm tra catalog cục bộ đã xác minh, tạo đề xuất stack tối thiểu theo quy tắc xác định, rồi trình bày `aas-stack.json` và kế hoạch CLI để người dùng xem trước khi có bất kỳ thay đổi nào.
+**AAS Core** là lớp điều khiển cục bộ, ưu tiên agent được khuyến nghị cho Agentic Awesome Skills. Core cho phép Codex hoặc Claude Code tìm kiếm và đọc catalog cục bộ đã xác minh, tự chọn chính xác các ID skill, rồi lưu lựa chọn đó trong `aas-stack.json` để người dùng xem trước trước khi có bất kỳ thay đổi nào. Core không xếp hạng hay đề xuất skill.
 
 > **Ranh giới phát hành:** Gói npm 14.6.0 đã phát hành trước AAS Core và không thể dùng để bootstrap Core. Các gói hỗ trợ Core bắt đầu từ dòng 15.x; chỉ dùng một phiên bản chính xác có release notes tuyên bố rõ rằng nó bao gồm AAS Core.
 
 ## Luồng sử dụng
 
 1. Dùng AAS CLI chính thức để cấu hình MCP stdio cục bộ cho Codex hoặc Claude Code.
-2. Cho phép agent gọi `search_skills`, `get_skill` và `recommend_stack`; chỉ dùng `inspect_stack` hoặc `diff_stack` khi cần.
-3. Xem lại tệp `aas-stack.json` do agent đề xuất.
+2. Cho phép agent gọi `search_skills` và `get_skill`, tự đánh giá kết quả theo ngữ nghĩa, rồi gọi `compose_stack` với `profile` và các ID đã chọn; dùng `inspect_stack` để xác minh và `diff_stack` khi cần so sánh.
+3. Xem lại tệp `aas-stack.json` schema 2 chứa `profile` và đúng thứ tự ID do agent chọn.
 4. Dùng AAS CLI để xác thực manifest và xem trước kế hoạch chính xác.
 5. Dừng lại sau khi xem kế hoạch; chỉ nghiên cứu các giai đoạn sau nếu bạn chủ động tham gia phát triển preview có kiểm soát.
 
 ## Ranh giới tin cậy
 
 - AAS MCP chạy cục bộ và chỉ đọc; MCP không cài đặt, xóa, áp dụng hay cập nhật nội dung.
-- Đề xuất dựa trên quy tắc xác định và bằng chứng trong catalog, không dựa trên một lệnh gọi mô hình ẩn khác.
+- Kết quả tìm kiếm đầy đủ, phân trang và có thứ tự catalog ổn định; chúng không chứa điểm số hay thứ hạng. Codex hoặc Claude Code tự đánh giá và chọn skill.
 - `validate` và `plan` là luồng preview hiện được ghi nhận. `apply` và `recover` bị tắt theo mặc định và chưa phải là cam kết an toàn đã được chứng nhận.
 - Danh tính catalog và runtime được xác minh cục bộ. Theo mặc định, dữ liệu dự án không được gửi tới dịch vụ AAS.
 
 ## Quan hệ với plugin và cài đặt trực tiếp
 
-AAS Core là lớp điều phối và ra quyết định. Plugin, plugin chuyên biệt và bản cài đặt thư viện đầy đủ vẫn là các cách phân phối nội dung skill. Với Codex và Claude Code, nên dùng Core để xác định stack tối thiểu trước, rồi mới chọn cách phân phối phù hợp.
+AAS Core là lớp truy cập catalog, ghi nhận lựa chọn và xác thực; Codex hoặc Claude Code ra quyết định ngữ nghĩa. Plugin, plugin chuyên biệt và bản cài đặt thư viện đầy đủ vẫn là các cách phân phối nội dung skill. Với Codex và Claude Code, nên dùng Core để lưu stack do agent chọn trước, rồi mới chọn cách phân phối phù hợp.
 
 Các công cụ chưa có adapter AAS Core vẫn có thể dùng cách cài đặt trực tiếp, plugin hoặc tích hợp manifest tùy chỉnh.
 

--- a/docs/vietnamese/README.vi.md
+++ b/docs/vietnamese/README.vi.md
@@ -2,7 +2,7 @@
 
 > **Ghép stack kỹ năng cục bộ, xác định cho coding agent: từ hồ sơ dự án tường minh đến kế hoạch có thể xem lại trước mọi thay đổi trên target.**
 
-Codex hoặc Claude tự kiểm tra dự án; AAS không quét repository. Agent gửi một hồ sơ tường minh tới AAS MCP cục bộ, chỉ đọc. AAS Core đánh giá hồ sơ và policy dựa trên catalog cục bộ đã xác minh, rồi agent đề xuất `aas-stack.json`; CLI xác thực manifest và tạo kế hoạch preview bất biến trước khi thay đổi kỹ năng.
+Codex hoặc Claude tự kiểm tra dự án; AAS không quét repository. Agent tìm kiếm catalog cục bộ đầy đủ theo thứ tự ổn định, tự đánh giá kết quả không có điểm số hay xếp hạng, rồi gửi `profile` cùng chính xác các ID đã chọn tới `compose_stack`. AAS Core ghi nhận lựa chọn trong `aas-stack.json` schema 2; CLI xác thực manifest và tạo kế hoạch preview bất biến trước khi thay đổi kỹ năng.
 
 > **Ranh giới phát hành:** Gói npm 14.6.0 đã phát hành trước AAS Core và không thể dùng để bootstrap Core. Các gói hỗ trợ Core bắt đầu từ dòng 15.x; chỉ dùng một phiên bản chính xác có release notes tuyên bố rõ rằng nó bao gồm Core. Luồng preview được hỗ trợ dừng sau khi xem kế hoạch; `apply` và `recover` vẫn mang tính thử nghiệm. [Tìm hiểu AAS Core](AAS_CORE.vi.md).
 
@@ -15,7 +15,7 @@ Codex hoặc Claude tự kiểm tra dự án; AAS không quét repository. Agent
 [![OpenCode](https://img.shields.io/badge/OpenCode-CLI-gray)](https://github.com/opencode-ai/opencode)
 [![Antigravity](https://img.shields.io/badge/Antigravity-DeepMind-red)](https://github.com/sickn33/agentic-awesome-skills)
 
-Catalog gồm **1,967+ kỹ năng `SKILL.md`**, plugin chuyên biệt, bundle, workflow và installer trực tiếp vẫn rất quan trọng. Chúng là lớp nội dung, tuyển chọn, phân phối và tương thích xung quanh AAS Core, không phải sản phẩm chính cạnh tranh với Core:
+Catalog gồm **1,968+ kỹ năng `SKILL.md`**, plugin chuyên biệt, bundle, workflow và installer trực tiếp vẫn rất quan trọng. Chúng là lớp nội dung, tuyển chọn, phân phối và tương thích xung quanh AAS Core, không phải sản phẩm chính cạnh tranh với Core:
 
 - 🟣 **Claude Code** (Anthropic CLI)
 - 🔵 **Gemini CLI** (Google DeepMind)

--- a/docs_zh-CN/README.md
+++ b/docs_zh-CN/README.md
@@ -3,11 +3,11 @@
 
 > **面向编码代理的本地、确定性技能栈编排：从显式项目配置文件到任何目标变更前可审查的计划。**
 
-Codex 或 Claude 使用自身能力检查项目；AAS 不会扫描项目。代理向本地、只读的 AAS MCP 发送显式配置文件，AAS Core 根据经过验证的本地目录和策略返回可解释的建议。代理提出 `aas-stack.json`，随后 `aas` CLI 在任何技能变更前验证该清单并生成不可变的预览计划。
+Codex 或 Claude 使用自身能力检查项目；AAS 不会扫描项目。代理通过本地、只读的 AAS MCP 搜索完整目录，自行评估无分数、无排名的稳定分页结果，再把 `profile` 和精确的已选技能 ID 交给 `compose_stack`。AAS Core 将选择记录为 schema 2 的 `aas-stack.json`，随后 `aas` CLI 在任何技能变更前验证该清单并生成不可变的预览计划。
 
 > **发布边界：** 14.6.0 npm 包早于 AAS Core。支持 Core 的包从 15.x 系列开始，并且必须使用发布说明明确声明包含 Core 的精确版本。当前支持的预览路径在检查计划后停止；`apply` 和 `recover` 仍是实验功能。[了解 AAS Core](users/aas-core.md)。
 
-1,967+ 个 `SKILL.md`、专用插件、捆绑包、工作流和直接安装器仍然重要；它们是 AAS Core 周围的内容、策展、分发和兼容层，而不是并列的主要产品。
+1,968+ 个 `SKILL.md`、专用插件、捆绑包、工作流和直接安装器仍然重要；它们是 AAS Core 周围的内容、策展、分发和兼容层，而不是并列的主要产品。
 
 **从这里开始：** [AAS Core](users/aas-core.md) · [为仓库加星](https://github.com/sickn33/agentic-awesome-skills/stargazers) · [1 分钟安装](#installation) · [选择你的工具](#choose-your-tool) · [按工具查看最佳技能](#best-skills-by-tool) · [捆绑包](users/bundles.md) · [工作流](users/workflows.md)
 

--- a/docs_zh-CN/users/aas-core.md
+++ b/docs_zh-CN/users/aas-core.md
@@ -1,27 +1,27 @@
 # AAS Core
 
-**AAS Core** 是 Agentic Awesome Skills 推荐的本地、代理优先控制层。它让 Codex 或 Claude Code 根据经过验证的本地目录搜索和检查技能、生成确定性的最小技能栈建议，并在任何变更发生前提供可审查的 `aas-stack.json` 和 CLI 计划。
+**AAS Core** 是 Agentic Awesome Skills 推荐的本地、代理优先控制层。它让 Codex 或 Claude Code 搜索并读取经过验证的完整本地目录、自主选择精确的技能 ID，再由 Core 将该选择记录并验证为 `aas-stack.json`，以便在任何变更发生前审查 CLI 计划。Core 不对技能评分、排名或作出推荐。
 
 > **发布边界：** 14.6.0 npm 包早于 AAS Core，不能用于 Core 引导。支持 Core 的包从 15.x 系列开始；请只使用发布说明明确声明包含 AAS Core 的精确版本。
 
 ## 工作流程
 
 1. 使用官方 AAS CLI 为 Codex 或 Claude Code 配置本地 stdio MCP。
-2. 让代理调用 `search_skills`、`get_skill` 和 `recommend_stack`；需要时再调用 `inspect_stack` 或 `diff_stack`。
-3. 检查代理提出的 `aas-stack.json`。
+2. 让代理调用 `search_skills` 和 `get_skill`，自行对结果进行语义判断，然后用项目 `profile` 和已选 ID 调用 `compose_stack`；使用 `inspect_stack` 验证，需要比较时再调用 `diff_stack`。
+3. 检查 schema 2 的 `aas-stack.json`，确认其中的 `profile`、技能 ID 及其顺序与代理选择完全一致。
 4. 使用 AAS CLI 验证清单并预览精确计划。
 5. 检查计划后停止；只有在您明确参与受控预览开发时，才继续研究后续阶段。
 
 ## 信任边界
 
 - AAS MCP 在本地运行，并且只提供读取功能；它不会安装、删除、应用或更新任何内容。
-- 建议来自确定性规则和目录证据，而不是另一次隐藏的模型调用。
+- 搜索覆盖完整目录，结果可分页并按稳定的目录顺序返回，不包含相关性分数或排名；Codex 或 Claude Code 自行评估并选择技能。
 - `validate` 和 `plan` 是当前有文档支持的预览路径。`apply` 和 `recover` 默认禁用，不属于已经认证的预览安全声明。
 - 目录和运行时身份在本地验证。默认情况下，项目数据不会发送到 AAS 服务。
 
 ## 与插件和直接安装的关系
 
-AAS Core 是编排和决策层。插件、专用插件包和完整技能库安装仍然是技能内容的交付方式。对于 Codex 和 Claude Code，建议先使用 Core 确定最小技能栈，再选择适当的交付方式。
+AAS Core 是目录访问、选择记录和验证层；Codex 或 Claude Code 才负责语义决策。插件、专用插件包和完整技能库安装仍然是技能内容的交付方式。对于 Codex 和 Claude Code，建议先用 Core 保存代理选定的精确技能栈，再选择适当的交付方式。
 
 尚未提供 Core 主机适配器的工具仍可使用传统的直接安装、插件或自定义清单集成。
 

--- a/tools/lib/aas-v1/mcp/server.js
+++ b/tools/lib/aas-v1/mcp/server.js
@@ -97,10 +97,18 @@ const STACK_MANIFEST_SCHEMA = Object.freeze({
   },
 });
 
+const READ_ONLY_TOOL_ANNOTATIONS = Object.freeze({
+  readOnlyHint: true,
+  destructiveHint: false,
+  idempotentHint: true,
+  openWorldHint: false,
+});
+
 const TOOL_DEFINITIONS = Object.freeze([
   {
     name: "search_skills",
-    description: "Search the verified local AAS catalog without modifying local state.",
+    description: "Retrieve matching skills from the verified local AAS catalog in stable catalog order, without relevance scores, ranking, recommendations, or local-state changes.",
+    annotations: READ_ONLY_TOOL_ANNOTATIONS,
     inputSchema: {
       type: "object",
       additionalProperties: false,
@@ -114,6 +122,7 @@ const TOOL_DEFINITIONS = Object.freeze([
   {
     name: "get_skill",
     description: "Get the descriptive catalog record and, only when requested, explicitly untrusted full text for any local skill.",
+    annotations: READ_ONLY_TOOL_ANNOTATIONS,
     inputSchema: {
       type: "object",
       additionalProperties: false,
@@ -127,6 +136,7 @@ const TOOL_DEFINITIONS = Object.freeze([
   {
     name: "compose_stack",
     description: "Build a Core manifest from exact skill IDs already chosen by Codex or Claude. Core verifies catalog membership and preserves the selection without ranking, substitution, policy, or metadata filtering.",
+    annotations: READ_ONLY_TOOL_ANNOTATIONS,
     inputSchema: {
       type: "object",
       additionalProperties: false,
@@ -159,6 +169,7 @@ const TOOL_DEFINITIONS = Object.freeze([
   {
     name: "inspect_stack",
     description: "Validate an agent-selected in-memory AAS stack, its pinned catalog identity, and every selected skill ID without writing it.",
+    annotations: READ_ONLY_TOOL_ANNOTATIONS,
     inputSchema: {
       type: "object",
       additionalProperties: false,
@@ -169,6 +180,7 @@ const TOOL_DEFINITIONS = Object.freeze([
   {
     name: "diff_stack",
     description: "Diff a stack only against locally cached, integrity-verified catalogs.",
+    annotations: READ_ONLY_TOOL_ANNOTATIONS,
     inputSchema: {
       type: "object",
       additionalProperties: false,

--- a/tools/lib/aas-v1/search.js
+++ b/tools/lib/aas-v1/search.js
@@ -1,7 +1,7 @@
 "use strict";
 
 const { canonicalJson } = require("./canonical-json");
-const { compareStrings, sortedUnique, tokenize } = require("./normalize");
+const { sortedUnique, tokenize } = require("./normalize");
 
 const FORBIDDEN_QUERY_SYNTAX = /[\u0000-\u001f\u007f\\^$*?()[\]{}|]/u;
 
@@ -32,22 +32,24 @@ function searchSkills(catalog, input = {}) {
   }
   const queryTokens = sortedUnique(tokenize(query));
   const normalizedQuery = query.trim().toLowerCase();
-  const matches = catalog.skills.map((skill) => {
+  const exactMatch = normalizedQuery
+    ? catalog.skills.find((skill) => skill.id === normalizedQuery)
+    : null;
+  const candidates = exactMatch ? [exactMatch] : catalog.skills;
+  const matches = candidates.map((skill) => {
     const document = new Set(skill.searchTokens || []);
     const matchedTokens = queryTokens.filter((token) => document.has(token));
-    const exactId = normalizedQuery && skill.id === normalizedQuery ? 1 : 0;
-    const prefixId = normalizedQuery && skill.id.startsWith(normalizedQuery) ? 1 : 0;
-    const score = normalizedQuery ? exactId * 100000 + prefixId * 25000 + matchedTokens.length * 1000 : 1;
-    return { skill, score, matchedTokens };
-  }).filter((entry) => entry.score > 0)
-    .sort((left, right) => right.score - left.score || compareStrings(left.skill.id, right.skill.id));
+    const matchesQuery = !normalizedQuery
+      || skill.id.startsWith(normalizedQuery)
+      || matchedTokens.length > 0;
+    return { skill, matchedTokens, matchesQuery };
+  }).filter((entry) => entry.matchesQuery);
   const results = matches.slice(cursor, cursor + limit)
-    .map(({ skill, score, matchedTokens }) => {
+    .map(({ skill, matchedTokens }) => {
       const result = {
         id: skill.id,
         name: skill.name,
         category: skill.category,
-        score,
         matchedTokens,
         description: skill.description,
         tags: skill.tags,

--- a/tools/scripts/tests/aas_core_public_docs_contract.test.js
+++ b/tools/scripts/tests/aas_core_public_docs_contract.test.js
@@ -1,0 +1,87 @@
+#!/usr/bin/env node
+"use strict";
+
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const path = require("node:path");
+
+const repoRoot = path.resolve(__dirname, "../../..");
+
+const publicRoots = [
+  "README.md",
+  "docs/users",
+  "docs/vietnamese",
+  "docs_zh-CN",
+  "docs/integrations",
+  "docs/maintainers/repo-growth-seo.md",
+  "apps/web-app/index.html",
+  "apps/web-app/public/llms.txt",
+  "apps/web-app/public/site.webmanifest",
+  "apps/web-app/src/data/seoLandingPages.json",
+  "apps/web-app/src/pages/Home.tsx",
+  "apps/web-app/src/pages/SkillDetail.tsx",
+  "apps/web-app/src/utils/seo.ts",
+];
+
+const publicExtensions = new Set([".html", ".json", ".md", ".ts", ".tsx", ".txt"]);
+
+function collectPublicFiles(relativePath) {
+  const absolutePath = path.join(repoRoot, relativePath);
+  const stat = fs.statSync(absolutePath);
+  if (stat.isFile()) return [relativePath];
+
+  return fs.readdirSync(absolutePath, { withFileTypes: true })
+    .sort((left, right) => left.name.localeCompare(right.name))
+    .flatMap((entry) => {
+      const child = path.join(relativePath, entry.name);
+      if (entry.isDirectory()) return collectPublicFiles(child);
+      return publicExtensions.has(path.extname(entry.name)) ? [child] : [];
+    });
+}
+
+const publicFiles = publicRoots.flatMap(collectPublicFiles);
+
+for (const relativePath of publicFiles) {
+  const content = fs.readFileSync(path.join(repoRoot, relativePath), "utf8");
+  assert.doesNotMatch(
+    content,
+    /\brecommend_stack\b/,
+    `${relativePath} must not document the retired Core recommendation tool`,
+  );
+  assert.doesNotMatch(
+    content,
+    /"schemaVersion"\s*:\s*1(?=\s*[,}])/,
+    `${relativePath} must not publish a legacy Core stack example`,
+  );
+  assert.doesNotMatch(
+    content,
+    /"intent"\s*:/,
+    `${relativePath} must use the schema 2 profile field instead of intent`,
+  );
+
+  const affirmativeCoreSelectionClaims = content.match(
+    /\b(?:AAS Core|Core preview)[^.\n]{0,180}\b(?:recommend(?:s|ed|ing|ation|ations)?|rank(?:s|ed|ing)?)\b[^.\n]*/gi,
+  ) || [];
+  for (const claim of affirmativeCoreSelectionClaims) {
+    assert.match(
+      claim,
+      /\b(?:does not|do not|never|no (?:relevance )?(?:score|ranking|recommendation)|not (?:the )?output)\b/i,
+      `${relativePath} must attribute semantic selection to the coding agent, not Core: ${claim}`,
+    );
+  }
+
+  assert.doesNotMatch(
+    content,
+    /\bAAS Core(?: preview)?\s+(?:selects|chooses|evaluates|recommends|ranks)\b/i,
+    `${relativePath} must not make Core the semantic decision maker`,
+  );
+}
+
+const coreGuide = fs.readFileSync(path.join(repoRoot, "docs/users/aas-core.md"), "utf8");
+assert.match(coreGuide, /"schemaVersion"\s*:\s*2/);
+assert.match(coreGuide, /"profile"\s*:\s*\{/);
+assert.match(coreGuide, /"skills"\s*:\s*\[\s*\{\s*"id"\s*:/);
+assert.match(coreGuide, /stable catalog order and contain no relevance score/i);
+assert.match(coreGuide, /Codex or Claude evaluates the returned candidates semantically/i);
+
+console.log(`AAS Core public documentation contract passed (${publicFiles.length} files scanned).`);

--- a/tools/scripts/tests/aas_v1_core.test.js
+++ b/tools/scripts/tests/aas_v1_core.test.js
@@ -63,6 +63,31 @@ test("empty-query pagination enumerates the complete canonical catalog exactly o
   assert.equal(catalog.skills.length, canonicalSkillIds.length);
 });
 
+test("search retrieval preserves catalog order without scores or relevance ranking", () => {
+  const catalog = {
+    skills: [
+      { id: "z-first", name: "Z first", category: "test", searchTokens: ["alpha"], description: "", tags: [], triggers: [] },
+      { id: "a-many", name: "A many", category: "test", searchTokens: ["alpha", "beta"], description: "", tags: [], triggers: [] },
+      { id: "m-second", name: "M second", category: "test", searchTokens: ["beta"], description: "", tags: [], triggers: [] },
+      { id: "unrelated", name: "Unrelated", category: "test", searchTokens: ["gamma"], description: "", tags: [], triggers: [] },
+    ],
+  };
+
+  const firstPage = core.searchSkills(catalog, { query: "alpha beta", cursor: 0, limit: 2 });
+  const secondPage = core.searchSkills(catalog, { query: "alpha beta", cursor: firstPage.nextCursor, limit: 2 });
+  assert.deepEqual(firstPage.results.map((entry) => entry.id), ["z-first", "a-many"]);
+  assert.deepEqual(secondPage.results.map((entry) => entry.id), ["m-second"]);
+  assert.equal(firstPage.totalMatches, 3);
+  assert.equal(secondPage.nextCursor, null);
+  for (const result of [...firstPage.results, ...secondPage.results]) {
+    assert.equal(Object.hasOwn(result, "score"), false);
+    assert.equal(Object.hasOwn(result, "rank"), false);
+  }
+
+  const exact = core.searchSkills(catalog, { query: "a-many", limit: 50 });
+  assert.deepEqual(exact.results.map((entry) => entry.id), ["a-many"]);
+});
+
 test("every canonical skill is directly gettable, exactly searchable, and agent-composable", () => {
   const catalog = core.loadBundledCatalog();
 
@@ -71,7 +96,10 @@ test("every canonical skill is directly gettable, exactly searchable, and agent-
     assert.equal(skill.id, id);
 
     const search = core.searchSkills(catalog, { query: id, limit: 1 });
+    assert.equal(search.totalMatches, 1);
     assert.equal(search.results[0]?.id, id, `exact search did not return ${id} first`);
+    assert.equal(Object.hasOwn(search.results[0], "score"), false);
+    assert.equal(Object.hasOwn(search.results[0], "rank"), false);
 
     const composed = core.composeStack(catalog, selection([id]));
     assert.equal(composed.ok, true);
@@ -114,6 +142,8 @@ test("Core exposes descriptive catalog data and agent selections without policy 
     "proposedStack",
     "discoveryCandidates",
     "exclusions",
+    "score",
+    "rank",
   ]);
 
   assert.equal(core.recommendStack, undefined);

--- a/tools/scripts/tests/aas_v1_mcp.test.js
+++ b/tools/scripts/tests/aas_v1_mcp.test.js
@@ -100,6 +100,14 @@ test("MCP exposes the five agent-owned selection tools and one skill resource te
     "inspect_stack",
     "diff_stack",
   ]);
+  for (const definition of tools.result.tools) {
+    assert.deepEqual(definition.annotations, {
+      readOnlyHint: true,
+      destructiveHint: false,
+      idempotentHint: true,
+      openWorldHint: false,
+    });
+  }
   assert.equal(tools.result._meta.catalog.digest.startsWith("sha256-"), true);
   assert.equal(tools.result._meta.catalogSchemaVersion, "2.0.0");
   assert.equal(Object.hasOwn(tools.result._meta, "metadataSchemaVersion"), false);
@@ -110,6 +118,8 @@ test("MCP exposes the five agent-owned selection tools and one skill resource te
   assert.equal(searchDefinition.inputSchema.properties.cursor.minimum, 0);
   assert.equal(searchDefinition.inputSchema.properties.limit.maximum, 50);
   assert.equal(Object.hasOwn(searchDefinition.inputSchema.properties, "target"), false);
+  assert.match(searchDefinition.description, /stable catalog order/);
+  assert.match(searchDefinition.description, /without relevance scores, ranking, recommendations/);
 
   const composeDefinition = tools.result.tools.find((entry) => entry.name === "compose_stack");
   assert.deepEqual(composeDefinition.inputSchema.required, ["profile", "skillIds"]);
@@ -157,6 +167,10 @@ test("empty search paginates every catalog ID and every result is selectable", a
     assert.equal(response.result.isError, false);
     assert.equal(response.result.structuredContent.ok, true);
     assert.equal(response.result.structuredContent.totalMatches, expected.length);
+    for (const result of response.result.structuredContent.results) {
+      assert.equal(Object.hasOwn(result, "score"), false);
+      assert.equal(Object.hasOwn(result, "rank"), false);
+    }
     ids.push(...response.result.structuredContent.results.map((skill) => skill.id));
     cursor = response.result.structuredContent.nextCursor;
   } while (cursor !== null);
@@ -185,6 +199,8 @@ test("search, get, resource read, explicit composition, inspection, and unavaila
     params: { name: "search_skills", arguments: { query: "android ui", limit: 3 }, _meta: { progressToken: "codex-search-1" } },
   });
   assert.equal(search.result.isError, false);
+  assert.equal(search.result.structuredContent.results.every((result) => !Object.hasOwn(result, "score")), true);
+  assert.equal(search.result.structuredContent.results.every((result) => !Object.hasOwn(result, "rank")), true);
   const skillIds = search.result.structuredContent.results.slice(0, 2).map((skill) => skill.id);
   assert.equal(skillIds.length, 2);
 


### PR DESCRIPTION
# Pull Request Description

Makes AAS Core retrieval neutral and aligns the complete current public contract with agent-owned selection.

- removes relevance scores and ranking from search_skills while preserving deterministic catalog-order pagination and exact-ID lookup;
- declares all five MCP tools read-only, non-destructive, idempotent, and closed-world for isolated non-interactive clients;
- updates current English, Chinese, Vietnamese, integration, and hosted-app copy to schemaVersion 2, profile, and exact agent-selected IDs;
- adds regression coverage for 133 public documentation surfaces and all 1,968 exact-search/get/compose paths.

## Change Classification

- [ ] Skill PR
- [x] Docs PR
- [x] Infra PR

## Quality Bar Checklist ✅

- [x] **Standards**: Maintainer and security guidance reviewed.
- [x] **Metadata**: No SKILL.md content changed; npm run validate passed for all 1,968 skills.
- [x] **Risk Label**: Not applicable; no skill metadata changed.
- [x] **Triggers**: Not applicable; no skill content changed.
- [x] **Limitations**: Not applicable; no skill content changed.
- [x] **Security**: No offensive skill content changed.
- [x] **Safety scan**: npm run security:docs passed.
- [x] **Automated Skill Review**: Not applicable; no SKILL.md changed.
- [x] **Manual Logic Review**: Retrieval neutrality, MCP annotations, schema contract, and client behavior reviewed directly.
- [x] **Local Test**: Targeted Core/MCP tests, full test:aas-v1, full repository suite, web tests/coverage/build, and a real isolated Codex search_skills probe passed.
- [x] **Repo Checks**: validate, validate:references, warning budget, consistency, catalog check, and chain passed.
- [x] **Source-Only PR**: No generated registry artifacts are included.
- [x] **Credits**: Not applicable; no external source added.
- [x] **License provenance**: Not applicable; no external skill source added.
- [x] **Maintainer Edits**: Enabled by repository defaults.

## Validation

- Core: 126/126
- Web: 148/148; coverage and production build passed
- Catalog: 1,968 records, deterministic digest unchanged
- Public docs contract: 133 files scanned
- Full repository suite: passed
