### PR TITLE
fix: expose safe Core validation details

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Preserved bounded, path-safe schema diagnostics across Core and MCP errors so invalid profiles identify the logical field, validation keyword, and applicable limit without echoing input values, unknown property names, schema internals, or filesystem paths.
 - Corrected current public Core examples to use manifest schema 2 with `profile` and exact agent-selected IDs, with a regression test spanning English, Chinese, Vietnamese, integration, and hosted-app copy.
 - Marked all five local MCP tools explicitly read-only, non-destructive, idempotent, and closed-world so isolated non-interactive Codex clients can invoke the catalog workflow without treating the calls as approval-gated mutations.
 

--- a/tools/lib/aas-v1/mcp/server.js
+++ b/tools/lib/aas-v1/mcp/server.js
@@ -4,6 +4,7 @@ const fs = require("node:fs");
 const path = require("node:path");
 const core = require("..");
 const { validateManifest } = require("../stack");
+const { sanitizeValidationDetails } = require("../schema-validator");
 
 const TOOL_NAMES = Object.freeze([
   "search_skills",
@@ -226,14 +227,14 @@ function versionFields(catalog) {
   };
 }
 
-function structuredError(catalog, code, category = "invalidInput") {
+function structuredError(catalog, code, category = "invalidInput", details = {}) {
   return {
     ok: false,
     status: "error",
     ...versionFields(catalog),
     code,
     category,
-    details: {},
+    details: sanitizeValidationDetails(details),
   };
 }
 
@@ -486,7 +487,11 @@ class McpServer {
       return this.rpcResult(request.id, toolResult(payload, payload.ok === false));
     } catch (error) {
       const code = typeof error?.code === "string" ? error.code : "AAS_MCP_TOOL_FAILED";
-      return this.rpcResult(request.id, toolResult(structuredError(this.catalog, code), true));
+      const category = typeof error?.category === "string" ? error.category : "invalidInput";
+      return this.rpcResult(
+        request.id,
+        toolResult(structuredError(this.catalog, code, category, error?.details), true),
+      );
     }
   }
 

--- a/tools/lib/aas-v1/schema-validator.js
+++ b/tools/lib/aas-v1/schema-validator.js
@@ -7,6 +7,95 @@ const Ajv2020 = require("ajv/dist/2020");
 const SCHEMA_ROOT = path.resolve(__dirname, "../../../schemas/aas-v1");
 const ajv = new Ajv2020({ allErrors: true, strict: true, allowUnionTypes: true, validateFormats: false });
 const validators = new Map();
+const ISSUE_KEYWORDS = new Set([
+  "additionalProperties",
+  "const",
+  "enum",
+  "maxItems",
+  "maxLength",
+  "minItems",
+  "minLength",
+  "minimum",
+  "oneOf",
+  "pattern",
+  "propertyNames",
+  "required",
+  "type",
+  "uniqueItems",
+]);
+const SAFE_FIELD_SEGMENTS = new Set([
+  "catalog",
+  "constraints",
+  "frameworks",
+  "goals",
+  "host",
+  "id",
+  "input",
+  "integrity",
+  "languages",
+  "manifest",
+  "metadata",
+  "name",
+  "package",
+  "profile",
+  "projectType",
+  "schemaVersion",
+  "scope",
+  "skillIds",
+  "skills",
+  "stack",
+  "targets",
+  "toCatalogDigest",
+  "version",
+]);
+
+function logicalField(pathValue) {
+  if (typeof pathValue !== "string" || pathValue === "" || pathValue === "$") return "input";
+  const pointer = pathValue.startsWith("/")
+    ? pathValue.slice(1).split("/").map((part) => part.replace(/~1/g, "/").replace(/~0/g, "~"))
+    : pathValue.replace(/^\$\.?/, "").replace(/\[(\d*)\]/g, ".$index").split(".");
+  let result = "";
+  for (const part of pointer.filter(Boolean).slice(0, 16)) {
+    if (/^\d+$/.test(part) || part === "$index") {
+      result += "[]";
+    } else if (SAFE_FIELD_SEGMENTS.has(part)) {
+      result += result ? `.${part}` : part;
+    } else {
+      result += result ? ".[unknown]" : "[unknown]";
+    }
+  }
+  return result || "input";
+}
+
+function issueLimit(issue) {
+  if (Number.isSafeInteger(issue?.limit) && issue.limit >= 0) return issue.limit;
+  if (typeof issue?.limit === "boolean") return issue.limit;
+  if (typeof issue?.limit === "string" && /^[a-z]{1,16}$/.test(issue.limit)) return issue.limit;
+  const keyword = issue?.keyword;
+  const params = issue?.params;
+  if (["maxItems", "maxLength", "minItems", "minLength"].includes(keyword)
+    && Number.isSafeInteger(params?.limit) && params.limit >= 0) return params.limit;
+  if (keyword === "additionalProperties") return false;
+  if (keyword === "type" && typeof params?.type === "string" && /^[a-z]{1,16}$/.test(params.type)) return params.type;
+  return undefined;
+}
+
+function sanitizeValidationDetails(details) {
+  if (!details || !Array.isArray(details.issues)) return {};
+  const issues = [];
+  for (const source of details.issues.slice(0, 32)) {
+    if (!source || typeof source !== "object" || !ISSUE_KEYWORDS.has(source.keyword)) continue;
+    const entry = {
+      field: logicalField(source.field ?? source.instancePath ?? source.path),
+      keyword: source.keyword,
+    };
+    if (typeof source.code === "string" && /^AAS_[A-Z0-9_]{1,96}$/.test(source.code)) entry.code = source.code;
+    const limit = issueLimit(source);
+    if (limit !== undefined) entry.limit = limit;
+    issues.push(entry);
+  }
+  return issues.length ? { issues } : {};
+}
 
 function validatorFor(name) {
   if (validators.has(name)) return validators.get(name);
@@ -23,13 +112,8 @@ function validateInstance(name, value, code = "AAS_SCHEMA_INSTANCE_INVALID", cat
   const error = new Error(code);
   error.code = code;
   error.category = category;
-  error.details = {
-    issues: (validate.errors || []).slice(0, 32).map((issue) => ({
-      instancePath: issue.instancePath,
-      keyword: issue.keyword,
-    })),
-  };
+  error.details = sanitizeValidationDetails({ issues: validate.errors || [] });
   throw error;
 }
 
-module.exports = { SCHEMA_ROOT, validateInstance, validatorFor };
+module.exports = { SCHEMA_ROOT, sanitizeValidationDetails, validateInstance, validatorFor };

--- a/tools/lib/aas-v1/stack/manifest.js
+++ b/tools/lib/aas-v1/stack/manifest.js
@@ -2,6 +2,7 @@
 
 const versions = require("../versions");
 const { canonicalJson, sha256 } = require("../canonical-json");
+const { sanitizeValidationDetails } = require("../schema-validator");
 
 const DIGEST_PATTERN = /^sha256-[a-f0-9]{64}$/;
 const ID_PATTERN = /^[a-z0-9][a-z0-9._-]*(?:\/[a-z0-9][a-z0-9._-]*)*$/;
@@ -15,25 +16,33 @@ function isPlainObject(value) {
   return prototype === Object.prototype || prototype === null;
 }
 
-function issue(path, code, details = {}) {
-  return { path, code, ...details };
+function issue(field, code, keyword, limit) {
+  return { field, code, keyword, ...(limit === undefined ? {} : { limit }) };
 }
 
 function rejectUnknownKeys(value, allowed, path, issues) {
   if (!isPlainObject(value)) return;
   for (const key of Object.keys(value).sort()) {
-    if (!allowed.has(key)) issues.push(issue(`${path}.${key}`, "AAS_STACK_FIELD_UNKNOWN"));
+    if (!allowed.has(key)) issues.push(issue(path, "AAS_STACK_FIELD_UNKNOWN", "additionalProperties", false));
   }
 }
 
 function validateString(value, path, issues, options = {}) {
   const { minimum = 1, maximum = 256, pattern } = options;
-  if (typeof value !== "string" || value.length < minimum || value.length > maximum) {
-    issues.push(issue(path, "AAS_STACK_STRING_INVALID"));
+  if (typeof value !== "string") {
+    issues.push(issue(path, "AAS_STACK_STRING_INVALID", "type", "string"));
+    return false;
+  }
+  if (value.length < minimum) {
+    issues.push(issue(path, "AAS_STACK_STRING_INVALID", "minLength", minimum));
+    return false;
+  }
+  if (value.length > maximum) {
+    issues.push(issue(path, "AAS_STACK_STRING_INVALID", "maxLength", maximum));
     return false;
   }
   if (pattern && !pattern.test(value)) {
-    issues.push(issue(path, "AAS_STACK_STRING_FORMAT_INVALID"));
+    issues.push(issue(path, "AAS_STACK_STRING_FORMAT_INVALID", "pattern"));
     return false;
   }
   return true;
@@ -41,15 +50,23 @@ function validateString(value, path, issues, options = {}) {
 
 function validateUniqueStringArray(value, path, issues, options = {}) {
   const { minimum = 0, maximum = 64, pattern, allowed } = options;
-  if (!Array.isArray(value) || value.length < minimum || value.length > maximum) {
-    issues.push(issue(path, "AAS_STACK_ARRAY_INVALID"));
+  if (!Array.isArray(value)) {
+    issues.push(issue(path, "AAS_STACK_ARRAY_INVALID", "type", "array"));
+    return;
+  }
+  if (value.length < minimum) {
+    issues.push(issue(path, "AAS_STACK_ARRAY_INVALID", "minItems", minimum));
+    return;
+  }
+  if (value.length > maximum) {
+    issues.push(issue(path, "AAS_STACK_ARRAY_INVALID", "maxItems", maximum));
     return;
   }
   const seen = new Set();
   value.forEach((entry, index) => {
     if (!validateString(entry, `${path}[${index}]`, issues, { maximum: 128, pattern })) return;
-    if (allowed && !allowed.has(entry)) issues.push(issue(`${path}[${index}]`, "AAS_STACK_VALUE_UNSUPPORTED"));
-    if (seen.has(entry)) issues.push(issue(`${path}[${index}]`, "AAS_STACK_VALUE_DUPLICATE"));
+    if (allowed && !allowed.has(entry)) issues.push(issue(`${path}[${index}]`, "AAS_STACK_VALUE_UNSUPPORTED", "enum"));
+    if (seen.has(entry)) issues.push(issue(`${path}[${index}]`, "AAS_STACK_VALUE_DUPLICATE", "uniqueItems"));
     seen.add(entry);
   });
 }
@@ -62,13 +79,13 @@ function invalidResult(issues) {
     ...versions,
     code: "AAS_STACK_MANIFEST_INVALID",
     category: "invalidInput",
-    details: { issues },
+    details: sanitizeValidationDetails({ issues }),
   };
 }
 
 function validateManifest(manifest) {
   const issues = [];
-  if (!isPlainObject(manifest)) return invalidResult([issue("$", "AAS_STACK_OBJECT_REQUIRED")]);
+  if (!isPlainObject(manifest)) return invalidResult([issue("manifest", "AAS_STACK_OBJECT_REQUIRED", "type", "object")]);
 
   rejectUnknownKeys(
     manifest,
@@ -77,11 +94,11 @@ function validateManifest(manifest) {
     issues,
   );
 
-  if (manifest.schemaVersion !== 2) issues.push(issue("$.schemaVersion", "AAS_STACK_SCHEMA_VERSION_UNSUPPORTED"));
+  if (manifest.schemaVersion !== 2) issues.push(issue("schemaVersion", "AAS_STACK_SCHEMA_VERSION_UNSUPPORTED", "const", 2));
   validateString(manifest.name, "$.name", issues, { maximum: 128, pattern: /^[A-Za-z0-9][A-Za-z0-9._ -]*$/ });
 
   if (!isPlainObject(manifest.catalog)) {
-    issues.push(issue("$.catalog", "AAS_STACK_OBJECT_REQUIRED"));
+    issues.push(issue("catalog", "AAS_STACK_OBJECT_REQUIRED", "type", "object"));
   } else {
     rejectUnknownKeys(manifest.catalog, new Set(["package", "version", "integrity"]), "$.catalog", issues);
     validateString(manifest.catalog.package, "$.catalog.package", issues, { maximum: 214, pattern: PACKAGE_PATTERN });
@@ -90,26 +107,28 @@ function validateManifest(manifest) {
   }
 
   if (!Array.isArray(manifest.targets) || manifest.targets.length < 1 || manifest.targets.length > 8) {
-    issues.push(issue("$.targets", "AAS_STACK_TARGETS_INVALID"));
+    const keyword = !Array.isArray(manifest.targets) ? "type" : manifest.targets.length < 1 ? "minItems" : "maxItems";
+    const limit = keyword === "type" ? "array" : keyword === "minItems" ? 1 : 8;
+    issues.push(issue("targets", "AAS_STACK_TARGETS_INVALID", keyword, limit));
   } else {
     const seenTargets = new Set();
     manifest.targets.forEach((target, index) => {
       const path = `$.targets[${index}]`;
       if (!isPlainObject(target)) {
-        issues.push(issue(path, "AAS_STACK_OBJECT_REQUIRED"));
+        issues.push(issue(path, "AAS_STACK_OBJECT_REQUIRED", "type", "object"));
         return;
       }
       rejectUnknownKeys(target, new Set(["host", "scope"]), path, issues);
-      if (!SUPPORTED_HOSTS.has(target.host)) issues.push(issue(`${path}.host`, "AAS_STACK_TARGET_HOST_UNSUPPORTED"));
-      if (!SUPPORTED_SCOPES.has(target.scope)) issues.push(issue(`${path}.scope`, "AAS_STACK_TARGET_SCOPE_UNSUPPORTED"));
+      if (!SUPPORTED_HOSTS.has(target.host)) issues.push(issue(`${path}.host`, "AAS_STACK_TARGET_HOST_UNSUPPORTED", "enum"));
+      if (!SUPPORTED_SCOPES.has(target.scope)) issues.push(issue(`${path}.scope`, "AAS_STACK_TARGET_SCOPE_UNSUPPORTED", "enum"));
       const key = `${target.host}:${target.scope}`;
-      if (seenTargets.has(key)) issues.push(issue(path, "AAS_STACK_TARGET_DUPLICATE"));
+      if (seenTargets.has(key)) issues.push(issue(path, "AAS_STACK_TARGET_DUPLICATE", "uniqueItems"));
       seenTargets.add(key);
     });
   }
 
   if (!isPlainObject(manifest.profile)) {
-    issues.push(issue("$.profile", "AAS_STACK_OBJECT_REQUIRED"));
+    issues.push(issue("profile", "AAS_STACK_OBJECT_REQUIRED", "type", "object"));
   } else {
     rejectUnknownKeys(manifest.profile, new Set(["goals", "projectType", "languages", "frameworks", "constraints"]), "$.profile", issues);
     validateUniqueStringArray(manifest.profile.goals, "$.profile.goals", issues, {
@@ -125,18 +144,19 @@ function validateManifest(manifest) {
   }
 
   if (!Array.isArray(manifest.skills) || manifest.skills.length > 128) {
-    issues.push(issue("$.skills", "AAS_STACK_SKILLS_INVALID"));
+    const keyword = !Array.isArray(manifest.skills) ? "type" : "maxItems";
+    issues.push(issue("skills", "AAS_STACK_SKILLS_INVALID", keyword, keyword === "type" ? "array" : 128));
   } else {
     const seenSkills = new Set();
     manifest.skills.forEach((skill, index) => {
       const path = `$.skills[${index}]`;
       if (!isPlainObject(skill)) {
-        issues.push(issue(path, "AAS_STACK_OBJECT_REQUIRED"));
+        issues.push(issue(path, "AAS_STACK_OBJECT_REQUIRED", "type", "object"));
         return;
       }
       rejectUnknownKeys(skill, new Set(["id"]), path, issues);
       if (validateString(skill.id, `${path}.id`, issues, { maximum: 256, pattern: ID_PATTERN })) {
-        if (seenSkills.has(skill.id)) issues.push(issue(`${path}.id`, "AAS_STACK_SKILL_DUPLICATE"));
+        if (seenSkills.has(skill.id)) issues.push(issue(`${path}.id`, "AAS_STACK_SKILL_DUPLICATE", "uniqueItems"));
         seenSkills.add(skill.id);
       }
     });

--- a/tools/scripts/tests/aas_v1_mcp.test.js
+++ b/tools/scripts/tests/aas_v1_mcp.test.js
@@ -319,6 +319,81 @@ test("search, get, resource read, explicit composition, inspection, and unavaila
   assert.equal(diff.result.structuredContent.code, "AAS_MCP_VERIFIED_CATALOG_NOT_AVAILABLE");
 });
 
+test("MCP propagates structured path-safe profile validation diagnostics", async () => {
+  const server = await initializedServer();
+  const catalog = core.loadBundledCatalog({ root: ROOT });
+  const selectedId = catalog.skills[0].id;
+  const response = await server.handle({
+    jsonrpc: "2.0",
+    id: 150,
+    method: "tools/call",
+    params: {
+      name: "compose_stack",
+      arguments: {
+        profile: {
+          goals: ["test"],
+          languages: [],
+          frameworks: ["x".repeat(129)],
+          constraints: [],
+        },
+        skillIds: [selectedId],
+      },
+    },
+  });
+
+  assert.equal(response.result.isError, true);
+  assert.equal(response.result.structuredContent.code, "AAS_STACK_MANIFEST_INVALID");
+  assert.deepEqual(response.result.structuredContent.details.issues, [{
+    field: "profile.frameworks[]",
+    keyword: "maxLength",
+    code: "AAS_STACK_STRING_INVALID",
+    limit: 128,
+  }]);
+  assert.deepEqual(
+    JSON.parse(response.result.content[0].text).details,
+    response.result.structuredContent.details,
+  );
+
+  const sensitiveKey = "/private/project/TOKEN_CANARY";
+  const forbidden = await server.handle({
+    jsonrpc: "2.0",
+    id: 151,
+    method: "tools/call",
+    params: {
+      name: "compose_stack",
+      arguments: {
+        profile: { goals: ["test"], [sensitiveKey]: "SECRET_VALUE_CANARY" },
+        skillIds: [selectedId],
+      },
+    },
+  });
+  assert.equal(forbidden.result.isError, true);
+  assert.equal(forbidden.result.structuredContent.code, "AAS_SELECTION_INPUT_INVALID");
+  assert.deepEqual(forbidden.result.structuredContent.details.issues, [{
+    field: "profile",
+    keyword: "additionalProperties",
+    limit: false,
+  }]);
+  assert.doesNotMatch(JSON.stringify(forbidden), /private|TOKEN_CANARY|SECRET_VALUE_CANARY|schemaPath|instancePath/);
+
+  const malformed = await server.handle({
+    jsonrpc: "2.0",
+    id: 152,
+    method: "tools/call",
+    params: {
+      name: "compose_stack",
+      arguments: { profile: "SECRET_PROFILE_CANARY", skillIds: [selectedId] },
+    },
+  });
+  assert.equal(malformed.result.isError, true);
+  assert.deepEqual(malformed.result.structuredContent.details.issues, [{
+    field: "profile",
+    keyword: "type",
+    limit: "object",
+  }]);
+  assert.doesNotMatch(JSON.stringify(malformed), /SECRET_PROFILE_CANARY|schemaPath|instancePath/);
+});
+
 test("composition rejects unknown, duplicate, missing, and mismatched selections without trusting skill prose", async () => {
   const server = await initializedServer();
   const catalog = core.loadBundledCatalog({ root: ROOT });

--- a/tools/scripts/tests/aas_v1_stack.test.js
+++ b/tools/scripts/tests/aas_v1_stack.test.js
@@ -7,7 +7,7 @@ const test = require("node:test");
 const versions = require("../../lib/aas-v1/versions");
 const { canonicalJson, sha256 } = require("../../lib/aas-v1/canonical-json");
 const { buildPlanEnvelope, validateManifest, validatePlanEnvelope } = require("../../lib/aas-v1/stack");
-const { validateInstance } = require("../../lib/aas-v1/schema-validator");
+const { sanitizeValidationDetails, validateInstance } = require("../../lib/aas-v1/schema-validator");
 
 const DIGEST_A = `sha256-${"a".repeat(64)}`;
 const DIGEST_B = `sha256-${"b".repeat(64)}`;
@@ -123,7 +123,61 @@ test("validateManifest returns a canonical digest with the agent-provided profil
   const withLegacyPolicy = { ...value, policy: { requireKnownSource: true } };
   const invalid = validateManifest(withLegacyPolicy);
   assert.equal(invalid.ok, false);
-  assert(invalid.details.issues.some((entry) => entry.path === "$.policy" && entry.code === "AAS_STACK_FIELD_UNKNOWN"));
+  assert(invalid.details.issues.some((entry) => (
+    entry.field === "input"
+      && entry.keyword === "additionalProperties"
+      && entry.limit === false
+      && entry.code === "AAS_STACK_FIELD_UNKNOWN"
+  )));
+});
+
+test("validateManifest reports bounded path-safe profile diagnostics without echoing input", () => {
+  const sensitiveKey = "/Users/example/private/TOKEN_CANARY";
+  const cases = [
+    {
+      value: manifest({ profile: { ...manifest().profile, goals: ["x".repeat(129)] } }),
+      expected: { field: "profile.goals[]", keyword: "maxLength", limit: 128 },
+    },
+    {
+      value: manifest({ profile: { ...manifest().profile, languages: Array.from({ length: 33 }, (_, index) => `lang-${index}`) } }),
+      expected: { field: "profile.languages", keyword: "maxItems", limit: 32 },
+    },
+    {
+      value: manifest({ profile: { ...manifest().profile, [sensitiveKey]: "SECRET_VALUE_CANARY" } }),
+      expected: { field: "profile", keyword: "additionalProperties", limit: false },
+    },
+    {
+      value: manifest({ profile: "SECRET_PROFILE_CANARY" }),
+      expected: { field: "profile", keyword: "type", limit: "object" },
+    },
+  ];
+
+  for (const { value, expected } of cases) {
+    const result = validateManifest(value);
+    assert.equal(result.ok, false);
+    assert(result.details.issues.some((entry) => (
+      entry.field === expected.field
+        && entry.keyword === expected.keyword
+        && entry.limit === expected.limit
+    )), `missing diagnostic ${JSON.stringify(expected)}`);
+    const serialized = JSON.stringify(result);
+    assert.doesNotMatch(serialized, /Users|TOKEN_CANARY|SECRET_VALUE_CANARY|SECRET_PROFILE_CANARY|schemaPath|instancePath/);
+    assert(result.details.issues.length <= 32);
+  }
+});
+
+test("schema diagnostics redact dynamic map keys even when they look path-safe", () => {
+  const details = sanitizeValidationDetails({
+    issues: [{
+      instancePath: "/metadata/TOKEN_SECRET_CANARY",
+      keyword: "type",
+      params: { type: "string" },
+    }],
+  });
+  assert.deepEqual(details, {
+    issues: [{ field: "metadata.[unknown]", keyword: "type", limit: "string" }],
+  });
+  assert.doesNotMatch(JSON.stringify(details), /TOKEN_SECRET_CANARY/);
 });
 
 test("validateManifest rejects duplicates, unsafe ids, legacy policy, and unsupported targets", () => {


### PR DESCRIPTION
## Summary

- preserve structured validation details across the MCP error boundary
- expose only bounded, allow-listed `field`, `keyword`, `limit`, and stable Core code values
- redact dynamic property names, input values, AJV internals, and filesystem paths
- cover overlong strings, oversized arrays, forbidden fields, malformed profiles, and dynamic-key canaries

## Change Classification

- [ ] Skill PR
- [ ] Docs PR
- [x] Infra PR

## Quality Bar Checklist

- [x] **Standards**: Reviewed the repository quality and security contracts.
- [x] **Safety scan**: `npm run security:docs` passed.
- [x] **Local Test**: Targeted tests, `npm run test:aas-v1`, and the full repository suite passed.
- [x] **Repo Checks**: `npm run validate`, `npm run validate:references`, warning budget, consistency audit, catalog integrity, and `npm audit` passed.
- [x] **Source-Only PR**: No generated registry artifacts are included.
- [x] **Maintainer Edits**: Enabled for this same-repository maintainer branch.

Skill metadata, risk labels, triggers, limitations, skill review, credits, and license provenance are not applicable because no `SKILL.md` or bundled skill content changes.

## Validation

- Core: 129/129
- Catalog: 1,968 records; digest unchanged
- Full repository suite: passed
- Independent security review: no remaining findings
