### PR TITLE
test: keep catalog enumeration dynamic

### DIFF
--- a/tools/scripts/tests/aas_v1_mcp.test.js
+++ b/tools/scripts/tests/aas_v1_mcp.test.js
@@ -208,7 +208,6 @@ test("MCP initialization imposes the agent-owned capability coverage contract", 
 test("empty search paginates every catalog ID and every result is selectable", async () => {
   const server = await initializedServer();
   const expected = core.loadBundledCatalog({ root: ROOT }).skills.map((skill) => skill.id);
-  assert.equal(expected.length, 1968);
   const ids = [];
   let cursor = 0;
   let requestId = 10;


### PR DESCRIPTION
## Summary

Remove the redundant hard-coded 1,968-skill snapshot from the MCP catalog enumeration test. The test still verifies the complete generated catalog end-to-end: every page reports the exact dynamic total, every catalog ID is returned in catalog order, every result is selectable, and the final ID set is unique and complete.

This prevents each source-only external skill PR from needing to modify a non-allowlisted Core test file while preserving the actual enumeration contract.

## Change Classification

- [ ] Skill PR
- [ ] Docs PR
- [x] Infra PR

## Quality Bar Checklist

- [x] Standards and current maintainer workflow reviewed.
- [x] No canonical skill or generated artifact changes.
- [x] Full npm test passes.
- [x] Targeted MCP test passes.
- [x] Validation, references, docs security, and warning budget pass.
- [x] Source-only PR.
- [x] Maintainer edits enabled.

## Validation

- git diff --check
- node --test tools/scripts/tests/aas_v1_mcp.test.js
- npm run validate
- npm run validate:references
- npm run security:docs
- npm run check:warning-budget
- npm test