### PR TITLE
fix: restore CLI topic SEO metadata

### DIFF
--- a/apps/web-app/src/data/seoLandingPages.json
+++ b/apps/web-app/src/data/seoLandingPages.json
@@ -2,7 +2,7 @@
   {
     "slug": "antigravity-cli-skills",
     "title": "Antigravity CLI Skill Stacks | AAS Core Preview",
-    "description": "Use the AAS Core preview catalog for neutral skill retrieval and to validate explainable, agent-selected Antigravity CLI stacks for coding, review, testing, and workflow automation.",
+    "description": "Use the AAS Core preview skills catalog for neutral skill retrieval and to validate explainable, agent-selected Antigravity CLI stacks for coding, review, testing, and workflow automation.",
     "eyebrow": "Antigravity CLI",
     "h1": "Antigravity CLI skills for agentic coding workflows",
     "summary": "Use AAS Core as the agent-first catalog and validation layer for exact skill IDs selected by Antigravity CLI and adjacent coding-agent runtimes.",

--- a/apps/web-app/src/data/seoLandingPages.test.ts
+++ b/apps/web-app/src/data/seoLandingPages.test.ts
@@ -3,6 +3,12 @@ import { createMockSkill } from '../factories/skill';
 import { getCuratedSkillsForSeoLandingPage, getSeoLandingPage } from './seoLandingPages';
 
 describe('SEO landing page skill curation', () => {
+  it('keeps plural skills discovery copy in the Antigravity CLI metadata', () => {
+    const page = getSeoLandingPage('antigravity-cli-skills');
+
+    expect(page?.description).toMatch(/skills/i);
+  });
+
   it('keeps real editorial picks first and deterministically fills with scored matches', () => {
     const page = getSeoLandingPage('antigravity-cli-skills');
     expect(page).toBeDefined();


### PR DESCRIPTION
## Summary
- restore plural skills discovery copy on the Antigravity CLI topic page
- add a focused regression test for the metadata contract

## Validation
- npm run validate
- npm run validate:references
- npm run security:docs
- npm test
- npm run app:test -- src/data/seoLandingPages.test.ts
- npm run app:build
- cd apps/web-app and npm run verify:seo -- --require-hosted-url

## Quality Bar Checklist
- [x] Change is source-owned and narrowly scoped
- [x] Relevant tests and SEO build verification pass
- [x] No generated registry artifacts are included