### PR TITLE
fix: preserve CLI topic metadata contract

### DIFF
--- a/apps/web-app/src/data/seoLandingPages.json
+++ b/apps/web-app/src/data/seoLandingPages.json
@@ -2,7 +2,7 @@
   {
     "slug": "antigravity-cli-skills",
     "title": "Antigravity CLI Skill Stacks | AAS Core Preview",
-    "description": "Use the AAS Core preview skills catalog for neutral skill retrieval and to validate explainable, agent-selected Antigravity CLI stacks for coding, review, testing, and workflow automation.",
+    "description": "Use the AAS Core preview catalog of skills for neutral skill retrieval and to validate explainable, agent-selected Antigravity CLI stacks for coding, review, testing, and workflow automation.",
     "eyebrow": "Antigravity CLI",
     "h1": "Antigravity CLI skills for agentic coding workflows",
     "summary": "Use AAS Core as the agent-first catalog and validation layer for exact skill IDs selected by Antigravity CLI and adjacent coding-agent runtimes.",


### PR DESCRIPTION
## Summary
- preserve the existing AAS Core preview catalog metadata contract
- keep plural skills discovery copy so the prerendered SEO verifier passes

## Validation
- npm run app:test:coverage
- npm run app:build
- cd apps/web-app and npm run verify:seo -- --require-hosted-url

## Quality Bar Checklist
- [x] Change is source-owned and narrowly scoped
- [x] Full web-app coverage and hosted SEO verification pass
- [x] No generated artifacts are included