### PR TITLE
docs: tighten AAS Core activation guidance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Clarified the AAS Core activation path with an exact release-pinned MCP command, a concise end-to-end quick path, an explicit preview-status matrix, and a tested boundary between structural validity, semantic suitability, compatibility, and safety.
 - Made exact package/MCP version parity a mandatory maintainer release gate: after npm publishes a new AAS package, every already-configured local AAS MCP host must be updated through the approval-bound, backup-first configuration flow and verified with a real MCP handshake before the release task is complete.
 
 ## [15.1.0] - 2026-07-19 - "Agent-Owned Selection and Audit Evidence"
@@ -37,7 +38,7 @@ Start here:
 - Added an MCP session-level capability coverage contract for Codex and Claude: agents must enumerate primary project capabilities, search and compare candidates for each, cover every capability or report a catalog gap, and avoid smallest-stack optimization before `compose_stack`. Core imposes no semantic small-stack policy; each manifest retains an explicit technical maximum of 128 skills.
 - Moved semantic skill selection fully to Codex and Claude: agents inspect the project, search and read the complete local catalog, and choose exact skill IDs using their own judgment; AAS Core no longer ranks or recommends skills.
 - Replaced the recommendation workflow with read-only `compose_stack`, which validates and returns the agent-owned manifest in memory; clients or the CLI persist `aas-stack.json` for inspection, validation, and immutable plan preview.
-- Removed Core selection policy and metadata eligibility gates. Every canonical skill is searchable, readable, selectable, and usable; risk, source, setup, compatibility, review, and evidence metadata are informational only.
+- Removed Core selection policy and metadata eligibility gates. Every canonical skill is searchable, readable, and available for agent selection; risk, source, setup, compatibility, review, and evidence metadata are informational only.
 - Made `search_skills` retrieval neutral: matching results preserve stable catalog order and no longer expose relevance scores or ranking while exact-ID lookup and complete pagination remain deterministic.
 - Updated the public product narrative, host guides, Workbench-facing copy sources, package metadata, and maintainer workflow to describe the agent-owned selection boundary. Released entries below remain historical descriptions of their releases.
 

--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 <!-- registry-sync: version=15.1.0; skills=1969; stars=43586; updated_at=2026-07-19T19:39:12+00:00 -->
 # AAS Core — Agentic Awesome Skills
 
-> **A complete local skill catalog for coding agents—from project inspection and agent-owned selection to a reproducible, reviewable plan.**
+> **Local, agent-owned skill stacks for coding agents—from complete catalog access to a reproducible, reviewable plan.**
 
 **Current release: V15.1.0.** This release includes AAS Core for complete local catalog search, agent-owned selection, manifest validation, planning, and diagnosis. Apply and recovery remain experimental and outside the supported preview path.
 
-Codex or Claude inspects your project, enumerates its primary capabilities, searches and compares candidates across the complete local AAS catalog, and chooses the exact skills. Core imposes no semantic policy that favors a small stack; the manifest format has an explicit technical maximum of 128 skills. Every current catalog skill remains individually searchable, readable, and selectable. AAS Core does not rank or recommend skills. Its read-only `compose_stack` tool validates and returns the agent-owned manifest in memory; a client or the `aas` CLI persists the reviewed stack and its optional selection-evidence sidecar.
+Codex or Claude inspects your project and chooses exact skills from the complete local AAS catalog. AAS Core does not rank or recommend them: its read-only `compose_stack` tool validates the agent-owned selection in memory, and a client or the `aas` CLI can persist it as `aas-stack.json` and produce an immutable plan before any target change.
 
 **[Read the AAS Core preview guide →](https://github.com/sickn33/agentic-awesome-skills/blob/main/docs/users/aas-core.md)**
 
@@ -53,12 +53,26 @@ AAS Core gives the repository one product model:
 - **Review in Workbench.** The hosted Workbench imports and reviews stack/plan JSON in browser memory; it does not access your filesystem or install anything.
 - **Retain every useful distribution path.** Direct installs, plugins, bundles, workflows, and the full catalog remain available as payload and compatibility surfaces.
 
+> [!IMPORTANT]
+> Structural and identity validity does not certify semantic fit, compatibility, setup correctness, operational safety, or safety to apply.
+
+| Surface | Current status |
+| --- | --- |
+| Published package | Current npm release; AAS Core status is `agent-first-preview` |
+| Catalog search and inspection | Supported preview; local and read-only |
+| Agent-owned composition | Supported preview; Core validates IDs and structure, not semantic suitability; manifests have a technical maximum of 128 skills |
+| Stack validation and plan preview | Supported preview; no target skill changes |
+| Workbench | Browser-local review of stack and plan artifacts |
+| Selection evidence | Exported and inspected through MCP/CLI contracts; not yet reviewed in Workbench |
+| Apply and recovery | Experimental, explicit opt-in, outside the supported safety claim |
+| Semantic suitability certification | Not provided |
+
 Read the [AAS Core guide](https://github.com/sickn33/agentic-awesome-skills/blob/main/docs/users/aas-core.md) for the exact trust boundaries, current preview status, Codex/Claude setup model, and CLI lifecycle.
 
 ## Why This Repo
 
 - **Agent-first, locally controlled**: Codex or Claude inspects the project and chooses from the complete local catalog without uploading your repository to AAS.
-- **Complete and inspectable**: every catalog skill is searchable, readable, selectable, and usable; metadata is informational and never an eligibility gate.
+- **Complete and inspectable**: every catalog skill is searchable, readable, and available for agent selection; Core does not certify suitability, compatibility, or operational safety, and metadata is informational rather than an eligibility gate.
 - **Approval before writes**: the durable artifacts are an approved stack and immutable plan, not an opaque one-shot install.
 - **Installable, not just inspirational**: use the compatible legacy installer or plugin distributions when direct delivery is the right path.
 - **Built for major agent workflows**: Claude Code, Cursor, Codex CLI, Autohand Code, Gemini CLI, Antigravity, Kiro, OpenCode, Copilot, and more.
@@ -66,6 +80,10 @@ Read the [AAS Core guide](https://github.com/sickn33/agentic-awesome-skills/blob
 - **Inspect before installing**: the hosted [Skill Workbench](https://sickn33.github.io/agentic-awesome-skills/workbench) reviews agent-produced stack manifests and immutable plans without browser-side installation.
 - **Focused delivery remains available**: specialized plugins package proven sets for web, security, data, docs, DevOps, QA, OSS, or agent/MCP workflows.
 - **Useful whether you want breadth or curation**: install the full catalog, choose a specialized plugin, start with bundles, or compare alternatives before installing.
+
+### Why not just search the skills directory?
+
+Direct file search can find candidate prose, but it leaves the result in the conversation. AAS Core adds verified catalog identity, explicit target binding, durable desired state, optional selection evidence, deterministic validation, immutable planning, and dedicated review surfaces. Its value is not choosing better than the coding agent; it is turning the agent's choice into reproducible, inspectable state.
 
 ## Table of Contents
 

--- a/docs/maintainers/aas-agent-first-control-plane-preview-profile.md
+++ b/docs/maintainers/aas-agent-first-control-plane-preview-profile.md
@@ -13,7 +13,7 @@ The earlier deterministic recommendation design and goal documents are retained 
 
 ## Supported surfaces
 
-- A complete, integrity-verified local catalog in which every canonical skill is searchable, readable, selectable, and usable.
+- A complete, integrity-verified local catalog in which every canonical skill is searchable, readable, and available for agent selection.
 - Local stdio MCP tools `search_skills`, `get_skill`, `compose_stack`, `inspect_stack`, and `diff_stack`, plus `aas://skills/{id}`.
 - Minimal, schema-validated `aas-stack.json` with pinned catalog identity, targets, goals, and exact agent-selected skill IDs.
 - CLI manifest validation, immutable plan preview, and read-only diagnosis.
@@ -23,7 +23,7 @@ The earlier deterministic recommendation design and goal documents are retained 
 
 1. The coding agent owns semantic selection. It may inspect the project with its normal local capabilities, search broadly, read full skill content when useful, compare alternatives, and choose exact IDs.
 2. AAS Core does not rank, recommend, promote, demote, exclude, or abstain on skills.
-3. Catalog metadata is informational only. Missing, incomplete, cautionary, or manually reviewed metadata must never make a canonical skill unsearchable, unselectable, or unusable.
+3. Catalog metadata is informational only. Missing, incomplete, cautionary, or manually reviewed metadata must never make a canonical skill unsearchable or unavailable for agent selection.
 4. `compose_stack` validates catalog identity, target shape, goals, exact IDs, and structural limits, then returns the pinned stack shape. It does not substitute a different selection.
 5. `aas-stack.json` has no Core selection policy. User constraints can guide the agent's reasoning, but they are not an MCP eligibility filter or manifest gate.
 

--- a/docs/maintainers/aas-agent-first-control-plane-v1-worklog.md
+++ b/docs/maintainers/aas-agent-first-control-plane-v1-worklog.md
@@ -1,6 +1,6 @@
 # AAS Agent-First Control Plane v1 Worklog
 
-- 2026-07-19: Semantic skill selection moved to Codex and Claude. Core now exposes the complete catalog and validates/pins exact agent-selected IDs through `compose_stack`; selection policy and metadata eligibility gates were retired. Every canonical skill must remain searchable, readable, selectable, and usable. Earlier recommendation entries below are historical.
+- 2026-07-19: Semantic skill selection moved to Codex and Claude. Core now exposes the complete catalog and validates/pins exact agent-selected IDs through `compose_stack`; selection policy and metadata eligibility gates were retired. Every canonical skill must remain searchable, readable, and available for agent selection. Earlier recommendation entries below are historical.
 
 ## 2026-07-18 — Baseline workflow retired
 

--- a/docs/users/aas-core.md
+++ b/docs/users/aas-core.md
@@ -20,14 +20,17 @@ your project
   -> aas stack plan (preview; no skill changes)
 ```
 
-AAS MCP does not scan the repository and does not decide which skills are best. Codex or Claude uses its own project understanding and judgment. Every current catalog skill remains individually searchable, readable, selectable, and usable; missing or incomplete metadata never makes a skill ineligible. Core has no semantic policy that favors a small stack, while every stack manifest has an explicit technical maximum of 128 skills.
+AAS MCP does not scan the repository and does not decide which skills are best. Codex or Claude uses its own project understanding and judgment. Every current catalog skill remains individually searchable, readable, and available for agent selection; missing or incomplete metadata never makes a skill ineligible. Core has no semantic policy that favors a small stack, while every stack manifest has an explicit technical maximum of 128 skills.
+
+> [!IMPORTANT]
+> Structural and identity validity does not certify semantic fit, compatibility, setup correctness, operational safety, or safety to apply.
 
 ## Configure the local MCP
 
 > **Release boundary:** AAS Core landed after release 14.6.0. Use an exact Core-capable release rather than an unreviewed moving tag.
 
 ```bash
-npm exec --yes --ignore-scripts --package=agentic-awesome-skills@X.Y.Z -- aas mcp configure \
+npm exec --yes --ignore-scripts --package=agentic-awesome-skills@15.1.0 -- aas mcp configure \
   --host codex \
   --scope user \
   --config /absolute/path/to/codex/config.toml \
@@ -41,6 +44,15 @@ Use `--host claude` with the appropriate absolute Claude MCP configuration path 
 ```
 
 Configuration is explicit and integrity-bound. AAS installs or reuses an exact content-addressed runtime, verifies it, and changes only its managed MCP configuration section. Restart the host if it does not reload MCP configuration automatically.
+
+## Quick path
+
+1. Run the exact-version MCP configuration command above, review its approval digest, and repeat it with `--approve <approval-digest>`.
+2. Give Codex or Claude the project outcome, target, constraints, and the selection prompt below.
+3. Let the agent search and inspect candidates, choose exact IDs, and call `compose_stack`; review the returned manifest before persisting it.
+4. Persist the selection as `aas-stack.json`, optionally with the separate evidence sidecar for an audit-enabled flow.
+5. Run `aas stack validate`, then `aas stack plan` with explicit absolute paths and integrity inputs.
+6. Review the immutable plan and stop. Apply and recovery remain experimental opt-in paths.
 
 ## Ask the agent to choose the stack
 
@@ -163,7 +175,7 @@ Stop after reviewing the plan unless you are deliberately participating in contr
 - MCP is local stdio, process-per-session, read-only, offline-capable, and contains no model credentials or telemetry.
 - Codex or Claude owns semantic selection. Different agents or project observations may reasonably produce different stacks.
 - Catalog integrity and manifest validation are deterministic; skill suitability is an agent judgment, not a Core score.
-- Core does not impose a semantic skill-count target. The technical manifest maximum is 128 skills, and every current catalog skill remains individually searchable, readable, selectable, and usable. Metadata remains visible but informational.
+- Core does not impose a semantic skill-count target. The technical manifest maximum is 128 skills, and every current catalog skill remains individually searchable, readable, and available for agent selection. Metadata remains visible but informational.
 - Evidence exports include raw `search_skills` queries; keep secrets and sensitive project content out of those queries.
 - Catalog updates and runtime changes are explicit. There is no resident daemon or implicit auto-update.
 - Skill prose is untrusted content and does not gain instruction authority by being returned through MCP.
@@ -171,6 +183,23 @@ Stop after reviewing the plan unless you are deliberately participating in contr
 ## Other ways to use the catalog
 
 Direct installs, specialized plugins, bundles, workflows, and the legacy installer remain available. These surfaces distribute or curate catalog content; AAS Core adds complete local access, durable agent-owned selection, manifest validation, and a reviewable plan.
+
+## Current preview status
+
+| Surface | Current status |
+| --- | --- |
+| Published package | Current npm release; AAS Core status is `agent-first-preview` |
+| Catalog search and inspection | Supported preview; local and read-only |
+| Agent-owned composition | Supported preview; Core validates IDs and structure, not semantic suitability |
+| Stack validation and plan preview | Supported preview; no target skill changes |
+| Workbench | Browser-local review of stack and plan artifacts |
+| Selection evidence | Exported and inspected through MCP/CLI contracts; not yet reviewed in Workbench |
+| Apply and recovery | Experimental, explicit opt-in, outside the supported safety claim |
+| Semantic suitability certification | Not provided |
+
+## Why not just search the skills directory?
+
+Direct file search can find candidate prose, but it leaves the result in the conversation. AAS Core adds verified catalog identity, explicit target binding, durable desired state, optional selection evidence, deterministic validation, immutable planning, and dedicated review surfaces. Its value is not choosing better than the coding agent; it is turning the agent's choice into reproducible, inspectable state.
 
 ## Next reads
 

--- a/tools/scripts/sync_repo_metadata.py
+++ b/tools/scripts/sync_repo_metadata.py
@@ -45,7 +45,7 @@ RECOMMENDED_TOPICS = [
     "mcp",
 ]
 README_TAGLINE_RE = re.compile(
-    r"^> \*\*(?:A complete local skill catalog for coding agents—from project inspection and agent-owned selection to a reproducible, reviewable plan\.|Local, deterministic skill-stack composition for coding agents—from an explicit project profile to a reviewable plan before any target change\.|AAS Core is the local, agent-first control plane for composing explainable, reproducible skill stacks from a catalog of \d[\d,]*\+ agentic skills\.|Installable GitHub library of \d[\d,]*\+ agentic skills for Claude Code, Cursor, Codex CLI, (?:Autohand Code, )?Gemini CLI, Antigravity, and other AI coding assistants\.)\*\*$",
+    r"^> \*\*(?:Local, agent-owned skill stacks for coding agents—from complete catalog access to a reproducible, reviewable plan\.|A complete local skill catalog for coding agents—from project inspection and agent-owned selection to a reproducible, reviewable plan\.|Local, deterministic skill-stack composition for coding agents—from an explicit project profile to a reviewable plan before any target change\.|AAS Core is the local, agent-first control plane for composing explainable, reproducible skill stacks from a catalog of \d[\d,]*\+ agentic skills\.|Installable GitHub library of \d[\d,]*\+ agentic skills for Claude Code, Cursor, Codex CLI, (?:Autohand Code, )?Gemini CLI, Antigravity, and other AI coding assistants\.)\*\*$",
     re.MULTILINE,
 )
 README_TITLE_RE = re.compile(
@@ -72,7 +72,7 @@ README_TOC_BROWSE_RE = re.compile(
     re.MULTILINE,
 )
 README_AGENT_SELECTION_PARAGRAPH_RE = re.compile(
-    r"^Codex or Claude inspects your project, enumerates its primary capabilities, searches and compares candidates across the complete local AAS catalog, and chooses the exact skills\..*$",
+    r"^Codex or Claude inspects your project(?:, enumerates its primary capabilities, searches and compares candidates across| and chooses exact skills from) the complete local AAS catalog.*$",
     re.MULTILINE,
 )
 README_SUPPORTING_PLAYBOOKS_RE = re.compile(
@@ -169,8 +169,8 @@ def sync_readme_copy(content: str, metadata: dict) -> str:
         (
             README_TAGLINE_RE,
             (
-                "> **A complete local skill catalog for coding agents—from project inspection and agent-owned "
-                "selection to a reproducible, reviewable plan.**"
+                "> **Local, agent-owned skill stacks for coding agents—from complete catalog access to a "
+                "reproducible, reviewable plan.**"
             ),
         ),
         (
@@ -183,13 +183,10 @@ def sync_readme_copy(content: str, metadata: dict) -> str:
         (
             README_AGENT_SELECTION_PARAGRAPH_RE,
             (
-                "Codex or Claude inspects your project, enumerates its primary capabilities, searches and compares "
-                "candidates across the complete local AAS catalog, and chooses the exact skills. Core imposes no "
-                "semantic policy that favors a small stack; the manifest format has an explicit technical maximum "
-                "of 128 skills. Every current catalog skill remains individually searchable, readable, and "
-                "selectable. AAS Core does not rank or recommend skills. Its read-only `compose_stack` tool "
-                "validates and returns the agent-owned manifest in memory; a client or the `aas` CLI persists "
-                "the reviewed stack and its optional selection-evidence sidecar."
+                "Codex or Claude inspects your project and chooses exact skills from the complete local AAS catalog. "
+                "AAS Core does not rank or recommend them: its read-only `compose_stack` tool validates the "
+                "agent-owned selection in memory, and a client or the `aas` CLI can persist it as `aas-stack.json` "
+                "and produce an immutable plan before any target change."
             ),
         ),
         (
@@ -251,6 +248,20 @@ def sync_getting_started(content: str, metadata: dict) -> str:
         "# Getting Started with AAS Core",
     )
     return content
+
+
+def sync_aas_core_guide(content: str, metadata: dict) -> str:
+    if metadata["core_included"]:
+        content = re.sub(
+            r"--package=agentic-awesome-skills@(?:X\.Y\.Z|[^\s\\]+)",
+            f"--package=agentic-awesome-skills@{metadata['version']}",
+            content,
+            count=1,
+        )
+    return content.replace(
+        "searchable, readable, selectable, and usable",
+        "searchable, readable, and available for agent selection",
+    )
 
 
 def sync_web_index_shell(content: str, metadata: dict) -> str:
@@ -410,6 +421,7 @@ def sync_curated_docs(base_dir: str, metadata: dict, dry_run: bool) -> int:
     updated_files = 0
     updated_files += int(update_text_file(root / "README.md", sync_readme_copy, metadata, dry_run))
     updated_files += int(update_text_file(root / "docs" / "users" / "getting-started.md", sync_getting_started, metadata, dry_run))
+    updated_files += int(update_text_file(root / "docs" / "users" / "aas-core.md", sync_aas_core_guide, metadata, dry_run))
     updated_files += int(update_text_file(root / "apps" / "web-app" / "index.html", sync_web_index_shell, metadata, dry_run))
     updated_files += int(update_text_file(root / "apps" / "web-app" / "public" / "llms.txt", sync_llms_text, metadata, dry_run))
     updated_files += int(

--- a/tools/scripts/tests/aas_core_public_docs_contract.test.js
+++ b/tools/scripts/tests/aas_core_public_docs_contract.test.js
@@ -6,6 +6,7 @@ const fs = require("node:fs");
 const path = require("node:path");
 
 const repoRoot = path.resolve(__dirname, "../../..");
+const packageJson = JSON.parse(fs.readFileSync(path.join(repoRoot, "package.json"), "utf8"));
 
 const publicRoots = [
   "README.md",
@@ -79,6 +80,14 @@ for (const relativePath of publicFiles) {
 
 const coreGuide = fs.readFileSync(path.join(repoRoot, "docs/users/aas-core.md"), "utf8");
 const usageGuide = fs.readFileSync(path.join(repoRoot, "docs/users/usage.md"), "utf8");
+const readme = fs.readFileSync(path.join(repoRoot, "README.md"), "utf8");
+const validityBoundary = /Structural and identity validity does not certify semantic fit, compatibility, setup correctness, operational safety, or safety to apply\./;
+assert.match(coreGuide, new RegExp(`--package=agentic-awesome-skills@${packageJson.version.replaceAll(".", "\\.")}`));
+assert.doesNotMatch(coreGuide, /--package=agentic-awesome-skills@(?:X\.Y\.Z|latest)\b/);
+assert.match(coreGuide, validityBoundary);
+assert.match(readme, validityBoundary);
+assert.doesNotMatch(coreGuide, /selectable, and usable/i);
+assert.doesNotMatch(readme, /selectable, and usable/i);
 assert.match(coreGuide, /"schemaVersion"\s*:\s*2/);
 assert.match(coreGuide, /"profile"\s*:\s*\{/);
 assert.match(coreGuide, /"skills"\s*:\s*\[\s*\{\s*"id"\s*:/);
@@ -94,7 +103,7 @@ for (const guide of [coreGuide, usageGuide]) {
   assert.match(guide, /smallest\s+stack/i);
   assert.match(guide, /no semantic policy|no semantic small-stack policy/i);
   assert.match(guide, /technical maximum of 128/i);
-  assert.match(guide, /every current catalog skill[^.\n]{0,180}individually searchable, readable, (?:and )?selectable/i);
+  assert.match(guide, /every current catalog skill[^.\n]{0,180}individually searchable, readable, (?:and )?(?:selectable|available for agent selection)/i);
   assert.match(guide, /compose_stack[\s\S]{0,200}in memory/i);
   assert.match(guide, /client or (?:the )?CLI[\s\S]{0,200}persist/i);
   assert.match(guide, /export_selection_evidence/);
@@ -112,9 +121,9 @@ for (const guide of [coreGuide, usageGuide]) {
 for (const relativePath of ["README.md", "apps/web-app/public/llms.txt"]) {
   const content = fs.readFileSync(path.join(repoRoot, relativePath), "utf8");
   assert.doesNotMatch(content, /(?:no |without an? )?arbitrary (?:skill-)?count cap/i);
-  assert.match(content, /no semantic policy/i);
+  assert.match(content, /no semantic policy|does not rank or recommend/i);
   assert.match(content, /technical maximum of 128/i);
-  assert.match(content, /every current catalog skill[^.\n]{0,180}individually searchable, readable, (?:and )?selectable/i);
+  assert.match(content, /every (?:current )?catalog skill[^.\n]{0,180}(?:individually )?searchable, readable, (?:and )?(?:selectable|available for agent selection)/i);
   assert.match(content, /compose_stack[^.\n]{0,160}in memory/i);
   assert.match(content, /client or (?:the )?(?:`?aas`? )?CLI[^.\n]{0,160}persist/i);
 }

--- a/tools/scripts/tests/npm_package_contents.test.js
+++ b/tools/scripts/tests/npm_package_contents.test.js
@@ -86,12 +86,12 @@ assert.ok(
   "published README must not link to an AAS Core guide path excluded from the npm package",
 );
 assert.ok(
-  coreGuide.includes("--package=agentic-awesome-skills@X.Y.Z"),
-  "AAS Core onboarding must require an explicitly Core-capable release",
+  coreGuide.includes(`--package=agentic-awesome-skills@${packageJson.version}`),
+  "AAS Core onboarding must pin the exact published package version",
 );
 assert.ok(
   !coreGuide.includes("--package=agentic-awesome-skills@latest"),
-  "AAS Core onboarding must not resolve latest while the current dist-tag predates Core",
+  "AAS Core onboarding must not resolve a moving npm dist-tag",
 );
 assert.ok(
   !/^\s*--runtime-version\b/m.test(coreGuide),

--- a/tools/scripts/tests/test_audit_consistency.py
+++ b/tools/scripts/tests/test_audit_consistency.py
@@ -71,7 +71,7 @@ class AuditConsistencyTests(unittest.TestCase):
             f"""<!-- registry-sync: version=8.4.0; skills={total_skills}; stars=26132; updated_at=2026-03-21T00:00:00+00:00 -->
 # AAS Core — Agentic Awesome Skills
 
-> **A complete local skill catalog for coding agents—from project inspection and agent-owned selection to a reproducible, reviewable plan.**
+> **Local, agent-owned skill stacks for coding agents—from complete catalog access to a reproducible, reviewable plan.**
 
 [![GitHub stars](https://img.shields.io/badge/⭐%2026%2C000%2B%20Stars-gold?style=for-the-badge)](https://github.com/sickn33/agentic-awesome-skills/stargazers)
 

--- a/tools/scripts/tests/test_sync_repo_metadata.py
+++ b/tools/scripts/tests/test_sync_repo_metadata.py
@@ -88,6 +88,11 @@ The 1,273+ reusable `SKILL.md` playbooks, specialized plugins, bundles, workflow
                 "# Getting Started with Agentic Awesome Skills (V8.3.0)\n",
                 encoding="utf-8",
             )
+            (root / "docs" / "users" / "aas-core.md").write_text(
+                "npm exec --yes --ignore-scripts --package=agentic-awesome-skills@X.Y.Z -- aas mcp configure\\\n\n"
+                "Every current catalog skill is searchable, readable, selectable, and usable.\n",
+                encoding="utf-8",
+            )
             (root / "docs" / "users" / "claude-code-skills.md").write_text(
                 "- It includes 1,273+ skills instead of a narrow single-domain starter pack.\n",
                 encoding="utf-8",
@@ -137,7 +142,9 @@ The 1,273+ reusable `SKILL.md` playbooks, specialized plugins, bundles, workflow
             self.assertIn("1,304+ skills across development", readme)
             self.assertIn("[📚 Browse 1,304+ Skills](#browse-1304-skills)", readme)
             self.assertIn("[Browse 1,304+ Skills](#browse-1304-skills)", readme)
-            self.assertIn("Every current catalog skill remains individually searchable, readable, and selectable.", readme)
+            self.assertIn("Local, agent-owned skill stacks for coding agents", readme)
+            self.assertIn("AAS Core does not rank or recommend them", readme)
+            self.assertIn("can persist it as `aas-stack.json`", readme)
             self.assertIn("The reusable `SKILL.md` playbooks", readme)
             self.assertIn("Guide capability coverage", readme)
             self.assertIn("does not certify semantic completeness", readme)
@@ -145,6 +152,11 @@ The 1,273+ reusable `SKILL.md` playbooks, specialized plugins, bundles, workflow
                 "# Getting Started with AAS Core\n",
                 (root / "docs" / "users" / "getting-started.md").read_text(encoding="utf-8"),
             )
+            aas_core = (root / "docs" / "users" / "aas-core.md").read_text(encoding="utf-8")
+            self.assertIn("--package=agentic-awesome-skills@8.4.0", aas_core)
+            self.assertIn("searchable, readable, and available for agent selection", aas_core)
+            self.assertNotIn("X.Y.Z", aas_core)
+            self.assertNotIn("selectable, and usable", aas_core)
             self.assertIn("1,304+ files", (root / "docs" / "users" / "gemini-cli-skills.md").read_text(encoding="utf-8"))
             self.assertIn("1,304+ specialized areas", (root / "docs" / "users" / "kiro-integration.md").read_text(encoding="utf-8"))
             self.assertIn("Total Bundles: 2", (root / "docs" / "users" / "bundles.md").read_text(encoding="utf-8"))


### PR DESCRIPTION
## Summary

- make the AAS Core quickstart copyable with the exact published package version
- state the boundary between structural validity, semantic suitability, compatibility, and safety
- add a compact preview-status matrix and explain why Core adds value beyond searching the skills directory
- keep release/version copy synchronized and add regression coverage

## Change Classification

- [ ] Skill PR
- [x] Docs PR
- [x] Infra PR

## Quality Bar Checklist ✅

- [x] **Standards**: Read `docs/contributors/quality-bar.md` and `docs/contributors/security-guardrails.md`.
- [x] **Metadata**: No `SKILL.md` frontmatter changed; `npm run validate` passes.
- [x] **Risk Label**: Not applicable; no skill content changed.
- [x] **Triggers**: Not applicable; no skill content changed.
- [x] **Limitations**: Product limits and unsupported guarantees are made more explicit.
- [x] **Security**: Not an offensive skill change.
- [x] **Safety scan**: `npm run security:docs` passes.
- [x] **Automated Skill Review**: Not applicable; no `SKILL.md` changed.
- [x] **Manual Logic Review**: Reviewed copy against the current MCP/Core/CLI/Workbench implementation.
- [x] **Local Test**: Full repository test suite and AAS v1 suite pass.
- [x] **Repo Checks**: `npm run validate:references`, consistency audit, stale-claim check, and catalog check pass.
- [x] **Source-Only PR**: No generated registry artifacts are included.
- [x] **Credits**: Not applicable.
- [x] **License provenance**: Not applicable.
- [x] **Maintainer Edits**: Enabled.

## Validation

- `npm run validate`
- `npm run validate:references`
- `npm run security:docs`
- `npm run test`
- `npm run test:aas-v1`
- `npm run check:aas-v1-catalog`
- `npm run audit:consistency`
- `npm run check:stale-claims`
- `git diff --check`
