### PR TITLE
fix: make protected release retries complete

### DIFF
--- a/tools/config/generated-files.json
+++ b/tools/config/generated-files.json
@@ -36,6 +36,7 @@
     "CHANGELOG.md",
     "package.json",
     "package-lock.json",
-    "README.md"
+    "README.md",
+    "docs/users/aas-core.md"
   ]
 }

--- a/tools/scripts/release_workflow.js
+++ b/tools/scripts/release_workflow.js
@@ -99,12 +99,15 @@ function remoteTagTarget(projectRoot, tagName) {
 function selectMergedReleaseCandidate(pullRequests, version) {
   const branch = `release/v${version}`;
   const matches = pullRequests.filter((pr) => (
-    pr.headRefName === branch && pr.baseRefName === "main" && /^[0-9a-f]{40}$/u.test(String(pr.mergeCommit?.oid || ""))
+    pr.headRefName === branch
+    && pr.baseRefName === "main"
+    && /^[0-9a-f]{40}$/u.test(String(pr.mergeCommit?.oid || ""))
+    && Number.isFinite(Date.parse(String(pr.mergedAt || "")))
   ));
-  if (matches.length !== 1) {
-    throw new Error(`Expected exactly one merged protected release PR for ${branch}.`);
+  if (matches.length === 0) {
+    throw new Error(`Expected at least one merged protected release PR for ${branch}.`);
   }
-  return matches[0];
+  return matches.sort((left, right) => Date.parse(right.mergedAt) - Date.parse(left.mergedAt))[0];
 }
 
 function mergedReleaseCandidate(projectRoot, version) {
@@ -121,7 +124,7 @@ function mergedReleaseCandidate(projectRoot, version) {
       "--limit",
       "10",
       "--json",
-      "number,headRefName,baseRefName,mergeCommit",
+      "number,headRefName,baseRefName,mergeCommit,mergedAt",
     ],
     projectRoot,
     { capture: true },

--- a/tools/scripts/tests/release_workflow.test.js
+++ b/tools/scripts/tests/release_workflow.test.js
@@ -23,10 +23,20 @@ const candidate = {
   headRefName: "release/v1.2.3",
   baseRefName: "main",
   mergeCommit: { oid: mergeOid },
+  mergedAt: "2026-01-01T00:00:00Z",
 };
 assert.strictEqual(release.selectMergedReleaseCandidate([candidate], "1.2.3"), candidate);
-assert.throws(() => release.selectMergedReleaseCandidate([], "1.2.3"), /exactly one/);
-assert.throws(() => release.selectMergedReleaseCandidate([candidate, { ...candidate, number: 11 }], "1.2.3"), /exactly one/);
+assert.throws(() => release.selectMergedReleaseCandidate([], "1.2.3"), /at least one/);
+const newerCandidate = {
+  ...candidate,
+  number: 11,
+  mergeCommit: { oid: "b".repeat(40) },
+  mergedAt: "2026-01-02T00:00:00Z",
+};
+assert.strictEqual(
+  release.selectMergedReleaseCandidate([candidate, newerCandidate], "1.2.3"),
+  newerCandidate,
+);
 
 const root = fs.mkdtempSync(path.join(os.tmpdir(), "release-workflow-"));
 const repo = path.join(root, "repo");


### PR DESCRIPTION
## Summary

- include the generated AAS Core version pin in release-managed staging
- select the latest merged protected release candidate for a safe same-version retry
- cover retry selection with a regression test

## Quality Bar Checklist

- [x] Release workflow regression test passes
- [x] Workflow contract test passes
- [x] Generated-file contract exposes the AAS Core guide only for release staging
- [x] No registry artifacts or skill content changed
