### PR TITLE
fix: cover nested skill bundle evidence

### DIFF
--- a/tools/scripts/merge_batch.cjs
+++ b/tools/scripts/merge_batch.cjs
@@ -186,7 +186,10 @@ function normalizeEvidenceRecord(record) {
 function isSkillContentRecord(record) {
   return [record?.old_path, record?.new_path]
     .filter((filePath) => typeof filePath === "string" && filePath)
-    .some((filePath) => ["canonical_skill", "skill_support"].includes(classifyPathPolicy(filePath).kind));
+    .some((filePath) => (
+      filePath.startsWith("skills/")
+      || ["canonical_skill", "skill_support"].includes(classifyPathPolicy(filePath).kind)
+    ));
 }
 
 function assertValidSnapshot(snapshot, label) {

--- a/tools/scripts/tests/merge_batch.test.js
+++ b/tools/scripts/tests/merge_batch.test.js
@@ -566,6 +566,23 @@ function approvalDependencies(overrides = {}) {
     }),
     report,
   );
+  const nestedBundleRecord = {
+    ...record,
+    old_path: "skills/example/examples/app/package-lock.json",
+    new_path: "skills/example/examples/app/package-lock.json",
+  };
+  const nestedBundleReport = {
+    ...report,
+    changes: [{ ...report.changes[0], records: [nestedBundleRecord] }],
+  };
+  assert.strictEqual(
+    mergeBatch.validateChangedSkillEvidence(nestedBundleReport, {
+      mergeBaseOid: BASE_SHA,
+      headOid: HEAD_SHA,
+      rawRecords: [nestedBundleRecord],
+    }),
+    nestedBundleReport,
+  );
   assert.throws(
     () => mergeBatch.validateChangedSkillEvidence(
       { ...report, head_oid: BLOB_SHA },


### PR DESCRIPTION
## Summary
- align merge-batch evidence coverage with the trusted changed-skill evaluator for every path under a canonical skill bundle
- add regression coverage for nested example lockfiles

## Quality Bar Checklist
- [x] `node tools/scripts/tests/merge_batch.test.js`
- [x] `git diff --check`

This bootstraps the protected merge path required for the Dependabot lockfile remediation in #964.