### PR TITLE
docs: link UIZZE homepage from skill overview

### DIFF
--- a/skills/uizze-ui-research/SKILL.md
+++ b/skills/uizze-ui-research/SKILL.md
@@ -16,7 +16,7 @@ tools: [claude, cursor, codex, copilot, antigravity, lovable]
 
 ## Overview
 
-Use UIZZE to give coding agents real product-UI context before implementation rather than relying on a generic styling prompt. The public catalog is free to browse; the hosted MCP workflow requires full access and a configured UIZZE agent token.
+Use [UIZZE](https://uizze.com) to give coding agents real product-UI context before implementation rather than relying on a generic styling prompt. The public catalog is free to browse; the hosted MCP workflow requires full access and a configured UIZZE agent token.
 
 This skill turns UI research into an explicit workflow: retrieve relevant references, translate transferable patterns into a design contract, implement within the current project's system, and run the available validation or critique gates.
 


### PR DESCRIPTION
# Pull Request Description

Adds one direct homepage link to the existing UIZZE UI Research overview. The wording, claims, risk level, and canonical source remain unchanged; only the existing UIZZE name is linked to https://uizze.com so readers can reach the public catalogue directly.

## Change Classification

- [x] Skill PR
- [ ] Docs PR
- [ ] Infra PR

## Quality Bar Checklist ✅

- [x] **Standards**: Read the contributor quality bar and security guardrails.
- [x] **Metadata**: Existing frontmatter remains valid; `npm run validate` passes.
- [x] **Risk Label**: Existing `risk: safe` remains appropriate.
- [x] **Triggers**: Existing trigger guidance is unchanged.
- [x] **Limitations**: Existing limitations are unchanged.
- [x] **Security**: No offensive guidance is present.
- [x] **Safety scan**: `npm run security:docs` passes.
- [ ] **Automated Skill Review**: Pending GitHub Actions.
- [x] **Manual Logic Review**: Reviewed semantics, safety, provenance, and failure modes; the URL is the official homepage and no instructions changed.
- [x] **Local Test**: Required generation chain and full repository test suite pass.
- [x] **Repo Checks**: `npm run validate:references` passes.
- [x] **Source-Only PR**: The diff contains only `skills/uizze-ui-research/SKILL.md`; generated artifacts are excluded.
- [x] **Credits**: Existing official source attribution remains unchanged and the README credit check passes.
- [x] **License provenance**: Existing provenance metadata is unchanged.
- [x] **Maintainer Edits**: Enabled.

## Validation

- `npm run validate`
- `npm run validate:references`
- `npm run security:docs`
- `npm run chain`
- `npm run catalog`
- `npm run check:warning-budget`
- `npm test`
- changed-skill evidence: non-blocking, zero audit or security findings

## Screenshots

Not applicable; Markdown-only link change.