### PR TITLE
ci: slim source validation workflow

### DIFF
--- a/.github/MAINTENANCE.md
+++ b/.github/MAINTENANCE.md
@@ -158,6 +158,14 @@ For every canonical `SKILL.md` or tracked bundle-file change, run validation, re
 3.  **Quality Bar** — PR description confirms the [Quality Bar Checklist](.github/PULL_REQUEST_TEMPLATE.md) (metadata, risk label, credits if applicable).
 4.  **Issue link** — If the PR fixes an issue, the PR description should contain `Closes #N` or `Fixes #N` so GitHub auto-closes the issue on merge.
 
+**Required-CI execution contract:**
+
+- `pr-policy` executes the fork-safety intake with code materialized from the exact protected base before the dependent required jobs start. This is an early, unprivileged rejection of unsafe fork diffs; `merge:batch` still recomputes the trusted decision and remains the only fork-run approval and merge authority.
+- The reported `impact_profile` is shadow telemetry only. It does not skip, downgrade, or satisfy any required check.
+- For an ordinary source PR, `source-validation` performs the generated-state refresh once and publishes a manifest bound to the exact repository, workflow/run attempt, and PR head SHA. `artifact-preview` verifies that manifest and its digest; it does not regenerate the same source-PR tree.
+- For the protected canonical-sync PR, `pr-policy` reproduces the exact tree from trusted `main`, `source-validation` records a lightweight boundary, and `artifact-preview` confirms that regeneration leaves no drift. The merged commit still receives the explicit final `main` CI and CodeQL runs.
+- The test runner emits timing telemetry for measurement. Deterministic sharding is an explicit local opt-in through `npm run test:local -- --shard-index N --shard-count M`; required CI continues to run the complete unsharded `npm run test` gate.
+
 **How you merge:**
 
 - **Always merge with `npm run merge:batch`**, which uses GitHub's immediate squash-merge endpoint so the PR shows as **Merged** and the contributor gets credit. Do **not** integrate locally, use a raw merge command, or close the PR after copying its changes.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,9 @@ jobs:
       direct_derived_changes_count: ${{ steps.intake.outputs.direct_derived_changes_count }}
       has_quality_checklist: ${{ steps.intake.outputs.has_quality_checklist }}
       has_issue_link: ${{ steps.intake.outputs.has_issue_link }}
+      fork_approval_safe: ${{ steps.intake.outputs.fork_approval_safe }}
+      impact_profile: ${{ steps.intake.outputs.impact_profile }}
+      impact_reasons: ${{ steps.intake.outputs.impact_reasons }}
     steps:
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
@@ -56,10 +59,14 @@ jobs:
         id: intake
         if: github.event_name == 'pull_request' && env.IS_TRUSTED_CANONICAL_SYNC_PR != 'true'
         run: |
-          node tools/scripts/pr_preflight.cjs \
-            --base "origin/${{ github.base_ref }}" \
-            --head "HEAD" \
+          trusted_root="$RUNNER_TEMP/pr-policy-main"
+          git worktree add --detach "$trusted_root" "${{ github.event.pull_request.base.sha }}"
+          NODE_PATH="$GITHUB_WORKSPACE/node_modules" node "$trusted_root/tools/scripts/pr_preflight.cjs" \
+            --repo "$GITHUB_WORKSPACE" \
+            --base "${{ github.event.pull_request.base.sha }}" \
+            --head "${{ github.event.pull_request.head.sha }}" \
             --event-path "$GITHUB_EVENT_PATH" \
+            --check-fork-safety \
             --no-run \
             --write-github-output \
             --write-step-summary
@@ -111,10 +118,6 @@ jobs:
           actual_tree=$(git -C "$GITHUB_WORKSPACE" rev-parse 'HEAD^{tree}')
           test "$expected_tree" = "$actual_tree"
 
-      - name: Install npm dependencies
-        if: env.IS_TRUSTED_CANONICAL_SYNC_PR == 'true'
-        run: npm ci --ignore-scripts
-
       - name: Enforce PR source-only contract
         if: github.event_name == 'pull_request' && env.IS_TRUSTED_CANONICAL_SYNC_PR != 'true'
         env:
@@ -142,31 +145,42 @@ jobs:
     if: github.event_name == 'pull_request' || inputs.canonical_sync_pr == true
     runs-on: ubuntu-latest
     needs: pr-policy
+    outputs:
+      preview_manifest_digest: ${{ steps.preview_manifest.outputs.manifest_digest }}
     steps:
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+        if: env.IS_TRUSTED_CANONICAL_SYNC_PR != 'true'
         with:
+          ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Set up Python
+        if: env.IS_TRUSTED_CANONICAL_SYNC_PR != 'true'
         uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
         with:
           python-version: "3.10"
 
       - name: Install Python dependencies
+        if: env.IS_TRUSTED_CANONICAL_SYNC_PR != 'true'
         run: pip install -r tools/requirements.txt
 
       - name: Set up Node
+        if: env.IS_TRUSTED_CANONICAL_SYNC_PR != 'true'
         uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5
         with:
           node-version: "lts/*"
 
       - name: Fetch base branch
+        if: env.IS_TRUSTED_CANONICAL_SYNC_PR != 'true'
         run: git fetch origin "${{ github.base_ref || 'main' }}"
 
       - name: Install npm dependencies
+        if: env.IS_TRUSTED_CANONICAL_SYNC_PR != 'true'
         run: npm ci
 
       - name: Verify directory structure
+        if: env.IS_TRUSTED_CANONICAL_SYNC_PR != 'true'
         run: |
           test -d skills/
           test -d apps/web-app/
@@ -176,9 +190,11 @@ jobs:
           test -f CONTRIBUTING.md
 
       - name: Validate source changes
+        if: env.IS_TRUSTED_CANONICAL_SYNC_PR != 'true'
         run: npm run validate
 
       - name: Enforce validation warning budget
+        if: env.IS_TRUSTED_CANONICAL_SYNC_PR != 'true'
         run: npm run check:warning-budget
 
       - name: Verify README source credits for changed skills
@@ -186,17 +202,66 @@ jobs:
         run: npm run check:readme-credits -- --base "origin/${{ github.base_ref }}" --head HEAD
 
       - name: Validate references
-        if: needs.pr-policy.outputs.requires_references == 'true'
+        if: env.IS_TRUSTED_CANONICAL_SYNC_PR != 'true' && needs.pr-policy.outputs.requires_references == 'true'
         run: npm run validate:references
 
       - name: Refresh ephemeral derived sources for tests
-        run: npm run plugin-compat:sync && npm run index && npm run bundles:sync && npm run sync:metadata && npm run catalog && npm run build:aas-v1-catalog
+        if: env.IS_TRUSTED_CANONICAL_SYNC_PR != 'true'
+        run: npm run plugin-compat:sync && npm run index && npm run bundles:sync && npm run sync:metadata && npm run catalog && npm run build:aas-v1-catalog && npm run sync:web-assets
 
       - name: Run tests
+        if: env.IS_TRUSTED_CANONICAL_SYNC_PR != 'true'
         run: npm run test
 
       - name: Run docs security checks
+        if: env.IS_TRUSTED_CANONICAL_SYNC_PR != 'true'
         run: npm run security:docs
+
+      - name: Create exact-head artifact preview manifest
+        id: preview_manifest
+        if: env.IS_TRUSTED_CANONICAL_SYNC_PR != 'true'
+        env:
+          CATEGORIES_CSV: ${{ needs.pr-policy.outputs.categories }}
+          PRIMARY_CATEGORY: ${{ needs.pr-policy.outputs.primary_category }}
+          PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          set -euo pipefail
+          mapfile -t managed_files < <(node tools/scripts/generated_files.js --include-mixed)
+          if [ "${#managed_files[@]}" -eq 0 ]; then
+            echo "::error::No managed files resolved from generated_files contract."
+            exit 1
+          fi
+          mapfile -d '' -t drift_files < <(git diff --name-only -z -- "${managed_files[@]}")
+          categories_json=$(node -e 'process.stdout.write(JSON.stringify(process.argv[1].split(",").filter(Boolean).sort()))' "$CATEGORIES_CSV")
+          args=()
+          for drift_file in "${drift_files[@]}"; do
+            args+=(--drift-file "$drift_file")
+          done
+          node tools/scripts/ci_artifact_preview.cjs create \
+            --output .tmp/artifact-preview/manifest.json \
+            --mode source-preview \
+            --repository "$GITHUB_REPOSITORY" \
+            --run-id "$GITHUB_RUN_ID" \
+            --run-attempt "$GITHUB_RUN_ATTEMPT" \
+            --workflow-sha "$GITHUB_WORKFLOW_SHA" \
+            --head-sha "$PR_HEAD_SHA" \
+            --primary-category "$PRIMARY_CATEGORY" \
+            --categories-json "$categories_json" \
+            "${args[@]}" \
+            --write-github-output
+
+      - name: Upload exact-head artifact preview manifest
+        if: env.IS_TRUSTED_CANONICAL_SYNC_PR != 'true'
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: source-preview-${{ github.run_id }}-${{ github.run_attempt }}
+          path: .tmp/artifact-preview/manifest.json
+          if-no-files-found: error
+          retention-days: 14
+
+      - name: Record canonical source-validation boundary
+        if: env.IS_TRUSTED_CANONICAL_SYNC_PR == 'true'
+        run: echo "Canonical source state and exact generated tree were reproduced by required pr-policy."
 
   pr-evidence:
     if: github.event_name == 'pull_request' || inputs.canonical_sync_pr == true
@@ -303,30 +368,52 @@ jobs:
     steps:
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
           fetch-depth: 0
           persist-credentials: false
 
       - name: Set up Python
+        if: env.IS_TRUSTED_CANONICAL_SYNC_PR == 'true'
         uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
         with:
           python-version: "3.10"
 
       - name: Install Python dependencies
+        if: env.IS_TRUSTED_CANONICAL_SYNC_PR == 'true'
         run: pip install -r tools/requirements.txt
 
       - name: Set up Node
+        if: env.IS_TRUSTED_CANONICAL_SYNC_PR == 'true'
         uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5
         with:
           node-version: "lts/*"
 
       - name: Install npm dependencies
+        if: env.IS_TRUSTED_CANONICAL_SYNC_PR == 'true'
         run: npm ci
 
-      - name: Generate canonical artifacts preview
+      - name: Download exact-head artifact preview manifest
         if: env.IS_TRUSTED_CANONICAL_SYNC_PR != 'true'
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          name: source-preview-${{ github.run_id }}-${{ github.run_attempt }}
+          path: .tmp/artifact-preview
+
+      - name: Verify and report exact-head artifact preview
+        if: env.IS_TRUSTED_CANONICAL_SYNC_PR != 'true'
+        env:
+          EXPECTED_DIGEST: ${{ needs.source-validation.outputs.preview_manifest_digest }}
+          PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         run: |
-          npm run chain
-          npm run sync:web-assets
+          node "$GITHUB_WORKSPACE/tools/scripts/ci_artifact_preview.cjs" verify-summary \
+            --manifest .tmp/artifact-preview/manifest.json \
+            --expected-repository "$GITHUB_REPOSITORY" \
+            --expected-run-id "$GITHUB_RUN_ID" \
+            --expected-run-attempt "$GITHUB_RUN_ATTEMPT" \
+            --expected-workflow-sha "$GITHUB_WORKFLOW_SHA" \
+            --expected-head-sha "$PR_HEAD_SHA" \
+            --expected-digest "$EXPECTED_DIGEST" \
+            --write-step-summary
 
       - name: Reproduce canonical-sync PR from main
         if: env.IS_TRUSTED_CANONICAL_SYNC_PR == 'true'
@@ -335,6 +422,7 @@ jobs:
         run: npm run sync:repo-state
 
       - name: Report generated drift
+        if: env.IS_TRUSTED_CANONICAL_SYNC_PR == 'true'
         run: |
           mapfile -t managed_files < <(node tools/scripts/generated_files.js --include-mixed)
           if [ "${#managed_files[@]}" -eq 0 ]; then
@@ -358,19 +446,9 @@ jobs:
             exit 0
           fi
 
-          if [ "$IS_TRUSTED_CANONICAL_SYNC_PR" = "true" ]; then
-            echo "::error::Canonical-sync PR is not byte-for-byte reproducible from main."
-            printf '%s\n' "$drift_files"
-            exit 1
-          fi
-
-          echo "::notice::Generated drift detected in artifact preview."
-          {
-            echo "- Generated drift: detected"
-            echo
-            echo "Predicted file updates:"
-            printf '%s\n' "$drift_files" | sed "s/^/- \`/; s/\$/\`/"
-          } >> "$GITHUB_STEP_SUMMARY"
+          echo "::error::Canonical-sync PR is not byte-for-byte reproducible from main."
+          printf '%s\n' "$drift_files"
+          exit 1
 
   main-validation-and-sync:
     if: github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && inputs.canonical_sync_pr != true && github.ref == 'refs/heads/main')

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Shortened PR feedback by parallelizing independent validation, cancelling superseded PR runs, and removing repeated canonical setup and catalog generation; also removed retired workflow/retry code and bound Pages deployments to the exact published release tag.
+- Added trusted-base fork fail-fast intake and shadow impact telemetry without weakening `merge:batch`; source validation now generates one exact-head preview manifest for verification, canonical checks split exact-tree reproduction from drift confirmation, and local timing/sharding remains observational and opt-in while required CI stays complete.
 
 ## [15.3.0] - 2026-07-22 - "Security Boundaries and Maintainer Reliability"
 

--- a/docs/maintainers/merge-batch.md
+++ b/docs/maintainers/merge-batch.md
@@ -26,6 +26,15 @@ npm run merge:batch -- --prs 450 --reviewed-head <40-character-head-sha>
 
 Use `--dry-run` to exercise local classification without approving a run or merging. An abbreviated or stale attestation is rejected.
 
+## CI Intake Contract
+
+- Before dependent required jobs do expensive setup or wait work, `pr-policy` runs the fork-safety classifier from the exact protected-base implementation and fails an unsafe fork diff early.
+- That CI result is fail-fast evidence, not merge authority. `merge:batch` independently recomputes the complete decision from trusted `main` and remains the only command allowed to approve fork runs or merge the PR.
+- `impact_profile` is shadow-only telemetry. It never skips a required job, test, review, or merge gate.
+- Normal source PRs generate derived preview state once in `source-validation`; `artifact-preview` verifies the exact-head manifest and digest instead of generating the tree again.
+- Canonical-sync PRs use the complementary path: `pr-policy` proves the exact reproduced tree, lightweight `source-validation` records that boundary, and `artifact-preview` confirms no generated drift. Final CI and CodeQL still run on the resulting `main` commit.
+- Test timing is observational. Local deterministic sharding requires the explicit `npm run test:local -- --shard-index N --shard-count M` opt-in; required CI remains complete and unsharded.
+
 ## Happy Path
 
 `merge:batch` will:

--- a/docs/maintainers/pr-autonomy.md
+++ b/docs/maintainers/pr-autonomy.md
@@ -31,6 +31,8 @@ The manifest always contains:
 
 The `untrusted_advisory` marker is intentional. No workflow, merge command, or future bot may treat the artifact as privileged authorization.
 
+The `pr-policy` job also reports an `impact_profile` and its reasons. That profile is observational shadow telemetry only: it does not skip, downgrade, or satisfy any required job, test, review, or merge gate.
+
 ## Shadow Routes
 
 - `block`: deterministic repository policy failed, such as a newly introduced changed-skill regression or a direct edit to generated artifacts.
@@ -41,6 +43,8 @@ Every new or relocated skill and every canonical skill-content change requires m
 
 ## Fork Review States
 
+For an ordinary fork PR, `pr-policy` materializes the intake implementation from the exact protected base and evaluates fork safety before its dependent required jobs begin expensive setup or waiting. This makes unsafe paths, modes, objects, sizes, and repository identity fail fast in unprivileged CI. It is not authorization: `merge:batch` independently recomputes the full decision from trusted `main` and remains the sole authority for fork-run approval and merge.
+
 The Skill Review workflow separates two outcomes:
 
 - `review`: a semantic review actually ran using trusted base scripts;
@@ -50,7 +54,7 @@ A successful `manual-review-required` check means only that the requirement was 
 
 ## Maintainer Recalculation
 
-`merge:batch` must bind workflow approval and human attestation to one full head SHA. When it refreshes a PR body by closing and reopening the PR, it also records the pre-refresh workflow-run IDs and accepts checks only from post-refresh check suites. A shared head SHA is not sufficient evidence of freshness because multiple `pull_request` events can exist for the same commit. Before approving a waiting fork run, it independently:
+`merge:batch` must bind workflow approval and human attestation to one full head SHA. It does not rewrite the PR body or close and reopen the PR to manufacture replacement runs. Before approving a waiting fork run, it independently:
 
 1. captures base and head object IDs;
 2. fetches those objects without checking out pull-request code;
@@ -61,13 +65,21 @@ A successful `manual-review-required` check means only that the requirement was 
 7. rejects operational errors, malformed evidence, incomplete snapshots, score-component regressions, provenance identity regressions, or any other deterministic blocker;
 8. re-reads both pull-request base and head before and after approval and immediately before merge.
 
-A real merge also requires effective server-side protection for `main`: the four exact GitHub-Actions-owned checks (`pr-policy`, `pr-evidence`, `source-validation`, and `artifact-preview`), strict up-to-date enforcement, pull-request-only changes, administrator enforcement, no applicable ruleset bypass actors, and no merge queue. If that enforcement cannot be proven, `merge:batch` refuses non-dry-run operation. Base drift is never retried with stale evidence; the batch must be rerun from the new tuple. Pre-existing auto-merge state is rejected, and the immediate GitHub merge endpoint must return `merged: true` before post-merge work begins.
+A real merge also requires effective server-side protection for `main`: the four exact GitHub-Actions-owned checks (`pr-policy`, `pr-evidence`, `source-validation`, and `artifact-preview`), strict up-to-date enforcement, pull-request-only changes, administrator enforcement, no applicable ruleset bypass actors, and no merge queue. If that enforcement cannot be proven, `merge:batch` refuses non-dry-run operation. `merge:batch` does not retry base drift automatically or reuse stale evidence; the batch must be rerun from the new tuple. Pre-existing auto-merge state is rejected, and the immediate GitHub merge endpoint must return `merged: true` before post-merge work begins.
 
 Sensitive same-repository PRs may use the repository-wide source exception only when the PR author is the repository owner and the maintainer attests the exact full head SHA. Collaborator-authored sensitive PRs do not inherit trust from branch location and fail closed under the external safety policy. Every accepted PR remains bound to the protected branch, trusted-base evidence evaluator, exact PR/base/head tuple, semantic-review requirements, and required checks. Missing or mismatched head-repository identity is treated as external.
 
 For any tracked change under a canonical `skills/<skill-id>/**` subtree, the maintainer supplies `--reviewed-head <full-sha>`. A stale, abbreviated, or mismatched SHA fails closed. Skill Review triggers for `skills/**` and `plugins/**/skills/**`, and its reusable result is keyed by the complete nearest skill-directory fingerprint, so nested examples, scripts, lockfiles, references, assets, and other bundled files cannot bypass semantic review.
 
 Deletions, copies, ambiguous moves, and all canonical skill-content changes remain manual-only in this stage even when deterministic evidence contains no regression. A passing ratchet is not semantic approval and never makes a skill eligible for automatic merge.
+
+## Required CI Work Split
+
+For an ordinary source PR, `source-validation` runs validation, tests, security checks, and generated-state refresh once, then uploads a byte-canonical JSON preview manifest listing drift paths and bound to repository, workflow SHA, run ID and attempt, and exact PR head SHA. `artifact-preview` verifies the downloaded manifest, digest, and identity before reporting drift; it does not repeat source generation.
+
+For the protected canonical-sync PR, `pr-policy` already reproduces the exact expected tree from trusted `main`. `source-validation` is therefore a lightweight boundary record, while `artifact-preview` regenerates and confirms that the canonical head has no drift. After protected merge, explicitly dispatched final CI and CodeQL validate the resulting `main` commit.
+
+The test runner emits per-test and summary timing telemetry so maintainers can measure before changing the DAG. Deterministic sharding is available only through an explicit `npm run test:local -- --shard-index N --shard-count M` invocation. Required CI uses the complete unsharded `npm run test` path; neither timing, sharding, nor `impact_profile` removes assurance.
 
 ## Protected Canonical Sync
 

--- a/skills/antigravity-maintainer-batch-release/SKILL.md
+++ b/skills/antigravity-maintainer-batch-release/SKILL.md
@@ -51,6 +51,10 @@ Before changing anything:
 3. Run checks in parallel where independent.
    - Use the repository validation, test, docs-security, source-credit, reference, warning-budget, and targeted app checks required by the changed files.
    - Fix deterministic policy failures in the source; do not wait for them as if they were flaky CI.
+   - Treat `pr-policy` fork classification from the exact protected-base implementation as an unprivileged fail-fast gate before dependent work, never as approval authority. `merge:batch` must still recompute the current trusted decision before approving any fork run or merging.
+   - Treat `impact_profile` as shadow-only telemetry. It must not skip, downgrade, or satisfy any required check.
+   - For ordinary source PRs, require `source-validation` to generate preview state once and `artifact-preview` to verify the manifest bound to the exact head and run identity. For canonical-sync PRs, rely on `pr-policy` exact-tree reproduction, keep `source-validation` lightweight, require `artifact-preview` to confirm no drift, and retain final CI and CodeQL on the merged `main` commit.
+   - Keep timing observational and test sharding opt-in. Required CI must continue to run the full unsharded `npm run test`; deterministic local shards may be used only through `npm run test:local -- --shard-index N --shard-count M`.
 
 4. Merge accepted source PRs in conflict-aware order.
    - Run a dry classification first when useful.

--- a/tools/lib/git-blob-sizes.js
+++ b/tools/lib/git-blob-sizes.js
@@ -1,0 +1,56 @@
+const { spawnSync } = require("child_process");
+
+const FULL_SHA_PATTERN = /^[0-9a-f]{40}$/u;
+
+function runCommand(command, args, cwd, options = {}) {
+  const result = spawnSync(command, args, {
+    cwd,
+    encoding: "utf8",
+    input: options.input,
+    stdio: ["pipe", "pipe", "pipe"],
+  });
+  if (result.error) throw result.error;
+  if (typeof result.status !== "number" || result.status !== 0) {
+    throw new Error(result.stderr.trim() || `${command} ${args.join(" ")} failed with status ${result.status}`);
+  }
+  return result.stdout.trim();
+}
+
+function resolveBlobSizes(projectRoot, records, options = {}) {
+  const execute = options.runCommand || runCommand;
+  const objectIds = [...new Set(records.flatMap((record) => [record.old_oid, record.new_oid]))]
+    .filter((oid) => FULL_SHA_PATTERN.test(String(oid || "")) && !/^0+$/u.test(oid));
+  if (!objectIds.length) {
+    throw new Error("Raw Git diff did not contain any materialized blob object IDs.");
+  }
+
+  const stdout = execute(
+    "git",
+    ["cat-file", "--batch-check=%(objectname) %(objecttype) %(objectsize)"],
+    projectRoot,
+    { capture: true, input: `${objectIds.join("\n")}\n` },
+  );
+  const sizes = new Map();
+  for (const line of String(stdout || "").split(/\r?\n/u).filter(Boolean)) {
+    const match = line.match(/^(?<oid>[0-9a-f]{40}) (?<type>\S+) (?<size>\d+)$/u);
+    if (!match?.groups || !objectIds.includes(match.groups.oid)) {
+      throw new Error(`Unexpected git cat-file response: ${line}`);
+    }
+    if (match.groups.type !== "blob") {
+      throw new Error(`Object ${match.groups.oid} is ${match.groups.type}, not a blob.`);
+    }
+    const size = Number(match.groups.size);
+    if (!Number.isSafeInteger(size) || size < 0) {
+      throw new Error(`Object ${match.groups.oid} has an invalid size.`);
+    }
+    sizes.set(match.groups.oid, size);
+  }
+  for (const oid of objectIds) {
+    if (!sizes.has(oid)) {
+      throw new Error(`git cat-file did not return metadata for ${oid}.`);
+    }
+  }
+  return sizes;
+}
+
+module.exports = { resolveBlobSizes };

--- a/tools/lib/workflow-contract.js
+++ b/tools/lib/workflow-contract.js
@@ -317,6 +317,60 @@ function classifyChangeRecords(records, options = {}) {
   };
 }
 
+function classifyShadowImpact(records, contract) {
+  if (!Array.isArray(records) || records.length === 0) {
+    return { profile: "unknown", reasons: ["missing_change_records"] };
+  }
+
+  const changedPaths = [];
+  const reasons = [];
+  for (const [index, record] of records.entries()) {
+    const expectedSides = CHANGE_STATUS_SIDES[String(record?.status || "")];
+    if (!expectedSides) {
+      reasons.push(`record_${index}:unknown_status`);
+      continue;
+    }
+    for (const side of ["old", "new"]) {
+      if (!expectedSides[side]) continue;
+      const filePath = record?.[`${side}_path`];
+      const validation = validateRawRepoPath(filePath);
+      if (!validation.safe) {
+        reasons.push(...validation.reasons.map((reason) => `record_${index}:${side}_${reason}`));
+        continue;
+      }
+      changedPaths.push(filePath);
+    }
+  }
+
+  if (reasons.length > 0 || changedPaths.length === 0) {
+    return {
+      profile: "unknown",
+      reasons: [...new Set(reasons.length > 0 ? reasons : ["missing_changed_paths"])],
+    };
+  }
+
+  const uniquePaths = [...new Set(changedPaths)];
+  const pathPolicies = uniquePaths.map((filePath) => classifyPathPolicy(filePath));
+  if (pathPolicies.every((policy) => ["canonical_skill", "skill_support"].includes(policy.kind))) {
+    return { profile: "narrow-skill", reasons: [] };
+  }
+  if (pathPolicies.every((policy) => policy.kind === "documentation")) {
+    return { profile: "narrow-docs", reasons: [] };
+  }
+
+  const classification = classifyChangedFiles(uniquePaths, contract);
+  const hasKnownFullImpact = classification.categories.length > 0
+    || uniquePaths.some((filePath) => isDerivedFile(filePath, contract));
+  if (hasKnownFullImpact) {
+    return {
+      profile: "full",
+      reasons: ["mixed_or_broad_change"],
+    };
+  }
+
+  return { profile: "unknown", reasons: ["unclassified_path"] };
+}
+
 function matchesContractEntry(filePath, entry) {
   const normalizedPath = normalizeRepoPath(filePath);
   const normalizedEntry = normalizeRepoPath(entry);
@@ -481,6 +535,7 @@ module.exports = {
   classifyChangeRecords,
   classifyChangedFiles,
   classifyPathPolicy,
+  classifyShadowImpact,
   extractChangelogSection,
   getDirectDerivedChanges,
   getManagedFiles,

--- a/tools/scripts/ci_artifact_preview.cjs
+++ b/tools/scripts/ci_artifact_preview.cjs
@@ -1,0 +1,248 @@
+#!/usr/bin/env node
+
+const crypto = require("crypto");
+const fs = require("fs");
+const path = require("path");
+
+const MODES = new Set(["source-preview", "canonical-exact-tree"]);
+const SHA_RE = /^[0-9a-f]{40}$/;
+const DIGEST_RE = /^[0-9a-f]{64}$/;
+const REPOSITORY_RE = /^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/;
+
+function canonicalize(value) {
+  if (Array.isArray(value)) return value.map(canonicalize);
+  if (value && typeof value === "object") {
+    return Object.fromEntries(
+      Object.keys(value).sort().map((key) => [key, canonicalize(value[key])]),
+    );
+  }
+  return value;
+}
+
+function canonicalJson(value) {
+  return JSON.stringify(canonicalize(value));
+}
+
+function sha256(value) {
+  return crypto.createHash("sha256").update(value).digest("hex");
+}
+
+function parsePositiveInteger(value, label) {
+  if (!/^[1-9]\d*$/.test(String(value))) throw new Error(`${label} must be a positive integer`);
+  const parsed = Number(value);
+  if (!Number.isSafeInteger(parsed)) throw new Error(`${label} is outside the safe integer range`);
+  return parsed;
+}
+
+function validateString(value, label) {
+  if (typeof value !== "string" || value.length === 0 || /[\0-\x1f\x7f]/.test(value)) {
+    throw new Error(`${label} must be a non-empty string without control characters`);
+  }
+  return value;
+}
+
+function validateRelativePath(value) {
+  validateString(value, "drift file");
+  if (value.includes("\\") || path.posix.isAbsolute(value) || path.posix.normalize(value) !== value) {
+    throw new Error(`Drift file must be a normalized repository-relative POSIX path: ${value}`);
+  }
+  if (value.split("/").some((part) => part === "" || part === "." || part === "..")) {
+    throw new Error(`Drift file contains an unsafe path segment: ${value}`);
+  }
+  return value;
+}
+
+function validateOrderedUniqueStrings(values, label, itemValidator = validateString) {
+  if (!Array.isArray(values)) throw new Error(`${label} must be an array`);
+  let previous = null;
+  return values.map((value, index) => {
+    const validated = itemValidator(value, `${label}[${index}]`);
+    if (previous !== null && previous >= validated) {
+      throw new Error(`${label} must be strictly sorted and contain no duplicates`);
+    }
+    previous = validated;
+    return validated;
+  });
+}
+
+function validateManifest(manifest) {
+  if (!manifest || typeof manifest !== "object" || Array.isArray(manifest)) {
+    throw new Error("Manifest must be a JSON object");
+  }
+  const expectedKeys = [
+    "categories", "driftFiles", "headSha", "mode", "primaryCategory", "repository",
+    "runAttempt", "runId", "schemaVersion", "workflowSha",
+  ].sort();
+  const actualKeys = Object.keys(manifest).sort();
+  if (JSON.stringify(actualKeys) !== JSON.stringify(expectedKeys)) {
+    throw new Error("Manifest contains missing or unsupported fields");
+  }
+  if (manifest.schemaVersion !== 1) throw new Error("Unsupported manifest schemaVersion");
+  if (!MODES.has(manifest.mode)) throw new Error(`Unsupported preview mode: ${manifest.mode}`);
+  if (!REPOSITORY_RE.test(validateString(manifest.repository, "repository"))) {
+    throw new Error("repository must use the owner/name form");
+  }
+  if (!/^\d+$/.test(String(manifest.runId))) throw new Error("runId must contain decimal digits");
+  parsePositiveInteger(manifest.runAttempt, "runAttempt");
+  for (const [label, value] of [["workflowSha", manifest.workflowSha], ["headSha", manifest.headSha]]) {
+    if (!SHA_RE.test(value)) throw new Error(`${label} must be a full lowercase SHA-1`);
+  }
+  validateString(manifest.primaryCategory, "primaryCategory");
+  validateOrderedUniqueStrings(manifest.categories, "categories");
+  validateOrderedUniqueStrings(manifest.driftFiles, "driftFiles", validateRelativePath);
+  if (manifest.mode === "canonical-exact-tree" && manifest.driftFiles.length !== 0) {
+    throw new Error("canonical-exact-tree manifests must not contain generated drift");
+  }
+  return manifest;
+}
+
+function parseOptions(argv) {
+  if (argv.length === 0) throw new Error("Expected create or verify-summary command");
+  const command = argv[0];
+  if (!new Set(["create", "verify-summary"]).has(command)) throw new Error(`Unknown command: ${command}`);
+  const repeatable = new Set(["drift-file"]);
+  const flags = new Set(["write-github-output", "write-step-summary"]);
+  const options = { command, driftFile: [] };
+  for (let index = 1; index < argv.length; index += 1) {
+    const token = argv[index];
+    if (!token.startsWith("--")) throw new Error(`Unexpected argument: ${token}`);
+    const name = token.slice(2);
+    if (flags.has(name)) {
+      const key = name.replace(/-([a-z])/g, (_, letter) => letter.toUpperCase());
+      if (options[key]) throw new Error(`Duplicate option: ${token}`);
+      options[key] = true;
+      continue;
+    }
+    const value = argv[index + 1];
+    if (!value || value.startsWith("--")) throw new Error(`${token} requires a value`);
+    const key = name.replace(/-([a-z])/g, (_, letter) => letter.toUpperCase());
+    if (!repeatable.has(name) && options[key] !== undefined) throw new Error(`Duplicate option: ${token}`);
+    if (repeatable.has(name)) options[key].push(value);
+    else options[key] = value;
+    index += 1;
+  }
+  return options;
+}
+
+function requireOptions(options, names) {
+  for (const name of names) {
+    if (options[name] === undefined) throw new Error(`--${name.replace(/[A-Z]/g, (letter) => `-${letter.toLowerCase()}`)} is required`);
+  }
+}
+
+function appendGithubOutput(digest) {
+  if (!process.env.GITHUB_OUTPUT) throw new Error("GITHUB_OUTPUT is required with --write-github-output");
+  fs.appendFileSync(process.env.GITHUB_OUTPUT, `manifest_digest=${digest}\n`, "utf8");
+}
+
+function createManifest(options) {
+  requireOptions(options, [
+    "output", "mode", "repository", "runId", "runAttempt", "workflowSha", "headSha",
+    "primaryCategory", "categoriesJson",
+  ]);
+  let categories;
+  try {
+    categories = JSON.parse(options.categoriesJson);
+  } catch (error) {
+    throw new Error(`--categories-json must be valid JSON: ${error.message}`);
+  }
+  const manifest = validateManifest({
+    schemaVersion: 1,
+    mode: options.mode,
+    repository: options.repository,
+    runId: String(options.runId),
+    runAttempt: parsePositiveInteger(options.runAttempt, "runAttempt"),
+    workflowSha: options.workflowSha,
+    headSha: options.headSha,
+    primaryCategory: options.primaryCategory,
+    categories,
+    driftFiles: options.driftFile,
+  });
+  const serialized = canonicalJson(manifest);
+  const digest = sha256(serialized);
+  fs.mkdirSync(path.dirname(path.resolve(options.output)), { recursive: true });
+  fs.writeFileSync(options.output, `${serialized}\n`, { encoding: "utf8", mode: 0o600 });
+  if (options.writeGithubOutput) appendGithubOutput(digest);
+  process.stdout.write(`${digest}\n`);
+  return { digest, manifest };
+}
+
+function readCanonicalManifest(filePath) {
+  const raw = fs.readFileSync(filePath, "utf8");
+  let manifest;
+  try {
+    manifest = JSON.parse(raw);
+  } catch (error) {
+    throw new Error(`Manifest is not valid JSON: ${error.message}`);
+  }
+  validateManifest(manifest);
+  const serialized = canonicalJson(manifest);
+  if (raw !== `${serialized}\n`) throw new Error("Manifest is not encoded as canonical JSON with one trailing newline");
+  return { manifest, serialized };
+}
+
+function appendSummary(manifest, digest) {
+  if (!process.env.GITHUB_STEP_SUMMARY) throw new Error("GITHUB_STEP_SUMMARY is required with --write-step-summary");
+  const drift = manifest.driftFiles.length
+    ? manifest.driftFiles.map((file) => `- \`${file.replace(/`/g, "\\`")}\``).join("\n")
+    : "- none";
+  const lines = [
+    "## Artifact Preview", "",
+    `- Mode: \`${manifest.mode}\``,
+    `- Primary change: \`${manifest.primaryCategory.replace(/`/g, "\\`")}\``,
+    `- Categories: ${manifest.categories.length ? manifest.categories.map((item) => `\`${item.replace(/`/g, "\\`")}\``).join(", ") : "none"}`,
+    `- Workflow SHA: \`${manifest.workflowSha}\``,
+    `- Manifest SHA-256: \`${digest}\``, "", "Generated drift:", drift, "",
+  ];
+  fs.appendFileSync(process.env.GITHUB_STEP_SUMMARY, lines.join("\n"), "utf8");
+}
+
+function verifySummary(options) {
+  requireOptions(options, [
+    "manifest", "expectedRepository", "expectedRunId", "expectedRunAttempt",
+    "expectedWorkflowSha", "expectedHeadSha", "expectedDigest",
+  ]);
+  if (!DIGEST_RE.test(options.expectedDigest)) throw new Error("--expected-digest must be a lowercase SHA-256");
+  const { manifest, serialized } = readCanonicalManifest(options.manifest);
+  const bindings = [
+    ["repository", options.expectedRepository],
+    ["runId", String(options.expectedRunId)],
+    ["runAttempt", parsePositiveInteger(options.expectedRunAttempt, "expectedRunAttempt")],
+    ["workflowSha", options.expectedWorkflowSha],
+    ["headSha", options.expectedHeadSha],
+  ];
+  for (const [key, expected] of bindings) {
+    if (manifest[key] !== expected) throw new Error(`Manifest ${key} does not match the expected workflow identity`);
+  }
+  const digest = sha256(serialized);
+  if (digest !== options.expectedDigest) throw new Error("Manifest SHA-256 does not match --expected-digest");
+  if (options.writeStepSummary) appendSummary(manifest, digest);
+  process.stdout.write(`${digest}\n`);
+  return manifest;
+}
+
+function main(argv = process.argv.slice(2)) {
+  const options = parseOptions(argv);
+  return options.command === "create" ? createManifest(options) : verifySummary(options);
+}
+
+if (require.main === module) {
+  try {
+    main();
+  } catch (error) {
+    console.error(`[ci-artifact-preview] ${error.message}`);
+    process.exit(2);
+  }
+}
+
+module.exports = {
+  canonicalJson,
+  createManifest,
+  main,
+  parseOptions,
+  readCanonicalManifest,
+  sha256,
+  validateManifest,
+  validateRelativePath,
+  verifySummary,
+};

--- a/tools/scripts/ci_artifact_preview.cjs
+++ b/tools/scripts/ci_artifact_preview.cjs
@@ -27,6 +27,15 @@ function sha256(value) {
   return crypto.createHash("sha256").update(value).digest("hex");
 }
 
+function escapeHtml(value) {
+  return String(value)
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+    .replaceAll('"', "&quot;")
+    .replaceAll("'", "&#39;");
+}
+
 function parsePositiveInteger(value, label) {
   if (!/^[1-9]\d*$/.test(String(value))) throw new Error(`${label} must be a positive integer`);
   const parsed = Number(value);
@@ -184,15 +193,15 @@ function readCanonicalManifest(filePath) {
 function appendSummary(manifest, digest) {
   if (!process.env.GITHUB_STEP_SUMMARY) throw new Error("GITHUB_STEP_SUMMARY is required with --write-step-summary");
   const drift = manifest.driftFiles.length
-    ? manifest.driftFiles.map((file) => `- \`${file.replace(/`/g, "\\`")}\``).join("\n")
+    ? manifest.driftFiles.map((file) => `- <code>${escapeHtml(file)}</code>`).join("\n")
     : "- none";
   const lines = [
     "## Artifact Preview", "",
-    `- Mode: \`${manifest.mode}\``,
-    `- Primary change: \`${manifest.primaryCategory.replace(/`/g, "\\`")}\``,
-    `- Categories: ${manifest.categories.length ? manifest.categories.map((item) => `\`${item.replace(/`/g, "\\`")}\``).join(", ") : "none"}`,
-    `- Workflow SHA: \`${manifest.workflowSha}\``,
-    `- Manifest SHA-256: \`${digest}\``, "", "Generated drift:", drift, "",
+    `- Mode: <code>${escapeHtml(manifest.mode)}</code>`,
+    `- Primary change: <code>${escapeHtml(manifest.primaryCategory)}</code>`,
+    `- Categories: ${manifest.categories.length ? manifest.categories.map((item) => `<code>${escapeHtml(item)}</code>`).join(", ") : "none"}`,
+    `- Workflow SHA: <code>${escapeHtml(manifest.workflowSha)}</code>`,
+    `- Manifest SHA-256: <code>${escapeHtml(digest)}</code>`, "", "Generated drift:", drift, "",
   ];
   fs.appendFileSync(process.env.GITHUB_STEP_SUMMARY, lines.join("\n"), "utf8");
 }
@@ -238,6 +247,7 @@ if (require.main === module) {
 module.exports = {
   canonicalJson,
   createManifest,
+  escapeHtml,
   main,
   parseOptions,
   readCanonicalManifest,

--- a/tools/scripts/merge_batch.cjs
+++ b/tools/scripts/merge_batch.cjs
@@ -6,6 +6,7 @@ const path = require("path");
 const { spawnSync } = require("child_process");
 
 const { findProjectRoot } = require("../lib/project-root");
+const { resolveBlobSizes } = require("../lib/git-blob-sizes");
 const { parseRawDiff } = require("../lib/git-raw-diff");
 const {
   classifyChangeRecords,
@@ -406,43 +407,6 @@ function readRawChangeRecords(projectRoot, baseOid, headOid, dependencies = {}) 
     projectRoot,
   );
   return parseRawDiff(raw);
-}
-
-function resolveBlobSizes(projectRoot, records, dependencies = {}) {
-  const execute = dependencies.runCommand || runCommand;
-  const objectIds = [...new Set(records.flatMap((record) => [record.old_oid, record.new_oid]))]
-    .filter((oid) => FULL_SHA_PATTERN.test(String(oid || "")) && !/^0+$/u.test(oid));
-  if (!objectIds.length) {
-    throw new Error("Raw Git diff did not contain any materialized blob object IDs.");
-  }
-
-  const stdout = execute(
-    "git",
-    ["cat-file", "--batch-check=%(objectname) %(objecttype) %(objectsize)"],
-    projectRoot,
-    { capture: true, input: `${objectIds.join("\n")}\n` },
-  );
-  const sizes = new Map();
-  for (const line of String(stdout || "").split(/\r?\n/u).filter(Boolean)) {
-    const match = line.match(/^(?<oid>[0-9a-f]{40}) (?<type>\S+) (?<size>\d+)$/u);
-    if (!match?.groups || !objectIds.includes(match.groups.oid)) {
-      throw new Error(`Unexpected git cat-file response: ${line}`);
-    }
-    if (match.groups.type !== "blob") {
-      throw new Error(`Object ${match.groups.oid} is ${match.groups.type}, not a blob.`);
-    }
-    const size = Number(match.groups.size);
-    if (!Number.isSafeInteger(size) || size < 0) {
-      throw new Error(`Object ${match.groups.oid} has an invalid size.`);
-    }
-    sizes.set(match.groups.oid, size);
-  }
-  for (const oid of objectIds) {
-    if (!sizes.has(oid)) {
-      throw new Error(`git cat-file did not return metadata for ${oid}.`);
-    }
-  }
-  return sizes;
 }
 
 function runGhJson(projectRoot, args, options = {}) {

--- a/tools/scripts/pr_preflight.cjs
+++ b/tools/scripts/pr_preflight.cjs
@@ -5,10 +5,13 @@ const path = require("path");
 const { spawnSync } = require("child_process");
 const sanitizeFilename = require("sanitize-filename");
 
+const { resolveBlobSizes } = require("../lib/git-blob-sizes");
 const { findProjectRoot } = require("../lib/project-root");
 const { parseRawDiff } = require("../lib/git-raw-diff");
 const {
+  classifyChangeRecords,
   classifyChangedFiles,
+  classifyShadowImpact,
   getDirectDerivedChanges,
   hasIssueLink,
   hasQualityChecklist,
@@ -19,10 +22,12 @@ const {
 
 function parseArgs(argv) {
   const args = {
+    repo: null,
     base: null,
     head: "HEAD",
     eventPath: null,
     checkPolicy: false,
+    checkForkSafety: false,
     noRun: false,
     writeGithubOutput: false,
     writeStepSummary: false,
@@ -31,7 +36,10 @@ function parseArgs(argv) {
 
   for (let index = 0; index < argv.length; index += 1) {
     const arg = argv[index];
-    if (arg === "--base") {
+    if (arg === "--repo") {
+      args.repo = argv[index + 1] || null;
+      index += 1;
+    } else if (arg === "--base") {
       args.base = argv[index + 1];
       index += 1;
     } else if (arg === "--head") {
@@ -42,6 +50,8 @@ function parseArgs(argv) {
       index += 1;
     } else if (arg === "--check-policy") {
       args.checkPolicy = true;
+    } else if (arg === "--check-fork-safety") {
+      args.checkForkSafety = true;
     } else if (arg === "--no-run") {
       args.noRun = true;
     } else if (arg === "--write-github-output") {
@@ -163,14 +173,39 @@ function changedFilesFromRecords(records) {
     .map(normalizeRepoPath))];
 }
 
-function loadPullRequestBody(eventPath) {
+function loadPullRequestEvent(eventPath) {
   if (!eventPath) {
     return null;
   }
 
   const rawEvent = fs.readFileSync(safeUserPath(eventPath), "utf8");
-  const event = JSON.parse(rawEvent);
-  return event.pull_request?.body || "";
+  return JSON.parse(rawEvent).pull_request || null;
+}
+
+function evaluateForkSafety(projectRoot, changeRecords, pullRequest) {
+  if (!pullRequest) {
+    return { applicable: false, approvalSafe: true, reasons: [], requiresHumanReview: false };
+  }
+  const headRepository = String(pullRequest?.head?.repo?.full_name || "").toLowerCase();
+  const baseRepository = String(pullRequest?.base?.repo?.full_name || "").toLowerCase();
+  if (!headRepository || !baseRepository) {
+    return {
+      applicable: true,
+      approvalSafe: false,
+      reasons: ["pull_request_repository_identity_unavailable"],
+      requiresHumanReview: false,
+    };
+  }
+  if (headRepository === baseRepository) {
+    return { applicable: false, approvalSafe: true, reasons: [], requiresHumanReview: false };
+  }
+
+  const preliminary = classifyChangeRecords(changeRecords, { requireBlobSizes: false });
+  if (!preliminary.approvalSafe) {
+    return { applicable: true, ...preliminary };
+  }
+  const blobSizes = resolveBlobSizes(projectRoot, changeRecords);
+  return { applicable: true, ...classifyChangeRecords(changeRecords, { blobSizes }) };
 }
 
 function appendGithubOutput(result) {
@@ -188,6 +223,11 @@ function appendGithubOutput(result) {
     `changed_files_count=${String(result.changedFiles.length)}`,
     `has_quality_checklist=${String(result.prBody.hasQualityChecklist)}`,
     `has_issue_link=${String(result.prBody.hasIssueLink)}`,
+    `fork_safety_applicable=${String(result.forkSafety.applicable)}`,
+    `fork_approval_safe=${String(result.forkSafety.approvalSafe)}`,
+    `fork_safety_reasons=${JSON.stringify(result.forkSafety.reasons)}`,
+    `impact_profile=${result.shadowImpact.profile}`,
+    `impact_reasons=${JSON.stringify(result.shadowImpact.reasons)}`,
   ];
 
   fs.appendFileSync(outputPath, `${lines.join("\n")}\n`, "utf8");
@@ -214,6 +254,8 @@ function appendStepSummary(result) {
     `- \`validate:references\` required: ${result.requiresReferencesValidation ? "yes" : "no"}`,
     `- PR template checklist: ${result.prBody.hasQualityChecklist ? "present" : "missing"}`,
     `- Issue auto-close link: ${result.prBody.hasIssueLink ? "detected" : "not detected"}`,
+    `- Fork approval safety: ${result.forkSafety.applicable ? (result.forkSafety.approvalSafe ? "safe" : "blocked") : "not applicable"}`,
+    `- Shadow impact profile: \`${result.shadowImpact.profile}\` (observational only; no test is skipped)`,
     "",
     "> Generated drift is reported separately in the artifact preview job and remains informational on pull requests.",
   ];
@@ -223,14 +265,17 @@ function appendStepSummary(result) {
 
 function main() {
   const args = parseArgs(process.argv.slice(2));
-  const projectRoot = findProjectRoot(__dirname);
+  const projectRoot = args.repo ? path.resolve(args.repo) : findProjectRoot(__dirname);
   const contract = loadWorkflowContract(__dirname);
   const baseRef = args.base || resolveBaseRef(projectRoot);
   const changeRecords = getChangeRecords(projectRoot, baseRef, args.head);
   const changedFiles = changedFilesFromRecords(changeRecords);
   const classification = classifyChangedFiles(changedFiles, contract);
   const directDerivedChanges = getDirectDerivedChanges(changedFiles, contract);
-  const pullRequestBody = loadPullRequestBody(args.eventPath);
+  const pullRequest = loadPullRequestEvent(args.eventPath);
+  const pullRequestBody = pullRequest?.body ?? null;
+  const forkSafety = evaluateForkSafety(projectRoot, changeRecords, pullRequest);
+  const shadowImpact = classifyShadowImpact(changeRecords, contract);
 
   const result = {
     baseRef,
@@ -241,6 +286,8 @@ function main() {
     primaryCategory: classification.primaryCategory,
     directDerivedChanges,
     requiresReferencesValidation: requiresReferencesValidation(changedFiles, contract),
+    forkSafety,
+    shadowImpact,
     prBody: {
       available: pullRequestBody !== null,
       hasQualityChecklist: hasQualityChecklist(pullRequestBody),
@@ -284,6 +331,11 @@ function main() {
     }
   }
 
+  if (args.checkForkSafety && forkSafety.applicable && !forkSafety.approvalSafe) {
+    console.error(`Fork PR is not approval-safe: ${forkSafety.reasons.slice(0, 12).join(", ") || "unclassified diff"}.`);
+    process.exit(1);
+  }
+
   if (!args.noRun) {
     runCommand("npm", ["run", "validate"], projectRoot);
 
@@ -299,4 +351,11 @@ if (require.main === module) {
   main();
 }
 
-module.exports = { changedFilesFromRecords, getChangeRecords, getChangedFiles, parseArgs };
+module.exports = {
+  changedFilesFromRecords,
+  evaluateForkSafety,
+  getChangeRecords,
+  getChangedFiles,
+  loadPullRequestEvent,
+  parseArgs,
+};

--- a/tools/scripts/tests/automation_workflows.test.js
+++ b/tools/scripts/tests/automation_workflows.test.js
@@ -171,6 +171,12 @@ assert.ok(
 );
 assert.match(
   ciWorkflow,
+  /- name: Intake PR change[\s\S]*?git worktree add --detach "\$trusted_root" "\$\{\{ github\.event\.pull_request\.base\.sha \}\}"[\s\S]*?"\$trusted_root\/tools\/scripts\/pr_preflight\.cjs"[\s\S]*?--base "\$\{\{ github\.event\.pull_request\.base\.sha \}\}"[\s\S]*?--head "\$\{\{ github\.event\.pull_request\.head\.sha \}\}"[\s\S]*?--check-fork-safety/,
+  "PR policy must execute trusted-base fork classification against the exact base/head tuple",
+);
+assert.match(ciWorkflow, /impact_profile: \$\{\{ steps\.intake\.outputs\.impact_profile \}\}/);
+assert.match(
+  ciWorkflow,
   /GH_TOKEN: \$\{\{ github\.token \}\}/,
   "main CI should provide GH_TOKEN for contributor synchronization",
 );
@@ -215,6 +221,11 @@ assert.match(
   ciWorkflow,
   /artifact-preview:[\s\S]*?actions\/checkout@[a-f0-9]{40}[\s\S]*?fetch-depth: 0[\s\S]*?persist-credentials: false/,
   "artifact-preview should retain history because canonical provenance generation reads git history",
+);
+assert.match(
+  ciWorkflow,
+  /source-validation:[\s\S]*?ci_artifact_preview\.cjs create[\s\S]*?actions\/upload-artifact@[a-f0-9]{40}[\s\S]*?artifact-preview:[\s\S]*?actions\/download-artifact@[a-f0-9]{40}[\s\S]*?ci_artifact_preview\.cjs" verify-summary/,
+  "normal PR artifact preview must reuse the exact-head manifest produced by source validation",
 );
 assert.doesNotMatch(
   offlineCatalogBuilder,

--- a/tools/scripts/tests/ci_artifact_preview.test.js
+++ b/tools/scripts/tests/ci_artifact_preview.test.js
@@ -12,6 +12,12 @@ const SUMMARY = path.join(ROOT, "summary.md");
 const WORKFLOW_SHA = "a".repeat(40);
 const HEAD_SHA = "b".repeat(40);
 
+assert.strictEqual(
+  preview.escapeHtml(`<tag attr="value">&'\\\``),
+  "&lt;tag attr=&quot;value&quot;&gt;&amp;&#39;\\`",
+  "step-summary values must be HTML-encoded instead of relying on incomplete Markdown escaping",
+);
+
 process.env.GITHUB_OUTPUT = OUTPUT;
 const created = preview.createManifest({
   output: MANIFEST,

--- a/tools/scripts/tests/ci_artifact_preview.test.js
+++ b/tools/scripts/tests/ci_artifact_preview.test.js
@@ -1,0 +1,135 @@
+const assert = require("assert");
+const fs = require("fs");
+const os = require("os");
+const path = require("path");
+
+const preview = require("../ci_artifact_preview.cjs");
+
+const ROOT = fs.mkdtempSync(path.join(os.tmpdir(), "ci-artifact-preview-"));
+const MANIFEST = path.join(ROOT, "preview.json");
+const OUTPUT = path.join(ROOT, "github-output.txt");
+const SUMMARY = path.join(ROOT, "summary.md");
+const WORKFLOW_SHA = "a".repeat(40);
+const HEAD_SHA = "b".repeat(40);
+
+process.env.GITHUB_OUTPUT = OUTPUT;
+const created = preview.createManifest({
+  output: MANIFEST,
+  mode: "source-preview",
+  repository: "owner/repo",
+  runId: "12345",
+  runAttempt: "1",
+  workflowSha: WORKFLOW_SHA,
+  headSha: HEAD_SHA,
+  primaryCategory: "skill",
+  categoriesJson: '["docs","skill"]',
+  driftFile: ["CATALOG.md", "data/skills.json"],
+  writeGithubOutput: true,
+});
+assert.match(created.digest, /^[0-9a-f]{64}$/);
+assert.strictEqual(fs.readFileSync(OUTPUT, "utf8"), `manifest_digest=${created.digest}\n`);
+assert.strictEqual(
+  fs.readFileSync(MANIFEST, "utf8"),
+  `${preview.canonicalJson(created.manifest)}\n`,
+  "create must use byte-stable canonical JSON",
+);
+
+process.env.GITHUB_STEP_SUMMARY = SUMMARY;
+const verified = preview.verifySummary({
+  manifest: MANIFEST,
+  expectedRepository: "owner/repo",
+  expectedRunId: "12345",
+  expectedRunAttempt: "1",
+  expectedWorkflowSha: WORKFLOW_SHA,
+  expectedHeadSha: HEAD_SHA,
+  expectedDigest: created.digest,
+  writeStepSummary: true,
+});
+assert.deepStrictEqual(verified, created.manifest);
+assert.match(fs.readFileSync(SUMMARY, "utf8"), /Artifact Preview[\s\S]*CATALOG\.md/);
+
+for (const [field, value, pattern] of [
+  ["expectedRepository", "other/repo", /repository/],
+  ["expectedRunId", "999", /runId/],
+  ["expectedRunAttempt", "2", /runAttempt/],
+  ["expectedWorkflowSha", "c".repeat(40), /workflowSha/],
+  ["expectedHeadSha", "d".repeat(40), /headSha/],
+  ["expectedDigest", "e".repeat(64), /SHA-256/],
+]) {
+  const options = {
+    manifest: MANIFEST,
+    expectedRepository: "owner/repo",
+    expectedRunId: "12345",
+    expectedRunAttempt: "1",
+    expectedWorkflowSha: WORKFLOW_SHA,
+    expectedHeadSha: HEAD_SHA,
+    expectedDigest: created.digest,
+    [field]: value,
+  };
+  assert.throws(() => preview.verifySummary(options), pattern);
+}
+
+assert.throws(
+  () => preview.validateManifest({ ...created.manifest, workflowSha: "short" }),
+  /full lowercase SHA-1/,
+);
+assert.throws(
+  () => preview.validateManifest({ ...created.manifest, categories: ["skill", "docs"] }),
+  /strictly sorted/,
+);
+assert.throws(
+  () => preview.validateManifest({ ...created.manifest, driftFiles: ["CATALOG.md", "CATALOG.md"] }),
+  /strictly sorted/,
+);
+assert.throws(
+  () => preview.validateManifest({ ...created.manifest, driftFiles: ["../escape.md"] }),
+  /unsafe path segment/,
+);
+assert.throws(
+  () => preview.validateManifest({ ...created.manifest, driftFiles: ["bad\\path.md"] }),
+  /normalized repository-relative/,
+);
+assert.throws(
+  () => preview.validateManifest({ ...created.manifest, driftFiles: ["bad\npath.md"] }),
+  /control characters/,
+);
+assert.throws(
+  () => preview.validateManifest({ ...created.manifest, mode: "canonical-exact-tree" }),
+  /must not contain generated drift/,
+);
+assert.doesNotThrow(() => preview.validateManifest({
+  ...created.manifest,
+  mode: "canonical-exact-tree",
+  driftFiles: [],
+}));
+
+const nonCanonicalPath = path.join(ROOT, "noncanonical.json");
+fs.writeFileSync(nonCanonicalPath, `${JSON.stringify(created.manifest, null, 2)}\n`, "utf8");
+assert.throws(
+  () => preview.readCanonicalManifest(nonCanonicalPath),
+  /not encoded as canonical JSON/,
+);
+
+const tamperedPath = path.join(ROOT, "tampered.json");
+fs.writeFileSync(tamperedPath, fs.readFileSync(MANIFEST, "utf8").replace("CATALOG.md", "README.md"), "utf8");
+assert.throws(
+  () => preview.verifySummary({
+    manifest: tamperedPath,
+    expectedRepository: "owner/repo",
+    expectedRunId: "12345",
+    expectedRunAttempt: "1",
+    expectedWorkflowSha: WORKFLOW_SHA,
+    expectedHeadSha: HEAD_SHA,
+    expectedDigest: created.digest,
+  }),
+  /SHA-256/,
+);
+
+assert.throws(
+  () => preview.parseOptions(["create", "--mode", "source-preview", "--mode", "canonical-exact-tree"]),
+  /Duplicate option/,
+);
+assert.throws(() => preview.parseOptions(["unknown"]), /Unknown command/);
+
+fs.rmSync(ROOT, { recursive: true, force: true });
+console.log("ci artifact preview tests passed");

--- a/tools/scripts/tests/pr_preflight.test.js
+++ b/tools/scripts/tests/pr_preflight.test.js
@@ -6,6 +6,10 @@ const { spawnSync } = require("child_process");
 
 const repoRoot = path.resolve(__dirname, "..", "..", "..");
 const scriptPath = path.join(repoRoot, "tools", "scripts", "pr_preflight.cjs");
+const { evaluateForkSafety, parseArgs } = require("../pr_preflight.cjs");
+
+assert.strictEqual(parseArgs(["--repo", repoRoot, "--check-fork-safety"]).repo, repoRoot);
+assert.strictEqual(parseArgs(["--repo", repoRoot, "--check-fork-safety"]).checkForkSafety, true);
 
 const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "aas-pr-preflight-"));
 const eventPath = path.join(tempDir, "event.json");
@@ -15,6 +19,8 @@ fs.writeFileSync(
   JSON.stringify({
     pull_request: {
       body: "## Quality Bar Checklist ✅\n\n- [x] Canonical skill location\n",
+      base: { repo: { full_name: "sickn33/agentic-awesome-skills" } },
+      head: { repo: { full_name: "sickn33/agentic-awesome-skills" } },
     },
   }),
   "utf8",
@@ -44,3 +50,54 @@ assert.strictEqual(result.status, 0, result.stderr || result.stdout);
 const parsed = JSON.parse(result.stdout);
 assert.strictEqual(parsed.prBody.available, true);
 assert.strictEqual(parsed.prBody.hasQualityChecklist, true);
+assert.strictEqual(parsed.forkSafety.applicable, false);
+assert.strictEqual(parsed.forkSafety.approvalSafe, true);
+assert.strictEqual(parsed.shadowImpact.profile, "unknown");
+
+const ZERO_OID = "0".repeat(40);
+const WALKTHROUGH_OID = "1".repeat(40);
+const walkthroughPolicy = evaluateForkSafety(
+  repoRoot,
+  [{
+    status: "A",
+    old_path: null,
+    new_path: "walkthrough.md",
+    old_mode: "000000",
+    new_mode: "100644",
+    old_oid: ZERO_OID,
+    new_oid: WALKTHROUGH_OID,
+  }],
+  {
+    base: { repo: { full_name: "sickn33/agentic-awesome-skills" } },
+    head: { repo: { full_name: "community/example-fork" } },
+  },
+);
+assert.strictEqual(walkthroughPolicy.applicable, true);
+assert.strictEqual(walkthroughPolicy.approvalSafe, false);
+assert.ok(
+  walkthroughPolicy.reasons.some((reason) => reason.includes("new_unapproved_path")),
+  `PR #974-style root walkthrough.md must fail before merge: ${walkthroughPolicy.reasons.join(", ")}`,
+);
+
+const readmeOid = spawnSync("git", ["rev-parse", "HEAD:README.md"], {
+  cwd: repoRoot,
+  encoding: "utf8",
+});
+assert.strictEqual(readmeOid.status, 0, readmeOid.stderr);
+const safeForkPolicy = evaluateForkSafety(
+  repoRoot,
+  [{
+    status: "M",
+    old_path: "README.md",
+    new_path: "README.md",
+    old_mode: "100644",
+    new_mode: "100644",
+    old_oid: readmeOid.stdout.trim(),
+    new_oid: readmeOid.stdout.trim(),
+  }],
+  {
+    base: { repo: { full_name: "sickn33/agentic-awesome-skills" } },
+    head: { repo: { full_name: "community/example-fork" } },
+  },
+);
+assert.strictEqual(safeForkPolicy.approvalSafe, true);

--- a/tools/scripts/tests/run-test-suite.js
+++ b/tools/scripts/tests/run-test-suite.js
@@ -2,6 +2,7 @@
 
 const fs = require("fs");
 const { spawnSync } = require("child_process");
+const crypto = require("crypto");
 const path = require("path");
 
 const NETWORK_TEST_ENV = "ENABLE_NETWORK_TESTS";
@@ -67,13 +68,124 @@ function isNetworkTestsEnabled() {
     : false;
 }
 
+function parsePositiveInteger(value, flag) {
+  if (!/^\d+$/.test(value)) {
+    throw new Error(`${flag} must be an integer`);
+  }
+
+  const parsed = Number(value);
+  if (!Number.isSafeInteger(parsed)) {
+    throw new Error(`${flag} is outside the supported integer range`);
+  }
+  return parsed;
+}
+
+function readOptionValue(args, index, flag) {
+  const argument = args[index];
+  const prefix = `${flag}=`;
+  if (argument.startsWith(prefix)) {
+    return { value: argument.slice(prefix.length), consumed: 1 };
+  }
+  if (argument === flag) {
+    if (index + 1 >= args.length || args[index + 1].startsWith("--")) {
+      throw new Error(`${flag} requires a value`);
+    }
+    return { value: args[index + 1], consumed: 2 };
+  }
+  return null;
+}
+
+function parseArgs(args) {
+  let mode = null;
+  let shardIndex = null;
+  let shardCount = null;
+
+  for (let index = 0; index < args.length;) {
+    const argument = args[index];
+    if (argument === "--local" || argument === "--network") {
+      if (mode) {
+        throw new Error(`Test mode specified more than once: ${argument}`);
+      }
+      mode = argument;
+      index += 1;
+      continue;
+    }
+
+    const indexOption = readOptionValue(args, index, "--shard-index");
+    if (indexOption) {
+      if (shardIndex !== null) {
+        throw new Error("--shard-index specified more than once");
+      }
+      shardIndex = parsePositiveInteger(indexOption.value, "--shard-index");
+      index += indexOption.consumed;
+      continue;
+    }
+
+    const countOption = readOptionValue(args, index, "--shard-count");
+    if (countOption) {
+      if (shardCount !== null) {
+        throw new Error("--shard-count specified more than once");
+      }
+      shardCount = parsePositiveInteger(countOption.value, "--shard-count");
+      index += countOption.consumed;
+      continue;
+    }
+
+    throw new Error(`Unknown test option: ${argument}`);
+  }
+
+  const hasShardOption = shardIndex !== null || shardCount !== null;
+  if (hasShardOption && (shardIndex === null || shardCount === null)) {
+    throw new Error("--shard-index and --shard-count must be supplied together");
+  }
+  if (hasShardOption && mode !== "--local") {
+    throw new Error("Test sharding is supported only with explicit --local mode");
+  }
+  if (hasShardOption && shardCount < 1) {
+    throw new Error("--shard-count must be at least 1");
+  }
+  if (hasShardOption && shardIndex >= shardCount) {
+    throw new Error("--shard-index is zero-based and must be less than --shard-count");
+  }
+
+  return { mode, shardIndex, shardCount };
+}
+
+function stableShardIndex(testPath, shardCount) {
+  const digest = crypto.createHash("sha256").update(testPath).digest();
+  return digest.readUInt32BE(0) % shardCount;
+}
+
+function shardCommands(commands, shardIndex, shardCount) {
+  if (shardIndex === null || shardCount === null) {
+    return commands;
+  }
+  return commands.filter(
+    (commandArgs) => stableShardIndex(commandArgs.at(-1), shardCount) === shardIndex,
+  );
+}
+
+function emitTiming(record) {
+  console.log(`[tests:timing] ${JSON.stringify(record)}`);
+}
+
 function runNodeCommand(args) {
+  const startedAt = process.hrtime.bigint();
   const result = spawnSync(process.execPath, args, {
     env: {
       ...process.env,
       PYTHONDONTWRITEBYTECODE: process.env.PYTHONDONTWRITEBYTECODE || "1",
     },
     stdio: "inherit",
+  });
+
+  const elapsedMs = Number(process.hrtime.bigint() - startedAt) / 1_000_000;
+
+  emitTiming({
+    type: "test",
+    path: args.at(-1),
+    elapsed_ms: Math.round(elapsedMs),
+    status: result.error || result.signal || result.status !== 0 ? "failed" : "passed",
   });
 
   if (result.error) {
@@ -93,31 +205,39 @@ function runNodeCommand(args) {
   }
 }
 
-function runCommandSet(commands) {
+function runCommandSet(commands, metadata = {}) {
+  const startedAt = process.hrtime.bigint();
   for (const commandArgs of commands) {
     runNodeCommand(commandArgs);
   }
+
+  const elapsedMs = Number(process.hrtime.bigint() - startedAt) / 1_000_000;
+  emitTiming({
+    type: "summary",
+    mode: metadata.mode || "default",
+    shard_index: metadata.shardIndex,
+    shard_count: metadata.shardCount,
+    test_count: commands.length,
+    elapsed_ms: Math.round(elapsedMs),
+  });
 }
 
 function main() {
-  const mode = process.argv[2];
+  const { mode, shardIndex, shardCount } = parseArgs(process.argv.slice(2));
   const { local, network } = discoverTestCommands();
 
   if (mode === "--local") {
-    runCommandSet(local);
+    const selected = shardCommands(local, shardIndex, shardCount);
+    runCommandSet(selected, { mode: "local", shardIndex, shardCount });
     return;
   }
 
   if (mode === "--network") {
-    runCommandSet(network);
+    runCommandSet(network, { mode: "network", shardIndex: null, shardCount: null });
     return;
   }
 
-  if (mode) {
-    throw new Error(`Unknown test mode: ${mode}`);
-  }
-
-  runCommandSet(local);
+  runCommandSet(local, { mode: "local", shardIndex: null, shardCount: null });
 
   if (!isNetworkTestsEnabled()) {
     console.log(
@@ -127,7 +247,7 @@ function main() {
   }
 
   console.log(`[tests] ${NETWORK_TEST_ENV} enabled; running network integration tests.`);
-  runCommandSet(network);
+  runCommandSet(network, { mode: "network", shardIndex: null, shardCount: null });
 }
 
 if (require.main === module) {
@@ -140,4 +260,7 @@ module.exports = {
   discoverTestCommands,
   isTestFile,
   listFiles,
+  parseArgs,
+  shardCommands,
+  stableShardIndex,
 };

--- a/tools/scripts/tests/run_test_suite.test.js
+++ b/tools/scripts/tests/run_test_suite.test.js
@@ -7,6 +7,9 @@ const {
   discoverTestCommands,
   isTestFile,
   listFiles,
+  parseArgs,
+  shardCommands,
+  stableShardIndex,
 } = require("./run-test-suite.js");
 
 const TEST_ROOT = path.join("tools", "scripts", "tests");
@@ -41,10 +44,83 @@ function testNetworkTestsRemainExplicitlySeparated() {
   }
 }
 
+function testDefaultAndNetworkModesRejectSharding() {
+  assert.deepStrictEqual(parseArgs([]), {
+    mode: null,
+    shardIndex: null,
+    shardCount: null,
+  });
+  assert.deepStrictEqual(parseArgs(["--network"]), {
+    mode: "--network",
+    shardIndex: null,
+    shardCount: null,
+  });
+  assert.throws(
+    () => parseArgs(["--shard-index", "0", "--shard-count", "2"]),
+    /only with explicit --local mode/,
+  );
+  assert.throws(
+    () => parseArgs(["--network", "--shard-index=0", "--shard-count=2"]),
+    /only with explicit --local mode/,
+  );
+}
+
+function testShardArgumentsFailClosed() {
+  assert.deepStrictEqual(
+    parseArgs(["--local", "--shard-index", "0", "--shard-count=3"]),
+    { mode: "--local", shardIndex: 0, shardCount: 3 },
+  );
+  assert.throws(() => parseArgs(["--local", "--shard-index", "0"]), /supplied together/);
+  assert.throws(
+    () => parseArgs(["--local", "--shard-index", "3", "--shard-count", "3"]),
+    /zero-based/,
+  );
+  assert.throws(
+    () => parseArgs(["--local", "--shard-index", "0", "--shard-count", "0"]),
+    /at least 1/,
+  );
+  assert.throws(
+    () => parseArgs(["--local", "--shard-index", "x", "--shard-count", "3"]),
+    /must be an integer/,
+  );
+  assert.throws(() => parseArgs(["--local", "--unexpected"]), /Unknown test option/);
+}
+
+function testStableShardingPartitionsEveryLocalTestExactlyOnce() {
+  const { local } = discoverTestCommands();
+  const shardCount = 4;
+  const assignments = new Map();
+
+  for (let shardIndex = 0; shardIndex < shardCount; shardIndex += 1) {
+    for (const command of shardCommands(local, shardIndex, shardCount)) {
+      const testPath = commandPath(command);
+      assert.strictEqual(stableShardIndex(testPath, shardCount), shardIndex);
+      assignments.set(testPath, (assignments.get(testPath) || 0) + 1);
+    }
+  }
+
+  assert.deepStrictEqual(
+    [...assignments.keys()].sort(),
+    local.map(commandPath).sort(),
+  );
+  assert.ok([...assignments.values()].every((count) => count === 1));
+
+  const reversed = [...local].reverse();
+  for (let shardIndex = 0; shardIndex < shardCount; shardIndex += 1) {
+    assert.deepStrictEqual(
+      shardCommands(reversed, shardIndex, shardCount).map(commandPath).sort(),
+      shardCommands(local, shardIndex, shardCount).map(commandPath).sort(),
+    );
+  }
+}
+
 function main() {
   testDiscoveryCoversEveryRepositoryTestFile();
   testNetworkTestsRemainExplicitlySeparated();
-  console.log("run-test-suite discovery tests passed.");
+  testDefaultAndNetworkModesRejectSharding();
+  testShardArgumentsFailClosed();
+  testStableShardingPartitionsEveryLocalTestExactlyOnce();
+  console.log("run-test-suite discovery and sharding tests passed.");
 }
 
 main();

--- a/tools/scripts/tests/workflow_contracts.test.js
+++ b/tools/scripts/tests/workflow_contracts.test.js
@@ -6,6 +6,7 @@ const {
   classifyChangeRecords,
   classifyChangedFiles,
   classifyPathPolicy,
+  classifyShadowImpact,
   extractChangelogSection,
   getDirectDerivedChanges,
   hasIssueLink,
@@ -64,6 +65,31 @@ const contract = {
   releaseManagedFiles: ["CHANGELOG.md", "package.json", "package-lock.json", "README.md"],
 };
 
+assert.deepStrictEqual(
+  classifyShadowImpact([modifiedRecord("skills/example/SKILL.md")], contract),
+  { profile: "narrow-skill", reasons: [] },
+);
+assert.deepStrictEqual(
+  classifyShadowImpact([modifiedRecord("docs/users/guide.md")], contract),
+  { profile: "narrow-docs", reasons: [] },
+);
+assert.strictEqual(
+  classifyShadowImpact([modifiedRecord("skills/example/SKILL.md"), modifiedRecord("docs/users/guide.md")], contract).profile,
+  "full",
+);
+assert.strictEqual(
+  classifyShadowImpact([modifiedRecord("tools/scripts/pr_preflight.cjs")], contract).profile,
+  "full",
+);
+assert.strictEqual(
+  classifyShadowImpact([addedRecord("walkthrough.md")], contract).profile,
+  "full",
+);
+assert.deepStrictEqual(
+  classifyShadowImpact([modifiedRecord("unclassified.bin")], contract),
+  { profile: "unknown", reasons: ["unclassified_path"] },
+);
+
 const repositoryRoot = path.resolve(__dirname, "..", "..", "..");
 const agentInstructions = fs.readFileSync(path.join(repositoryRoot, "AGENTS.md"), "utf8");
 const maintenanceGuide = fs.readFileSync(path.join(repositoryRoot, ".github", "MAINTENANCE.md"), "utf8");
@@ -95,7 +121,7 @@ assert.match(maintainerSkill, /authored by the repository owner/);
 assert.match(maintainerSkill, /exactly one merged release PR/);
 assert.match(maintenanceGuide, /canonical-repo-state` PR owns that state/);
 assert.match(autonomyGuide, /complete nearest skill-directory fingerprint/);
-for (const contractText of [maintainerSkill, maintenanceGuide, mergeBatchGuide]) {
+for (const contractText of [maintainerSkill, maintenanceGuide, mergeBatchGuide, autonomyGuide]) {
   assert.doesNotMatch(contractText, /may normalize the PR body|close\/reopen the PR|retries `Base branch was modified`/);
   assert.match(contractText, /does not (?:rewrite|mutate).*PR (?:body|metadata)|PR-body rewriting or normalization/);
   assert.match(contractText, /does not retry base drift|does not .*retry base drift|no automatic retry/);
@@ -106,6 +132,23 @@ assert.match(maintenanceGuide, /`npm run chain` already includes catalog generat
 assert.doesNotMatch(maintenanceGuide, /npm run chain\n\s+npm run catalog/);
 assert.match(autonomyGuide, /explicitly dispatches main CI and CodeQL/);
 assert.match(autonomyGuide, /Pages remains release-only/);
+for (const contractText of [maintainerSkill, maintenanceGuide, mergeBatchGuide, autonomyGuide]) {
+  assert.match(contractText, /protected[- ]base|protected base/);
+  assert.match(contractText, /impact_profile.*shadow|shadow-only.*impact_profile/s);
+  assert.match(contractText, /source-validation.*lightweight/s);
+  assert.match(contractText, /required CI.*(?:complete|full).*unsharded/is);
+}
+assert.match(maintenanceGuide, /merge:batch.*only fork-run approval and merge authority/);
+assert.match(mergeBatchGuide, /merge:batch.*only command allowed to approve fork runs or merge/s);
+assert.match(autonomyGuide, /merge:batch.*sole authority for fork-run approval and merge/s);
+assert.match(maintainerSkill, /merge:batch.*recompute the current trusted decision/s);
+for (const contractText of [maintenanceGuide, mergeBatchGuide, autonomyGuide]) {
+  assert.match(contractText, /source-validation.*(?:refresh|generate|generated-state).*once|(?:refresh|generate|generated-state).*once.*source-validation/s);
+  assert.match(contractText, /artifact-preview.*(?:verif(?:y|ies).*manifest|manifest.*verif(?:y|ies))/s);
+  assert.match(contractText, /final (?:CI and CodeQL|`main` CI and CodeQL)/i);
+}
+assert.match(autonomyGuide, /timing telemetry/);
+assert.match(autonomyGuide, /npm run test:local -- --shard-index N --shard-count M/);
 assert.match(mergingGuide, /No local-integration exception/);
 assert.doesNotMatch(mergingGuide, /Rare exception: local squash|`gh pr merge <PR_NUMBER>/);
 assert.match(maintainerSkillUi, /\$antigravity-maintainer-batch-release/);
@@ -208,7 +251,7 @@ assert.doesNotMatch(
 assert.match(ciWorkflow, /^permissions:\n  contents: read$/m);
 assert.match(
   ciWorkflow,
-  /source-validation:[\s\S]*?- name: Refresh ephemeral derived sources for tests\n\s+run: npm run plugin-compat:sync && npm run index && npm run bundles:sync && npm run sync:metadata && npm run catalog && npm run build:aas-v1-catalog\n[\s\S]*?- name: Run tests\n\s+run: npm run test/,
+  /source-validation:[\s\S]*?- name: Refresh ephemeral derived sources for tests\n\s+if: env\.IS_TRUSTED_CANONICAL_SYNC_PR != 'true'\n\s+run: npm run plugin-compat:sync && npm run index && npm run bundles:sync && npm run sync:metadata && npm run catalog && npm run build:aas-v1-catalog && npm run sync:web-assets\n[\s\S]*?- name: Run tests\n\s+if: env\.IS_TRUSTED_CANONICAL_SYNC_PR != 'true'\n\s+run: npm run test/,
   "source-only skill PRs must refresh uncommitted mirrors and indexes before tests read them",
 );
 assert.doesNotMatch(
@@ -218,7 +261,7 @@ assert.doesNotMatch(
 );
 assert.match(ciWorkflow, /name: pr-evidence-/);
 assert.doesNotMatch(ciWorkflow, /pull_request_target:/);
-assert.doesNotMatch(ciWorkflow, /actions\/download-artifact/);
+assert.match(ciWorkflow, /actions\/download-artifact@[0-9a-f]{40}/);
 const prEvidenceJob = ciWorkflow.match(/^  pr-evidence:\n([\s\S]*?)(?=^  artifact-preview:)/m)?.[0] || "";
 assert.ok(prEvidenceJob, "pr-evidence job must exist");
 assert.doesNotMatch(prEvidenceJob, /(?:contents|pull-requests|actions): write/);
@@ -244,18 +287,34 @@ assert.match(
 const sourceValidationJob = ciWorkflow.match(/^  source-validation:\n([\s\S]*?)(?=^  pr-evidence:)/m)?.[0] || "";
 assert.match(sourceValidationJob, /needs: pr-policy/, "source validation should not wait for independent PR evidence");
 assert.doesNotMatch(sourceValidationJob, /needs:.*pr-evidence/);
+assert.match(
+  sourceValidationJob,
+  /actions\/checkout@[0-9a-f]{40}[\s\S]*?ref: \$\{\{ github\.event\.pull_request\.head\.sha \}\}/,
+  "source validation must generate its preview from the exact PR head instead of GitHub's synthetic merge commit",
+);
+assert.match(sourceValidationJob, /preview_manifest_digest: \$\{\{ steps\.preview_manifest\.outputs\.manifest_digest \}\}/);
+assert.match(sourceValidationJob, /ci_artifact_preview\.cjs create/);
+assert.match(sourceValidationJob, /actions\/upload-artifact@[0-9a-f]{40}/);
+assert.match(
+  sourceValidationJob,
+  /- name: Record canonical source-validation boundary\n\s+if: env\.IS_TRUSTED_CANONICAL_SYNC_PR == 'true'/,
+  "canonical source validation should become a lightweight boundary record after pr-policy exact-tree reproduction",
+);
 const artifactPreviewJob = ciWorkflow.match(/^  artifact-preview:\n([\s\S]*?)(?=^  main-validation-and-sync:)/m)?.[0] || "";
 assert.match(artifactPreviewJob, /needs: \[pr-policy, source-validation\]/);
+assert.match(artifactPreviewJob, /ref: \$\{\{ github\.event\.pull_request\.head\.sha \|\| github\.sha \}\}/);
 assert.match(
   artifactPreviewJob,
-  /- name: Generate canonical artifacts preview[\s\S]*?run: \|\n\s+npm run chain\n\s+npm run sync:web-assets/,
-  "artifact preview should rely on chain's catalog generation instead of repeating it",
+  /- name: Download exact-head artifact preview manifest[\s\S]*?actions\/download-artifact@[0-9a-f]{40}[\s\S]*?- name: Verify and report exact-head artifact preview[\s\S]*?ci_artifact_preview\.cjs" verify-summary/,
+  "artifact preview should consume and verify the source-validation manifest instead of regenerating the same tree",
 );
 assert.doesNotMatch(
   artifactPreviewJob,
-  /npm run chain\n\s+npm run catalog/,
-  "artifact preview must not build the catalog twice",
+  /npm run chain|Generate canonical artifacts preview/,
+  "artifact preview must not regenerate normal source-PR artifacts",
 );
+assert.match(artifactPreviewJob, /- name: Reproduce canonical-sync PR from main\n\s+if: env\.IS_TRUSTED_CANONICAL_SYNC_PR == 'true'/);
+assert.match(artifactPreviewJob, /- name: Report generated drift\n\s+if: env\.IS_TRUSTED_CANONICAL_SYNC_PR == 'true'/);
 
 const decisionModule = fs.readFileSync(
   path.resolve(__dirname, "..", "..", "lib", "pr-decision.js"),


### PR DESCRIPTION
## Summary

- fail fast on fork diffs using the protected-base classifier while keeping merge:batch authoritative
- generate source preview state once and verify an exact-head content-bound manifest
- make canonical source-validation lightweight while preserving exact-tree and final-main gates
- add timing plus opt-in deterministic test sharding without skipping required CI
- update the canonical maintainer skill, guides, changelog, and contract tests

## Quality Bar Checklist

- [x] Validation and reference checks pass
- [x] Full unsharded test suite passes
- [x] Documentation security checks pass
- [x] Workflow lint and targeted contract tests pass
- [x] Generated outputs are intentionally excluded from this source PR and left to protected canonical sync

## Verification

- npm run validate
- npm run validate:references
- npm run security:docs
- npm run check:warning-budget
- npm run lint:workflows
- npm run test (102 local tests, complete and unsharded)
