### PR TITLE
docs: refresh UIZZE skill source and free preview

### DIFF
--- a/README.md
+++ b/README.md
@@ -411,7 +411,7 @@ Key source families include:
 
 ### Official Sources
 
-- **[aislon/uizze-mcp](https://github.com/aislon/uizze-mcp)**: Official source for the `uizze-ui-research` skill and UIZZE MCP-assisted UI research workflows.
+- **[uizze/uizze](https://github.com/uizze/uizze)**: Official source for UIZZE agent skills and MCP-assisted UI research workflows.
 - **[anthropics/skills](https://github.com/anthropics/skills)**: Official Anthropic skills repository - Document manipulation (DOCX, PDF, PPTX, XLSX), Brand Guidelines, Internal Communications.
 - **[anthropics/claude-cookbooks](https://github.com/anthropics/claude-cookbooks)**: Official notebooks and recipes for building with Claude.
 - **[remotion-dev/skills](https://github.com/remotion-dev/skills)**: Official Remotion skills - Video creation in React with 28 modular rules.

--- a/skills/uizze-ui-research/SKILL.md
+++ b/skills/uizze-ui-research/SKILL.md
@@ -1,13 +1,15 @@
 ---
 name: uizze-ui-research
-description: "Use when building or reviewing web and iOS product UI and you need real UI references, structured design contracts, or implementation validation through UIZZE MCP."
+description: "Use when building or reviewing web and iOS product UI and you need a free UI Slop Gate, real UI references, structured design contracts, or implementation validation through UIZZE."
 category: design
 risk: safe
-source: https://github.com/aislon/uizze-mcp/tree/main/skills/uizze-ui-research
-source_repo: aislon/uizze-mcp
+source: https://github.com/uizze/uizze
+source_repo: uizze/uizze
 source_type: official
+license: MIT
+license_source: https://github.com/uizze/uizze/blob/main/LICENSE
 date_added: "2026-07-12"
-author: samuelbushi
+author: UIZZE
 tags: [ui-design, ui-research, mcp, design-contracts, agent-workflows]
 tools: [claude, cursor, codex, copilot, antigravity, lovable]
 ---
@@ -16,7 +18,7 @@ tools: [claude, cursor, codex, copilot, antigravity, lovable]
 
 ## Overview
 
-Use UIZZE to give coding agents real product-UI context before implementation rather than relying on a generic styling prompt. The public catalog is free to browse; the hosted MCP workflow requires full access and a configured UIZZE agent token.
+Use UIZZE to give coding agents a concrete UI check before implementation turns into another generic screen. Start with the free UI Slop Gate when you need a fast rendered HTML/CSS check. Use the full UIZZE MCP when the work needs real product references, a design contract, and a final implementation review.
 
 This skill turns UI research into an explicit workflow: retrieve relevant references, translate transferable patterns into a design contract, implement within the current project's system, and run the available validation or critique gates.
 
@@ -26,16 +28,25 @@ This skill turns UI research into an explicit workflow: retrieve relevant refere
 - You need real interface references before implementing an AI-generated UI.
 - You are reviewing an implementation against explicit design constraints.
 - You need to reduce generic or repetitive UI by grounding work in observed product patterns.
+- You have rendered HTML/CSS and need a no-account first check before deciding whether the task needs deeper reference research.
 
 ## How It Works
 
-### Step 1: Confirm access and scope
+### Step 1: Start with the smallest useful check
 
-Confirm that the UIZZE MCP connection is already configured with a valid agent token before invoking hosted workflows. If it is unavailable, use the free public catalog for research or ask the user to configure access; do not attempt to bypass access controls or expose credentials.
+For a quick rendered-screen check, add the free UI Slop Gate to a supported coding agent:
+
+```bash
+codex mcp add uizze-preview --url https://uizze.com/mcp/preview
+```
+
+Give `check_ui_slop` the rendered HTML and CSS you are comfortable supplying. The preview requires no UIZZE login and exposes only that bounded diagnostic. It does not search the reference catalog or create a design contract.
+
+If the task needs research rather than a first check, browse the public catalog or connect the full UIZZE MCP through the client’s normal OAuth flow. Do not bypass access controls or expose credentials.
 
 ### Step 2: Retrieve relevant visual context
 
-Use the available UIZZE tools to find screens, flows, components, or elements that match the product task. Focus on transferable patterns such as hierarchy, navigation, interaction states, spacing, density, and responsive behavior.
+When the full connection is available, use UIZZE to find screens, flows, components, or elements that match the product task. Focus on transferable patterns such as hierarchy, navigation, interaction states, spacing, density, and responsive behavior.
 
 ### Step 3: Make constraints explicit
 
@@ -43,7 +54,7 @@ Create or use a structured design contract when the task needs explicit acceptan
 
 ### Step 4: Validate before completion
 
-Use the available UIZZE validation, audit, or critique workflow when the implementation is ready for review. Resolve the findings in the project and run normal project tests before calling the work complete.
+Use the full UIZZE validation, audit, or critique workflow when the implementation is ready for review. Resolve the findings in the project and run normal project tests before calling the work complete.
 
 ## Examples
 
@@ -69,8 +80,8 @@ Use UIZZE to inspect relevant real product settings screens, audit this implemen
 
 ## Security & Safety Notes
 
-- Keep the UIZZE agent token in local agent configuration or an environment variable only.
-- Hosted MCP workflows require authorized access; the free catalog does not grant permission to use paid workflows.
+- Keep any full-connection credential in local agent configuration only; never commit it or include it in client-side code.
+- The free preview receives only rendered HTML/CSS explicitly supplied for its one diagnostic tool. It does not grant access to the full reference catalog or contract workflow.
 - Treat returned references as research context, not reusable visual assets.
 
 ## Common Pitfalls
@@ -89,5 +100,5 @@ Use UIZZE to inspect relevant real product settings screens, audit this implemen
 ## Limitations
 
 - This skill does not replace product-specific user research, accessibility review, project tests, or human design judgment.
-- It cannot make a hosted UIZZE MCP workflow available without a valid authorized connection.
+- The free preview cannot search UIZZE references, create design contracts, or replace the full implementation review workflow.
 - Stop and ask for clarification if the product goal, existing design system, or access boundaries are missing.


### PR DESCRIPTION
## Summary

Updates the official UIZZE attribution from the retired Aislon namespace to `uizze/uizze`, removes the personal author field, and refreshes the skill with the current free-preview-first MCP workflow.

## Change Classification

- [x] Skill PR
- [x] Docs PR
- [ ] Infra PR

## Quality Bar Checklist ✅

- [x] **Metadata**: source, repository, license, and source credit now point to the official UIZZE organization.
- [x] **Risk Label**: `safe` remains appropriate; the skill only describes bounded UI review and safe configuration.
- [x] **Triggers**: updated with the free rendered HTML/CSS check.
- [x] **Limitations**: explicitly distinguishes the one-tool free preview from the full reference workflow.
- [x] **Safety scan**: manually reviewed command guidance; it has no credentials and uses the public UIZZE preview endpoint.
- [x] **Manual Logic Review**: reviewed semantics, access boundaries, provenance, and safety.
- [x] **Source-Only PR**: no generated registry artifacts are included.
- [x] **Credits**: README official source updated.
- [x] **License provenance**: MIT and the official license source are declared.

Repository CI can run the canonical validation, reference, documentation-security, and generated-drift checks for this source-only contribution.