### PR TITLE
docs: preserve UIZZE contributor credit

### DIFF
--- a/walkthrough.md
+++ b/walkthrough.md
@@ -1,6 +1,6 @@
 # Maintenance Walkthrough - 2026-07-26
 
-- Consolidated the two open UIZZE contribution paths into one protected maintainer repair, preserving the actionable public-catalog research, design-contract, implementation, and hard finish-gate workflow from PR `#929` together with the bounded preview introduced by PR `#983`.
+- Consolidated the two open UIZZE contribution paths into one protected maintainer repair, preserving the actionable public-catalog research, design-contract, implementation, and hard finish-gate workflow contributed by [@samuelbushi](https://github.com/samuelbushi) in PR `#929` together with the bounded preview introduced by PR `#983`.
 - Kept the free `check_ui_slop` preview optional while requiring explicit approval before persistent MCP configuration or external HTML/CSS transmission.
 - Added the official MIT license metadata and organizational author while preserving the existing immutable source identity; GitHub redirects the historical upstream URL to the transferred official repository.
 - Left generated registries and plugin mirrors out of the source PR so the protected canonical synchronization workflow remains their sole owner.


### PR DESCRIPTION
# Pull Request Description

Preserves explicit public credit for @samuelbushi's UIZZE workflow contribution after GitHub's squash of #985 omitted the branch commit trailers.

This updates the maintenance walkthrough only; it does not change the merged skill semantics or generated state.

## Change Classification

- [ ] Skill PR
- [x] Docs PR
- [ ] Infra PR

## Quality Bar Checklist ✅

- [x] **Standards**: Maintainer documentation contract reviewed.
- [x] **Metadata / Risk / Triggers / Limitations / Security**: Not applicable; no skill content changes.
- [x] **Manual Logic Review**: The link and attribution were checked against PR #929 and @samuelbushi.
- [x] **Local Test**: The public documentation contract test passed.
- [x] **Repo Checks**: `npm run validate:references` passed.
- [x] **Source-Only PR**: No generated artifacts are included.
- [x] **Credits**: This PR is the explicit credit repair.
- [x] **Maintainer Edits**: Same-repository maintainer branch.

Co-authored-by: sck_0 <188885273+sck000@users.noreply.github.com>
Co-authored-by: Samuel Bushi <contact@samuelbushi.com>
