### PR TITLE
feat: add orchestrate skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -449,6 +449,7 @@ Key source families include:
 
 ### Community Contributors
 
+- **[provencher/codex-skills](https://github.com/provencher/codex-skills)**: Source for the `orchestrate` skill - focused Codex multi-agent delegation with non-overlapping ownership, coordinator integration, and user-held approval gates (MIT).
 - **[0xsarwagya/ontoly](https://github.com/0xsarwagya/ontoly)**: Source for the `ontoly-software-graph` skill - deterministic TypeScript software graphs, MCP-backed architecture review, request tracing, impact analysis, and dependency analysis (MIT).
 - [amElnagdy/guard-skills](https://github.com/amElnagdy/guard-skills) — Code Quality & Testing Guard Skills (by amElnagdy)
 

--- a/skills/orchestrate/SKILL.md
+++ b/skills/orchestrate/SKILL.md
@@ -1,0 +1,61 @@
+---
+name: orchestrate
+description: "Coordinate focused subagents on substantial work, keep their ownership non-overlapping, and integrate verified results. Use for large-scope Codex tasks; keep trivial work with the coordinator."
+category: agent-orchestration
+risk: safe
+source: https://github.com/provencher/codex-skills/tree/8aa6c42b73781c905c55f8a1253a18127079ac21/orchestrate
+source_repo: provencher/codex-skills
+source_type: community
+date_added: "2026-07-26"
+author: provencher
+tags: [codex, orchestration, multi-agent, delegation, subagents]
+tools: [codex]
+license: MIT
+license_source: https://github.com/provencher/codex-skills/blob/8aa6c42b73781c905c55f8a1253a18127079ac21/LICENSE
+---
+
+# Orchestrate
+
+Coordinate substantial work across focused subagents while remaining available
+to the user and retaining responsibility for the integrated result.
+
+## When to Use
+
+- Use when a task has multiple independent research, review, or implementation lanes.
+- Use when parallel work will materially reduce elapsed time or improve coverage.
+- Use when a coordinator must synthesize several bounded outputs into one verified result.
+
+Keep trivial tasks with the coordinator.
+
+## Workflow
+
+1. Decompose the task into distinct, bounded assignments with explicit outputs.
+2. Run narrow, read-only scouts in parallel with low reasoning effort and no
+   inherited conversation when the runtime supports those controls. Give each
+   scout all scoped context and evidence required to complete its assignment.
+3. Use medium reasoning effort for routine implementation and high reasoning
+   effort for difficult work.
+4. Give each subagent distinct ownership. Prevent overlapping assignments, and
+   instruct leaf workers not to delegate.
+5. Integrate the outputs, resolve conflicts, and verify the combined result.
+6. Keep approvals and externally consequential decisions with the user.
+
+## Examples
+
+- For a repository-wide feature, assign non-overlapping agents to architecture
+  inspection, implementation, and test review, then integrate their findings
+  and run the final verification from the coordinator.
+- For a research brief, assign independent sources or questions to read-only
+  scouts, reconcile disagreements, and keep the final judgment with the
+  coordinator.
+
+## Limitations
+
+- Requires a runtime that exposes subagent or delegation tools; otherwise keep
+  the work with the coordinator.
+- Delegation does not authorize file mutations, public actions, purchases, or
+  other consequential operations beyond the user's original scope.
+- Parallel agents can add cost and coordination overhead, so use them only when
+  the task is substantial enough to benefit.
+- The coordinator remains responsible for checking claims, changes, tests, and
+  the final answer.

--- a/skills/orchestrate/agents/openai.yaml
+++ b/skills/orchestrate/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Orchestrate"
+  short_description: "Manage large-scope work across agents"
+  default_prompt: "Use $orchestrate to manage this large-scope task across focused agents."

--- a/walkthrough.md
+++ b/walkthrough.md
@@ -1,5 +1,14 @@
 # Maintenance Walkthrough - 2026-07-26
 
+- Added the MIT-licensed `orchestrate` skill from
+  [provencher/codex-skills](https://github.com/provencher/codex-skills) at
+  upstream commit `8aa6c42b73781c905c55f8a1253a18127079ac21`.
+- Preserved its concise Codex-native delegation policy and UI metadata while
+  adding the repository-required usage guidance, limitations, immutable
+  provenance, and user-held approval boundaries.
+- Kept the source PR limited to canonical skill content, source credit, and this
+  maintenance evidence; generated registries and plugin mirrors remain owned by
+  protected canonical synchronization.
 - Consolidated the two open UIZZE contribution paths into one protected maintainer repair, preserving the actionable public-catalog research, design-contract, implementation, and hard finish-gate workflow contributed by [@samuelbushi](https://github.com/samuelbushi) in PR `#929` together with the bounded preview introduced by PR `#983`.
 - Kept the free `check_ui_slop` preview optional while requiring explicit approval before persistent MCP configuration or external HTML/CSS transmission.
 - Added the official MIT license metadata and organizational author while preserving the existing immutable source identity; GitHub redirects the historical upstream URL to the transferred official repository.


### PR DESCRIPTION
# Pull Request Description

Add the MIT-licensed `orchestrate` skill from `provencher/codex-skills`, pinned to upstream commit `8aa6c42b73781c905c55f8a1253a18127079ac21`.

The canonical import preserves the concise Codex-native delegation policy and upstream `agents/openai.yaml`, while adding AAS-required metadata, usage criteria, examples, limitations, immutable license provenance, and explicit user-held approval boundaries. The PR also adds the README community source credit and maintenance evidence.

Generated registries and plugin mirrors are intentionally excluded for protected canonical synchronization.

## Change Classification

- [x] Skill PR
- [x] Docs PR
- [ ] Infra PR

## Issue Link (Optional)

No linked issue.

## Quality Bar Checklist ✅

- [x] **Standards**: I have read `docs/contributors/quality-bar.md` and `docs/contributors/security-guardrails.md`.
- [x] **Metadata**: The `SKILL.md` frontmatter is valid (checked with `npm run validate`).
- [x] **Risk Label**: I assigned `risk: safe`; this is guidance-only and performs no direct mutation or network action.
- [x] **Triggers**: The `## When to Use` section is clear and specific.
- [x] **Limitations**: The skill includes a `## Limitations` section.
- [x] **Security**: Not offensive; no disclaimer is required.
- [x] **Safety scan**: `npm run security:docs` passes.
- [ ] **Automated Skill Review**: Pending the `skill-review` GitHub Actions result for this exact head.
- [x] **Manual Logic Review**: Reviewed semantics, delegation boundaries, runtime assumptions, cost/latency, provenance, and `risk: safe` against exact head `2b0dece5f6bc5398013d6786293abd4f2119a868`.
- [x] **Local Test**: `npm run test` passes (102 local test files; network integration tests intentionally skipped by the repository runner).
- [x] **Repo Checks**: `npm run validate:references`, `npm run check:warning-budget`, `npm run chain`, README credit validation, changed-skill evidence, and `git diff --check` pass.
- [x] **Source-Only PR**: No generated registry artifacts, plugin mirrors, marketplaces, or catalog outputs are included.
- [x] **Credits**: Added `provencher/codex-skills` under README Community Contributors.
- [x] **License provenance**: Declared commit-pinned `license: MIT` and immutable `license_source` metadata.
- [x] **Maintainer Edits**: Enabled for this same-repository owner branch.

## Validation

- `npm run validate`
- `npm run validate:references`
- `npm run security:docs`
- `npm run check:warning-budget`
- `npm run chain` (generated drift inspected and excluded)
- `npm run test`
- `npm run check:readme-credits -- --base origin/main --head HEAD`
- `npm run pr:evidence -- --base origin/main --head HEAD --output /tmp/orchestrate-pr-evidence.json --json`
- `node tools/scripts/pr_preflight.cjs --repo . --base origin/main --head HEAD --no-run --json`
- `git diff --check`

## Screenshots (if applicable)

Not applicable.