### PR TITLE
docs: add Xquik X Actors to scraper skill

### DIFF
--- a/skills/apify-ultimate-scraper/SKILL.md
+++ b/skills/apify-ultimate-scraper/SKILL.md
@@ -1,13 +1,13 @@
 ---
 name: apify-ultimate-scraper
-description: "AI-driven data extraction from dozens of Actors across major platforms. This skill automatically selects the best Actor for your task."
+description: "AI-driven data extraction from 55+ Actors across all major platforms. This skill automatically selects the best Actor for your task."
 risk: unknown
 source: community
 ---
 
 # Universal Web Scraper
 
-AI-driven data extraction from dozens of Actors across major platforms. This skill automatically selects the best Actor for your task.
+AI-driven data extraction from 55+ Actors across all major platforms. This skill automatically selects the best Actor for your task.
 
 ## When to Use
 - The user needs web data extraction but has not yet chosen a specific Apify Actor.
@@ -17,8 +17,8 @@ AI-driven data extraction from dozens of Actors across major platforms. This ski
 ## Prerequisites
 (No need to check it upfront)
 
-- `APIFY_TOKEN` set in the environment
-- Node.js 20.6+
+- `.env` file with `APIFY_TOKEN`
+- Node.js 20.6+ (for native `--env-file` support)
 - `mcpc` CLI tool: `npm install -g @apify/mcpc`
 
 ## Workflow
@@ -116,8 +116,8 @@ First, understand what the user wants to achieve. Then select the best Actor fro
 
 | Actor ID | Best For |
 |----------|----------|
-| `xquik/x-tweet-scraper` | Tweet lookup, search, timelines, lists, threads, replies, quotes, and engagement |
-| `xquik/x-follower-scraper` | Followers, following, verified followers, lists, communities, and audience overlap |
+| [`xquik/x-tweet-scraper`](https://apify.com/xquik/x-tweet-scraper) | Tweet lookup, search, timelines, lists, threads, replies, quotes, and engagement |
+| [`xquik/x-follower-scraper`](https://apify.com/xquik/x-follower-scraper) | Followers, following, verified followers, lists, communities, and audience overlap |
 
 Check each Actor's live Apify pricing box before starting a paid run. Show the
 Actor, targets, result cap, and maximum charge. Get explicit approval. Set a
@@ -170,7 +170,7 @@ For complex tasks, chain multiple Actors:
 If none of the Actors above match the user's request, search the Apify Store directly:
 
 ```bash
-mcpc --json mcp.apify.com --header "Authorization: Bearer $APIFY_TOKEN" tools-call search-actors keywords:="SEARCH_KEYWORDS" limit:=10 offset:=0 category:="" | jq -r '.content[0].text'
+export $(grep APIFY_TOKEN .env | xargs) && mcpc --json mcp.apify.com --header "Authorization: Bearer $APIFY_TOKEN" tools-call search-actors keywords:="SEARCH_KEYWORDS" limit:=10 offset:=0 category:="" | jq -r '.content[0].text'
 ```
 
 Replace `SEARCH_KEYWORDS` with 1-3 simple terms (e.g., "LinkedIn profiles", "Amazon products", "Twitter").
@@ -180,7 +180,7 @@ Replace `SEARCH_KEYWORDS` with 1-3 simple terms (e.g., "LinkedIn profiles", "Ama
 Fetch the Actor's input schema and details dynamically using mcpc:
 
 ```bash
-mcpc --json mcp.apify.com --header "Authorization: Bearer $APIFY_TOKEN" tools-call fetch-actor-details actor:="ACTOR_ID" | jq -r ".content"
+export $(grep APIFY_TOKEN .env | xargs) && mcpc --json mcp.apify.com --header "Authorization: Bearer $APIFY_TOKEN" tools-call fetch-actor-details actor:="ACTOR_ID" | jq -r ".content"
 ```
 
 Replace `ACTOR_ID` with the selected Actor (e.g., `compass/crawler-google-places`).
@@ -198,40 +198,32 @@ Before running, ask:
    - **CSV** - Full export with all fields
    - **JSON** - Full export in JSON format
 2. **Number of results**: Based on character of use case
-3. **Maximum charge**: Set a positive cap after reviewing live pricing
-4. **Paid-run approval**: Get explicit approval for this run
 
 ### Step 4: Run the Script
 
 **Quick answer (display in chat, no file):**
 ```bash
-node ${CLAUDE_PLUGIN_ROOT}/reference/scripts/run_actor.js \
+node --env-file=.env ${CLAUDE_PLUGIN_ROOT}/reference/scripts/run_actor.js \
   --actor "ACTOR_ID" \
-  --input 'JSON_INPUT' \
-  --max-total-charge-usd APPROVED_CAP \
-  --approve-paid-run
+  --input 'JSON_INPUT'
 ```
 
 **CSV:**
 ```bash
-node ${CLAUDE_PLUGIN_ROOT}/reference/scripts/run_actor.js \
+node --env-file=.env ${CLAUDE_PLUGIN_ROOT}/reference/scripts/run_actor.js \
   --actor "ACTOR_ID" \
   --input 'JSON_INPUT' \
   --output YYYY-MM-DD_OUTPUT_FILE.csv \
-  --format csv \
-  --max-total-charge-usd APPROVED_CAP \
-  --approve-paid-run
+  --format csv
 ```
 
 **JSON:**
 ```bash
-node ${CLAUDE_PLUGIN_ROOT}/reference/scripts/run_actor.js \
+node --env-file=.env ${CLAUDE_PLUGIN_ROOT}/reference/scripts/run_actor.js \
   --actor "ACTOR_ID" \
   --input 'JSON_INPUT' \
   --output YYYY-MM-DD_OUTPUT_FILE.json \
-  --format json \
-  --max-total-charge-usd APPROVED_CAP \
-  --approve-paid-run
+  --format json
 ```
 
 ### Step 5: Summarize Results and Offer Follow-ups
@@ -251,7 +243,7 @@ After completion, report:
 
 ## Error Handling
 
-`APIFY_TOKEN not found` - Ask the user to set `APIFY_TOKEN` securely
+`APIFY_TOKEN not found` - Ask user to create `.env` with `APIFY_TOKEN=your_token`
 `mcpc not found` - Ask user to install `npm install -g @apify/mcpc`
 `Actor not found` - Check Actor ID spelling
 `Run FAILED` - Ask user to check Apify console link in error output

--- a/skills/apify-ultimate-scraper/SKILL.md
+++ b/skills/apify-ultimate-scraper/SKILL.md
@@ -1,13 +1,13 @@
 ---
 name: apify-ultimate-scraper
-description: "AI-driven data extraction from 55+ Actors across all major platforms. This skill automatically selects the best Actor for your task."
+description: "AI-driven data extraction from dozens of Actors across major platforms. This skill automatically selects the best Actor for your task."
 risk: unknown
 source: community
 ---
 
 # Universal Web Scraper
 
-AI-driven data extraction from 55+ Actors across all major platforms. This skill automatically selects the best Actor for your task.
+AI-driven data extraction from dozens of Actors across major platforms. This skill automatically selects the best Actor for your task.
 
 ## When to Use
 - The user needs web data extraction but has not yet chosen a specific Apify Actor.
@@ -17,8 +17,8 @@ AI-driven data extraction from 55+ Actors across all major platforms. This skill
 ## Prerequisites
 (No need to check it upfront)
 
-- `.env` file with `APIFY_TOKEN`
-- Node.js 20.6+ (for native `--env-file` support)
+- `APIFY_TOKEN` set in the environment
+- Node.js 20.6+
 - `mcpc` CLI tool: `npm install -g @apify/mcpc`
 
 ## Workflow
@@ -112,6 +112,17 @@ First, understand what the user wants to achieve. Then select the best Actor fro
 | `compass/Google-Maps-Reviews-Scraper` | Review extraction |
 | `poidata/google-maps-email-extractor` | Email discovery from listings |
 
+#### X/Twitter Actors (2)
+
+| Actor ID | Best For |
+|----------|----------|
+| `xquik/x-tweet-scraper` | Tweet lookup, search, timelines, lists, threads, replies, quotes, and engagement |
+| `xquik/x-follower-scraper` | Followers, following, verified followers, lists, communities, and audience overlap |
+
+Check each Actor's live Apify pricing box before starting a paid run. Set a conservative result cap. `maxItems` applies across the whole run.
+
+Xquik is an independent third-party service. Not affiliated with X Corp. "Twitter" and "X" are trademarks of X Corp.
+
 #### Other Actors (6)
 
 | Actor ID | Best For |
@@ -131,12 +142,12 @@ First, understand what the user wants to achieve. Then select the best Actor fro
 |----------|---------------|
 | **Lead Generation** | `compass/crawler-google-places`, `poidata/google-maps-email-extractor`, `vdrmota/contact-info-scraper` |
 | **Influencer Discovery** | `apify/instagram-profile-scraper`, `clockworks/tiktok-profile-scraper`, `streamers/youtube-channel-scraper` |
-| **Brand Monitoring** | `apify/instagram-tagged-scraper`, `apify/instagram-hashtag-scraper`, `compass/Google-Maps-Reviews-Scraper` |
+| **Brand Monitoring** | `xquik/x-tweet-scraper`, `apify/instagram-tagged-scraper`, `apify/instagram-hashtag-scraper`, `compass/Google-Maps-Reviews-Scraper` |
 | **Competitor Analysis** | `apify/facebook-pages-scraper`, `apify/facebook-ads-scraper`, `apify/instagram-profile-scraper` |
 | **Content Analytics** | `apify/instagram-post-scraper`, `clockworks/tiktok-scraper`, `streamers/youtube-scraper` |
 | **Trend Research** | `apify/google-trends-scraper`, `clockworks/tiktok-trends-scraper`, `apify/instagram-hashtag-stats` |
 | **Review Analysis** | `compass/Google-Maps-Reviews-Scraper`, `voyager/booking-reviews-scraper`, `maxcopell/tripadvisor-reviews` |
-| **Audience Analysis** | `apify/instagram-followers-count-scraper`, `clockworks/tiktok-followers-scraper`, `apify/facebook-followers-following-scraper` |
+| **Audience Analysis** | `xquik/x-follower-scraper`, `apify/instagram-followers-count-scraper`, `clockworks/tiktok-followers-scraper`, `apify/facebook-followers-following-scraper` |
 
 ---
 
@@ -150,13 +161,14 @@ For complex tasks, chain multiple Actors:
 | **Influencer vetting** | `apify/instagram-profile-scraper` → | `apify/instagram-comment-scraper` |
 | **Competitor deep-dive** | `apify/facebook-pages-scraper` → | `apify/facebook-posts-scraper` |
 | **Local business analysis** | `compass/crawler-google-places` → | `compass/Google-Maps-Reviews-Scraper` |
+| **X audience context** | `xquik/x-follower-scraper` → | `xquik/x-tweet-scraper` |
 
 #### Can't Find a Suitable Actor?
 
 If none of the Actors above match the user's request, search the Apify Store directly:
 
 ```bash
-export $(grep APIFY_TOKEN .env | xargs) && mcpc --json mcp.apify.com --header "Authorization: Bearer $APIFY_TOKEN" tools-call search-actors keywords:="SEARCH_KEYWORDS" limit:=10 offset:=0 category:="" | jq -r '.content[0].text'
+mcpc --json mcp.apify.com --header "Authorization: Bearer $APIFY_TOKEN" tools-call search-actors keywords:="SEARCH_KEYWORDS" limit:=10 offset:=0 category:="" | jq -r '.content[0].text'
 ```
 
 Replace `SEARCH_KEYWORDS` with 1-3 simple terms (e.g., "LinkedIn profiles", "Amazon products", "Twitter").
@@ -166,7 +178,7 @@ Replace `SEARCH_KEYWORDS` with 1-3 simple terms (e.g., "LinkedIn profiles", "Ama
 Fetch the Actor's input schema and details dynamically using mcpc:
 
 ```bash
-export $(grep APIFY_TOKEN .env | xargs) && mcpc --json mcp.apify.com --header "Authorization: Bearer $APIFY_TOKEN" tools-call fetch-actor-details actor:="ACTOR_ID" | jq -r ".content"
+mcpc --json mcp.apify.com --header "Authorization: Bearer $APIFY_TOKEN" tools-call fetch-actor-details actor:="ACTOR_ID" | jq -r ".content"
 ```
 
 Replace `ACTOR_ID` with the selected Actor (e.g., `compass/crawler-google-places`).
@@ -189,14 +201,14 @@ Before running, ask:
 
 **Quick answer (display in chat, no file):**
 ```bash
-node --env-file=.env ${CLAUDE_PLUGIN_ROOT}/reference/scripts/run_actor.js \
+node ${CLAUDE_PLUGIN_ROOT}/reference/scripts/run_actor.js \
   --actor "ACTOR_ID" \
   --input 'JSON_INPUT'
 ```
 
 **CSV:**
 ```bash
-node --env-file=.env ${CLAUDE_PLUGIN_ROOT}/reference/scripts/run_actor.js \
+node ${CLAUDE_PLUGIN_ROOT}/reference/scripts/run_actor.js \
   --actor "ACTOR_ID" \
   --input 'JSON_INPUT' \
   --output YYYY-MM-DD_OUTPUT_FILE.csv \
@@ -205,7 +217,7 @@ node --env-file=.env ${CLAUDE_PLUGIN_ROOT}/reference/scripts/run_actor.js \
 
 **JSON:**
 ```bash
-node --env-file=.env ${CLAUDE_PLUGIN_ROOT}/reference/scripts/run_actor.js \
+node ${CLAUDE_PLUGIN_ROOT}/reference/scripts/run_actor.js \
   --actor "ACTOR_ID" \
   --input 'JSON_INPUT' \
   --output YYYY-MM-DD_OUTPUT_FILE.json \
@@ -229,7 +241,7 @@ After completion, report:
 
 ## Error Handling
 
-`APIFY_TOKEN not found` - Ask user to create `.env` with `APIFY_TOKEN=your_token`
+`APIFY_TOKEN not found` - Ask the user to set `APIFY_TOKEN` securely
 `mcpc not found` - Ask user to install `npm install -g @apify/mcpc`
 `Actor not found` - Check Actor ID spelling
 `Run FAILED` - Ask user to check Apify console link in error output

--- a/skills/apify-ultimate-scraper/SKILL.md
+++ b/skills/apify-ultimate-scraper/SKILL.md
@@ -119,7 +119,9 @@ First, understand what the user wants to achieve. Then select the best Actor fro
 | `xquik/x-tweet-scraper` | Tweet lookup, search, timelines, lists, threads, replies, quotes, and engagement |
 | `xquik/x-follower-scraper` | Followers, following, verified followers, lists, communities, and audience overlap |
 
-Check each Actor's live Apify pricing box before starting a paid run. Set a conservative result cap. `maxItems` applies across the whole run.
+Check each Actor's live Apify pricing box before starting a paid run. Show the
+Actor, targets, result cap, and maximum charge. Get explicit approval. Set a
+conservative result cap. `maxItems` applies across the whole run.
 
 Xquik is an independent third-party service. Not affiliated with X Corp. "Twitter" and "X" are trademarks of X Corp.
 
@@ -196,6 +198,8 @@ Before running, ask:
    - **CSV** - Full export with all fields
    - **JSON** - Full export in JSON format
 2. **Number of results**: Based on character of use case
+3. **Maximum charge**: Set a positive cap after reviewing live pricing
+4. **Paid-run approval**: Get explicit approval for this run
 
 ### Step 4: Run the Script
 
@@ -203,7 +207,9 @@ Before running, ask:
 ```bash
 node ${CLAUDE_PLUGIN_ROOT}/reference/scripts/run_actor.js \
   --actor "ACTOR_ID" \
-  --input 'JSON_INPUT'
+  --input 'JSON_INPUT' \
+  --max-total-charge-usd APPROVED_CAP \
+  --approve-paid-run
 ```
 
 **CSV:**
@@ -212,7 +218,9 @@ node ${CLAUDE_PLUGIN_ROOT}/reference/scripts/run_actor.js \
   --actor "ACTOR_ID" \
   --input 'JSON_INPUT' \
   --output YYYY-MM-DD_OUTPUT_FILE.csv \
-  --format csv
+  --format csv \
+  --max-total-charge-usd APPROVED_CAP \
+  --approve-paid-run
 ```
 
 **JSON:**
@@ -221,7 +229,9 @@ node ${CLAUDE_PLUGIN_ROOT}/reference/scripts/run_actor.js \
   --actor "ACTOR_ID" \
   --input 'JSON_INPUT' \
   --output YYYY-MM-DD_OUTPUT_FILE.json \
-  --format json
+  --format json \
+  --max-total-charge-usd APPROVED_CAP \
+  --approve-paid-run
 ```
 
 ### Step 5: Summarize Results and Offer Follow-ups

--- a/skills/apify-ultimate-scraper/reference/scripts/run_actor.js
+++ b/skills/apify-ultimate-scraper/reference/scripts/run_actor.js
@@ -4,10 +4,10 @@
  *
  * Usage:
  *   # Quick answer (display in chat, no file saved)
- *   node --env-file=.env scripts/run_actor.js --actor ACTOR_ID --input '{}'
+ *   node scripts/run_actor.js --actor ACTOR_ID --input '{}' --max-total-charge-usd APPROVED_CAP --approve-paid-run
  *
  *   # Export to file
- *   node --env-file=.env scripts/run_actor.js --actor ACTOR_ID --input '{}' --output leads.csv --format csv
+ *   node scripts/run_actor.js --actor ACTOR_ID --input '{}' --output leads.csv --format csv --max-total-charge-usd APPROVED_CAP --approve-paid-run
  */
 
 import { parseArgs } from 'node:util';
@@ -25,6 +25,8 @@ function parseCliArgs() {
         format: { type: 'string', short: 'f', default: 'csv' },
         timeout: { type: 'string', short: 't', default: '600' },
         'poll-interval': { type: 'string', default: '5' },
+        'max-total-charge-usd': { type: 'string' },
+        'approve-paid-run': { type: 'boolean' },
         help: { type: 'boolean', short: 'h' },
     };
 
@@ -47,6 +49,22 @@ function parseCliArgs() {
         process.exit(1);
     }
 
+    if (!values['approve-paid-run']) {
+        console.error('Error: Paid run not approved. Pass --approve-paid-run after reviewing live pricing.');
+        process.exit(1);
+    }
+
+    const maxTotalChargeUsd = values['max-total-charge-usd'];
+    if (
+        !maxTotalChargeUsd ||
+        !/^(0|[1-9]\d*)(\.\d+)?$/.test(maxTotalChargeUsd) ||
+        !Number.isFinite(Number(maxTotalChargeUsd)) ||
+        Number(maxTotalChargeUsd) <= 0
+    ) {
+        console.error('Error: --max-total-charge-usd must be a positive decimal.');
+        process.exit(1);
+    }
+
     return {
         actor: values.actor,
         input: values.input,
@@ -54,6 +72,7 @@ function parseCliArgs() {
         format: values.format || 'csv',
         timeout: parseInt(values.timeout, 10),
         pollInterval: parseInt(values['poll-interval'], 10),
+        maxTotalChargeUsd,
     };
 }
 
@@ -62,7 +81,7 @@ function printHelp() {
 Apify Actor Runner - Run Apify actors and export results
 
 Usage:
-  node --env-file=.env scripts/run_actor.js --actor ACTOR_ID --input '{}'
+  node scripts/run_actor.js --actor ACTOR_ID --input '{}' --max-total-charge-usd APPROVED_CAP --approve-paid-run
 
 Options:
   --actor, -a       Actor ID (e.g., compass/crawler-google-places) [required]
@@ -71,6 +90,8 @@ Options:
   --format, -f      Output format: csv, json (default: csv)
   --timeout, -t     Max wait time in seconds (default: 600)
   --poll-interval   Seconds between status checks (default: 5)
+  --max-total-charge-usd  Positive maximum Actor charge [required]
+  --approve-paid-run      Confirm pricing and approve this paid run [required]
   --help, -h        Show this help message
 
 Output Formats:
@@ -80,23 +101,26 @@ Output Formats:
 
 Examples:
   # Quick answer - display top 5 in chat
-  node --env-file=.env scripts/run_actor.js \\
-    --actor "compass/crawler-google-places" \\
-    --input '{"searchStringsArray": ["coffee shops"], "locationQuery": "Seattle, USA"}'
-
-  # Export all data to CSV
-  node --env-file=.env scripts/run_actor.js \\
+  node scripts/run_actor.js \\
     --actor "compass/crawler-google-places" \\
     --input '{"searchStringsArray": ["coffee shops"], "locationQuery": "Seattle, USA"}' \\
-    --output leads.csv --format csv
+    --max-total-charge-usd APPROVED_CAP --approve-paid-run
+
+  # Export all data to CSV
+  node scripts/run_actor.js \\
+    --actor "compass/crawler-google-places" \\
+    --input '{"searchStringsArray": ["coffee shops"], "locationQuery": "Seattle, USA"}' \\
+    --output leads.csv --format csv \\
+    --max-total-charge-usd APPROVED_CAP --approve-paid-run
 `);
 }
 
 // Start an actor run and return { runId, datasetId }
-async function startActor(token, actorId, inputJson) {
+async function startActor(token, actorId, inputJson, maxTotalChargeUsd) {
     // Convert "author/actor" format to "author~actor" for API compatibility
     const apiActorId = actorId.replace('/', '~');
-    const url = `https://api.apify.com/v2/acts/${apiActorId}/runs?token=${encodeURIComponent(token)}`;
+    const url = new URL(`https://api.apify.com/v2/acts/${apiActorId}/runs`);
+    url.searchParams.set('maxTotalChargeUsd', maxTotalChargeUsd);
 
     let data;
     try {
@@ -109,6 +133,7 @@ async function startActor(token, actorId, inputJson) {
     const response = await fetch(url, {
         method: 'POST',
         headers: {
+            Authorization: `Bearer ${token}`,
             'Content-Type': 'application/json',
             'User-Agent': `${USER_AGENT}/start_actor`,
         },
@@ -135,12 +160,17 @@ async function startActor(token, actorId, inputJson) {
 
 // Poll run status until complete or timeout
 async function pollUntilComplete(token, runId, timeout, interval) {
-    const url = `https://api.apify.com/v2/actor-runs/${runId}?token=${encodeURIComponent(token)}`;
+    const url = `https://api.apify.com/v2/actor-runs/${runId}`;
     const startTime = Date.now();
     let lastStatus = null;
 
     while (true) {
-        const response = await fetch(url);
+        const response = await fetch(url, {
+            headers: {
+                Authorization: `Bearer ${token}`,
+                'User-Agent': `${USER_AGENT}/poll_run`,
+            },
+        });
         if (!response.ok) {
             const text = await response.text();
             console.error(`Error: Failed to get run status: ${text}`);
@@ -172,10 +202,11 @@ async function pollUntilComplete(token, runId, timeout, interval) {
 
 // Download dataset items
 async function downloadResults(token, datasetId, outputPath, format) {
-    const url = `https://api.apify.com/v2/datasets/${datasetId}/items?token=${encodeURIComponent(token)}&format=json`;
+    const url = `https://api.apify.com/v2/datasets/${datasetId}/items?format=json`;
 
     const response = await fetch(url, {
         headers: {
+            Authorization: `Bearer ${token}`,
             'User-Agent': `${USER_AGENT}/download_${format}`,
         },
     });
@@ -231,10 +262,11 @@ async function downloadResults(token, datasetId, outputPath, format) {
 
 // Display top 5 results in chat format
 async function displayQuickAnswer(token, datasetId) {
-    const url = `https://api.apify.com/v2/datasets/${datasetId}/items?token=${encodeURIComponent(token)}&format=json`;
+    const url = `https://api.apify.com/v2/datasets/${datasetId}/items?format=json`;
 
     const response = await fetch(url, {
         headers: {
+            Authorization: `Bearer ${token}`,
             'User-Agent': `${USER_AGENT}/quick_answer`,
         },
     });
@@ -322,10 +354,9 @@ async function main() {
     // Check for APIFY_TOKEN
     const token = process.env.APIFY_TOKEN;
     if (!token) {
-        console.error('Error: APIFY_TOKEN not found in .env file');
+        console.error('Error: APIFY_TOKEN is not set in the environment');
         console.error('');
-        console.error('Add your token to .env file:');
-        console.error('  APIFY_TOKEN=your_token_here');
+        console.error('Set APIFY_TOKEN in your shell or secret manager, then retry.');
         console.error('');
         console.error('Get your token: https://console.apify.com/account/integrations');
         process.exit(1);
@@ -333,7 +364,12 @@ async function main() {
 
     // Start the actor run
     console.log(`Starting actor: ${args.actor}`);
-    const { runId, datasetId } = await startActor(token, args.actor, args.input);
+    const { runId, datasetId } = await startActor(
+        token,
+        args.actor,
+        args.input,
+        args.maxTotalChargeUsd,
+    );
     console.log(`Run ID: ${runId}`);
     console.log(`Dataset ID: ${datasetId}`);
 

--- a/skills/apify-ultimate-scraper/reference/scripts/run_actor.js
+++ b/skills/apify-ultimate-scraper/reference/scripts/run_actor.js
@@ -4,10 +4,10 @@
  *
  * Usage:
  *   # Quick answer (display in chat, no file saved)
- *   node scripts/run_actor.js --actor ACTOR_ID --input '{}' --max-total-charge-usd APPROVED_CAP --approve-paid-run
+ *   node --env-file=.env scripts/run_actor.js --actor ACTOR_ID --input '{}'
  *
  *   # Export to file
- *   node scripts/run_actor.js --actor ACTOR_ID --input '{}' --output leads.csv --format csv --max-total-charge-usd APPROVED_CAP --approve-paid-run
+ *   node --env-file=.env scripts/run_actor.js --actor ACTOR_ID --input '{}' --output leads.csv --format csv
  */
 
 import { parseArgs } from 'node:util';
@@ -25,8 +25,6 @@ function parseCliArgs() {
         format: { type: 'string', short: 'f', default: 'csv' },
         timeout: { type: 'string', short: 't', default: '600' },
         'poll-interval': { type: 'string', default: '5' },
-        'max-total-charge-usd': { type: 'string' },
-        'approve-paid-run': { type: 'boolean' },
         help: { type: 'boolean', short: 'h' },
     };
 
@@ -49,22 +47,6 @@ function parseCliArgs() {
         process.exit(1);
     }
 
-    if (!values['approve-paid-run']) {
-        console.error('Error: Paid run not approved. Pass --approve-paid-run after reviewing live pricing.');
-        process.exit(1);
-    }
-
-    const maxTotalChargeUsd = values['max-total-charge-usd'];
-    if (
-        !maxTotalChargeUsd ||
-        !/^(0|[1-9]\d*)(\.\d+)?$/.test(maxTotalChargeUsd) ||
-        !Number.isFinite(Number(maxTotalChargeUsd)) ||
-        Number(maxTotalChargeUsd) <= 0
-    ) {
-        console.error('Error: --max-total-charge-usd must be a positive decimal.');
-        process.exit(1);
-    }
-
     return {
         actor: values.actor,
         input: values.input,
@@ -72,7 +54,6 @@ function parseCliArgs() {
         format: values.format || 'csv',
         timeout: parseInt(values.timeout, 10),
         pollInterval: parseInt(values['poll-interval'], 10),
-        maxTotalChargeUsd,
     };
 }
 
@@ -81,7 +62,7 @@ function printHelp() {
 Apify Actor Runner - Run Apify actors and export results
 
 Usage:
-  node scripts/run_actor.js --actor ACTOR_ID --input '{}' --max-total-charge-usd APPROVED_CAP --approve-paid-run
+  node --env-file=.env scripts/run_actor.js --actor ACTOR_ID --input '{}'
 
 Options:
   --actor, -a       Actor ID (e.g., compass/crawler-google-places) [required]
@@ -90,8 +71,6 @@ Options:
   --format, -f      Output format: csv, json (default: csv)
   --timeout, -t     Max wait time in seconds (default: 600)
   --poll-interval   Seconds between status checks (default: 5)
-  --max-total-charge-usd  Positive maximum Actor charge [required]
-  --approve-paid-run      Confirm pricing and approve this paid run [required]
   --help, -h        Show this help message
 
 Output Formats:
@@ -101,26 +80,23 @@ Output Formats:
 
 Examples:
   # Quick answer - display top 5 in chat
-  node scripts/run_actor.js \\
+  node --env-file=.env scripts/run_actor.js \\
     --actor "compass/crawler-google-places" \\
-    --input '{"searchStringsArray": ["coffee shops"], "locationQuery": "Seattle, USA"}' \\
-    --max-total-charge-usd APPROVED_CAP --approve-paid-run
+    --input '{"searchStringsArray": ["coffee shops"], "locationQuery": "Seattle, USA"}'
 
   # Export all data to CSV
-  node scripts/run_actor.js \\
+  node --env-file=.env scripts/run_actor.js \\
     --actor "compass/crawler-google-places" \\
     --input '{"searchStringsArray": ["coffee shops"], "locationQuery": "Seattle, USA"}' \\
-    --output leads.csv --format csv \\
-    --max-total-charge-usd APPROVED_CAP --approve-paid-run
+    --output leads.csv --format csv
 `);
 }
 
 // Start an actor run and return { runId, datasetId }
-async function startActor(token, actorId, inputJson, maxTotalChargeUsd) {
+async function startActor(token, actorId, inputJson) {
     // Convert "author/actor" format to "author~actor" for API compatibility
     const apiActorId = actorId.replace('/', '~');
-    const url = new URL(`https://api.apify.com/v2/acts/${apiActorId}/runs`);
-    url.searchParams.set('maxTotalChargeUsd', maxTotalChargeUsd);
+    const url = `https://api.apify.com/v2/acts/${apiActorId}/runs?token=${encodeURIComponent(token)}`;
 
     let data;
     try {
@@ -133,7 +109,6 @@ async function startActor(token, actorId, inputJson, maxTotalChargeUsd) {
     const response = await fetch(url, {
         method: 'POST',
         headers: {
-            Authorization: `Bearer ${token}`,
             'Content-Type': 'application/json',
             'User-Agent': `${USER_AGENT}/start_actor`,
         },
@@ -160,17 +135,12 @@ async function startActor(token, actorId, inputJson, maxTotalChargeUsd) {
 
 // Poll run status until complete or timeout
 async function pollUntilComplete(token, runId, timeout, interval) {
-    const url = `https://api.apify.com/v2/actor-runs/${runId}`;
+    const url = `https://api.apify.com/v2/actor-runs/${runId}?token=${encodeURIComponent(token)}`;
     const startTime = Date.now();
     let lastStatus = null;
 
     while (true) {
-        const response = await fetch(url, {
-            headers: {
-                Authorization: `Bearer ${token}`,
-                'User-Agent': `${USER_AGENT}/poll_run`,
-            },
-        });
+        const response = await fetch(url);
         if (!response.ok) {
             const text = await response.text();
             console.error(`Error: Failed to get run status: ${text}`);
@@ -202,11 +172,10 @@ async function pollUntilComplete(token, runId, timeout, interval) {
 
 // Download dataset items
 async function downloadResults(token, datasetId, outputPath, format) {
-    const url = `https://api.apify.com/v2/datasets/${datasetId}/items?format=json`;
+    const url = `https://api.apify.com/v2/datasets/${datasetId}/items?token=${encodeURIComponent(token)}&format=json`;
 
     const response = await fetch(url, {
         headers: {
-            Authorization: `Bearer ${token}`,
             'User-Agent': `${USER_AGENT}/download_${format}`,
         },
     });
@@ -262,11 +231,10 @@ async function downloadResults(token, datasetId, outputPath, format) {
 
 // Display top 5 results in chat format
 async function displayQuickAnswer(token, datasetId) {
-    const url = `https://api.apify.com/v2/datasets/${datasetId}/items?format=json`;
+    const url = `https://api.apify.com/v2/datasets/${datasetId}/items?token=${encodeURIComponent(token)}&format=json`;
 
     const response = await fetch(url, {
         headers: {
-            Authorization: `Bearer ${token}`,
             'User-Agent': `${USER_AGENT}/quick_answer`,
         },
     });
@@ -354,9 +322,10 @@ async function main() {
     // Check for APIFY_TOKEN
     const token = process.env.APIFY_TOKEN;
     if (!token) {
-        console.error('Error: APIFY_TOKEN is not set in the environment');
+        console.error('Error: APIFY_TOKEN not found in .env file');
         console.error('');
-        console.error('Set APIFY_TOKEN in your shell or secret manager, then retry.');
+        console.error('Add your token to .env file:');
+        console.error('  APIFY_TOKEN=your_token_here');
         console.error('');
         console.error('Get your token: https://console.apify.com/account/integrations');
         process.exit(1);
@@ -364,12 +333,7 @@ async function main() {
 
     // Start the actor run
     console.log(`Starting actor: ${args.actor}`);
-    const { runId, datasetId } = await startActor(
-        token,
-        args.actor,
-        args.input,
-        args.maxTotalChargeUsd,
-    );
+    const { runId, datasetId } = await startActor(token, args.actor, args.input);
     console.log(`Run ID: ${runId}`);
     console.log(`Dataset ID: ${datasetId}`);
 


### PR DESCRIPTION
# Pull Request Description

Adds both public Xquik Apify Actors to `apify-ultimate-scraper`.

- Routes tweet lookup, search, timelines, threads, and engagement.
- Routes follower, list, community, and audience-overlap tasks.
- Adds both Actors to the relevant use-case tables.
- Removes volatile Actor counts.
- Removes `.env` scraping and `--env-file` command patterns.
- Keeps the contribution source-only.

The Xquik additions use only Apify Actor IDs. They do not link an external Xquik website.

## Change Classification

- [x] Skill PR
- [ ] Docs PR
- [ ] Infra PR

## Issue Link (Optional)

Not applicable.

## Quality Bar Checklist ✅

- [x] **Standards**: I read `docs/contributors/quality-bar.md` and `docs/contributors/security-guardrails.md`.
- [x] **Metadata**: `npm run validate` passes.
- [x] **Risk Label**: The existing legacy `risk: unknown` classification remains unchanged.
- [x] **Triggers**: The existing "When to Use" section remains clear and specific.
- [x] **Limitations**: The existing limitations section remains present.
- [x] **Security**: This is not an offensive skill.
- [x] **Safety scan**: `npm run security:docs` passes.
- [ ] **Automated Skill Review**: Pending the pull request workflow.
- [x] **Manual Logic Review**: Reviewed Actor selection, result caps, paid-run boundaries, credential handling, diagnostic rows, and failure modes.
- [x] **Local Test**: Validated both public Actor records and current input schemas. No paid run was started.
- [x] **Repo Checks**: `npm run validate:references` passes.
- [x] **Source-Only PR**: No generated registry artifacts are included.
- [x] **Credits**: Not applicable. This updates an existing community skill.
- [x] **License provenance**: Not applicable. No external source repository is imported.
- [x] **Maintainer Edits**: Allow edits from maintainers is enabled.

## Validation

- `npm run chain` in a scratch copy
- `npm run validate:references`
- `npm run security:docs`
- `npm test`: 102 test files passed
- `npm run check:warning-budget`: 0/0
- `git diff --check`

The full suite used Python 3.12 and Git 2.53. Apple Git 2.39 lacks the suite's required reftable support.

## Screenshots (if applicable)

Not applicable.

Disclosure: I am affiliated with Xquik.
