### PR TITLE
fix: negotiate MCP protocol versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed AAS MCP initialization for newer clients such as Claude Code 2.1.x by negotiating the server-supported protocol revision instead of rejecting every request that advertises a different revision ([#1003](https://github.com/sickn33/agentic-awesome-skills/issues/1003)).
+
 ## [15.5.0] - 2026-07-26 - "Coordination, Founder Matching, and Fedora Hyprland"
 
 > Added focused multi-agent orchestration, privacy-preserving founder matching, and a consent-gated Fedora Hyprland lifecycle workflow; also expanded UIZZE with a free manual path and a harder UI finish gate.

--- a/docs/maintainers/aas-agent-first-control-plane-v1-design.md
+++ b/docs/maintainers/aas-agent-first-control-plane-v1-design.md
@@ -131,7 +131,7 @@ The server exposes only:
 
 Full skill text is returned only on request and is separated as `untrustedContent`; metadata and prose cannot acquire instruction authority. The server can signal this trust boundary but cannot guarantee how an external model will behave.
 
-Every structured response declares `protocolVersion`, `coreVersion`, `metadataSchemaVersion`, `scorerVersion`, and catalog digest. Incompatible versions fail explicitly.
+Every structured response declares `protocolVersion`, `coreVersion`, `metadataSchemaVersion`, `scorerVersion`, and catalog digest. MCP initialization responds with the server-supported protocol revision so the client can accept it or disconnect; incompatible artifact and schema versions still fail explicitly.
 
 ## CLI lifecycle
 

--- a/tools/lib/aas-v1/mcp/server.js
+++ b/tools/lib/aas-v1/mcp/server.js
@@ -679,10 +679,9 @@ class McpServer {
     if (!Object.hasOwn(request, "id") || !isPlainObject(request.params)) {
       return this.rpcError(id, -32600, "Invalid Request");
     }
-    if (request.params.protocolVersion !== core.protocolVersion) {
-      return this.rpcError(id, -32602, "Unsupported protocol version", {
-        code: "AAS_MCP_PROTOCOL_VERSION_INCOMPATIBLE",
-        expected: core.protocolVersion,
+    if (typeof request.params.protocolVersion !== "string" || request.params.protocolVersion.trim().length === 0) {
+      return this.rpcError(id, -32602, "Invalid protocolVersion", {
+        code: "AAS_MCP_PROTOCOL_VERSION_INVALID",
       });
     }
     this.initializeAccepted = true;

--- a/tools/scripts/tests/aas_v1_mcp.test.js
+++ b/tools/scripts/tests/aas_v1_mcp.test.js
@@ -101,20 +101,38 @@ test("strict JSON-lines parser rejects invalid UTF-8, duplicate keys, excess dep
   );
 });
 
-test("initialize fails closed on a protocol version other than 2025-06-18", async () => {
+test("initialize negotiates the server-supported version for a newer client", async () => {
   const server = new McpServer({ root: ROOT });
   const response = await server.handle({
     jsonrpc: "2.0",
     id: "init",
     method: "initialize",
-    params: { protocolVersion: "2024-11-05", capabilities: {}, clientInfo: { name: "test", version: "1" } },
+    params: { protocolVersion: "2025-11-25", capabilities: {}, clientInfo: { name: "test", version: "1" } },
   });
-  assert.equal(response.error.code, -32602);
-  assert.equal(response.error.data.code, "AAS_MCP_PROTOCOL_VERSION_INCOMPATIBLE");
-  assert.equal(response.error.data.expected, "2025-06-18");
+  assert.equal(response.result.protocolVersion, core.protocolVersion);
   await server.handle({ jsonrpc: "2.0", method: "notifications/initialized", params: {} });
-  const bypass = await server.handle({ jsonrpc: "2.0", id: 2, method: "tools/list", params: {} });
-  assert.equal(bypass.error.code, -32002);
+  const tools = await server.handle({ jsonrpc: "2.0", id: 2, method: "tools/list", params: {} });
+  assert.deepEqual(tools.result.tools.map((entry) => entry.name), TOOL_NAMES);
+});
+
+test("initialize rejects a missing or malformed protocol version", async () => {
+  const invalidVersions = [undefined, "", "   ", null, 20250618];
+  for (const protocolVersion of invalidVersions) {
+    const server = new McpServer({ root: ROOT });
+    const params = { capabilities: {}, clientInfo: { name: "test", version: "1" } };
+    if (protocolVersion !== undefined) params.protocolVersion = protocolVersion;
+    const response = await server.handle({
+      jsonrpc: "2.0",
+      id: "init",
+      method: "initialize",
+      params,
+    });
+    assert.equal(response.error.code, -32602);
+    assert.equal(response.error.data.code, "AAS_MCP_PROTOCOL_VERSION_INVALID");
+    await server.handle({ jsonrpc: "2.0", method: "notifications/initialized", params: {} });
+    const bypass = await server.handle({ jsonrpc: "2.0", id: 2, method: "tools/list", params: {} });
+    assert.equal(bypass.error.code, -32002);
+  }
 });
 
 test("MCP preserves the five stack tools and adds two read-only evidence tools", async () => {
@@ -733,7 +751,7 @@ test("stdio entrypoint emits protocol-only stdout and survives a malformed line"
   const stderr = [];
   child.stdout.on("data", (chunk) => stdout.push(chunk));
   child.stderr.on("data", (chunk) => stderr.push(chunk));
-  child.stdin.write('{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-06-18","capabilities":{},"clientInfo":{"name":"test","version":"1"}}}\n');
+  child.stdin.write('{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-11-25","capabilities":{},"clientInfo":{"name":"test","version":"1"}}}\n');
   child.stdin.write('{"a":1,"a":2}\n');
   child.stdin.write('{"jsonrpc":"2.0","method":"notifications/initialized","params":{}}\n');
   child.stdin.write('{"jsonrpc":"2.0","id":2,"method":"tools/list","params":{}}\n');

--- a/tools/scripts/tests/aas_v1_runtime_config.test.js
+++ b/tools/scripts/tests/aas_v1_runtime_config.test.js
@@ -218,7 +218,7 @@ test("the packed runtime launches MCP from an isolated verified dependency closu
     id: 1,
     method: "initialize",
     params: {
-      protocolVersion: core.protocolVersion,
+      protocolVersion: "2025-11-25",
       capabilities: {},
       clientInfo: { name: "isolated-runtime-test", version: "1" },
     },

--- a/verification/aas-preview/runner.mjs
+++ b/verification/aas-preview/runner.mjs
@@ -364,7 +364,7 @@ async function main() {
   const beforeMcp = { project: snapshotTree(projectRoot), cache: snapshotTree(cacheRoot) };
   const client = new JsonLineClient(mcpBin, ["--cache-root", cacheRoot], projectRoot);
   const initialize = await client.request(1, "initialize", {
-    protocolVersion: "2025-06-18",
+    protocolVersion: "2025-11-25",
     capabilities: {},
     clientInfo: { name: "aas-preview", version: "1" },
   });


### PR DESCRIPTION
## Summary

- negotiate MCP initialize requests by returning the server-supported protocol revision
- reject missing, empty, or non-string protocolVersion values
- cover direct server, stdio, packed-runtime, and preview execution paths
- document the corrected lifecycle behavior

Closes #1003

## Validation

- node --test tools/scripts/tests/aas_v1_mcp.test.js
- node --test tools/scripts/tests/aas_v1_runtime_config.test.js
- npm run test:aas-v1 (150 passed)
- npm run test (102 test files passed)
- npm run validate
- npm run validate:references
- npm run security:docs
- npm run check:warning-budget
- npm run check:aas-v1-catalog
- npm ci audit: 0 vulnerabilities

## Quality Bar Checklist

- [x] The server advertises only the protocol revision it actually implements.
- [x] Newer client revisions negotiate instead of failing initialization.
- [x] Malformed protocol revisions remain fail-closed.
- [x] Runtime and packaged execution paths have regression coverage.
- [x] CHANGELOG and maintainer design documentation are updated.
- [x] No generated registry artifacts are included.