### PR TITLE
feat: add 4 meta-skills addressing AAS Core limitations

### DIFF
--- a/skills/aas-lightweight/SKILL.md
+++ b/skills/aas-lightweight/SKILL.md
@@ -1,0 +1,242 @@
+---
+name: aas-lightweight
+description: Use AAS skills without the full AAS Core infrastructure for small projects, quick tasks, or solo workflows. Use when AAS MCP setup feels like overkill, when you want a single skill without the full catalog, or when working in a constrained environment.
+category: meta
+risk: safe
+source: community
+source_type: community
+date_added: "2026-07-28"
+author: sickn33-contributor
+tags: [aas, lightweight, quick-start, minimal, simple, solo]
+tools: [claude, codex, gemini, cursor, antigravity]
+---
+
+# AAS Lightweight
+
+## Overview
+
+AAS Core (MCP server, CLI, `aas-stack.json`, Workbench, evidence sidecar) is powerful
+but carries real setup overhead. For many tasks — a weekend project, a quick spike,
+a small fix — the full infrastructure is overkill.
+
+This skill gives you **3 lightweight paths** to get value from the AAS catalog
+without installing or configuring anything:
+
+1. **Browse & Copy** — find a skill on GitHub, paste it directly into your agent context
+2. **Micro-stack** — select 1–3 skills for a narrow task without a full stack manifest
+3. **Inline mode** — distill the key instructions from a skill into your current prompt
+
+Use this when: solo projects, prototypes, small tasks, constrained environments, or
+when you want to try a skill before committing to a full AAS setup.
+
+---
+
+## When to Use This Skill
+
+- Use when AAS MCP is not installed and you don't want to install it right now
+- Use for tasks that need 1–3 skills max (not a full project stack)
+- Use when working in a restricted environment (no npm, no CLI tools)
+- Use when you want to quickly test if a skill is useful before adding it to your stack
+- Use for one-off tasks where a full `aas-stack.json` workflow adds no value
+- **Do not use** when managing a team project with reproducibility requirements (use AAS Core instead)
+
+---
+
+## Path 1: Browse & Copy (Zero Setup)
+
+Find any skill directly on GitHub and paste its content into your agent session.
+
+### Step 1: Find the skill
+```
+GitHub URL pattern:
+https://github.com/sickn33/agentic-awesome-skills/tree/main/skills/<skill-name>
+
+Example:
+https://github.com/sickn33/agentic-awesome-skills/tree/main/skills/react-patterns
+```
+
+Or search the catalog:
+```
+https://github.com/sickn33/agentic-awesome-skills/blob/main/CATALOG.md
+```
+Use Ctrl+F on the CATALOG.md page to find skills by keyword.
+
+### Step 2: Get the raw SKILL.md
+```
+Raw URL pattern:
+https://raw.githubusercontent.com/sickn33/agentic-awesome-skills/main/skills/<skill-name>/SKILL.md
+```
+
+### Step 3: Paste into your agent prompt
+```
+Here is a skill I want you to follow for this task:
+
+---
+[paste SKILL.md content here]
+---
+
+Now apply this skill to: [your task description]
+```
+
+That's it. No installation, no MCP, no CLI.
+
+---
+
+## Path 2: Micro-Stack (1–3 Skills, No Manifest)
+
+For tasks that need a few skills but not a full project stack.
+
+### Step 1: Identify your task surface
+```
+Task: "Build a login form with validation and auth"
+Surface:
+  - Auth: clerk-auth or nextjs-supabase-auth
+  - Forms: zod-validation-expert
+  - UI: shadcn (if using shadcn)
+```
+
+### Step 2: Fetch skills with curl (no npm needed)
+```bash
+# Fetch one skill
+curl -s https://raw.githubusercontent.com/sickn33/agentic-awesome-skills/main/skills/clerk-auth/SKILL.md
+
+# Fetch and save locally
+curl -s https://raw.githubusercontent.com/sickn33/agentic-awesome-skills/main/skills/zod-validation-expert/SKILL.md > /tmp/zod-skill.md
+```
+
+### Step 3: Compose a lightweight context block
+```markdown
+## My Task Skills
+
+### clerk-auth
+[paste or curl content]
+
+### zod-validation-expert  
+[paste or curl content]
+
+Apply both skills to implement: login form with email/password + Zod schema validation.
+```
+
+### Step 4: Verify the result
+No `aas stack validate` needed — just check your output manually:
+```
+□ Does the code follow the skill's patterns?
+□ Are the skill's best practices reflected?
+□ Did the skill's "common pitfalls" get avoided?
+```
+
+---
+
+## Path 3: Inline Mode (Distill to Essentials)
+
+When you don't even want to paste a full SKILL.md — extract only what matters.
+
+### How to distill a skill inline
+
+Read the skill and extract:
+1. **The core workflow** (the numbered steps)
+2. **The key best practices** (✅ do this)
+3. **The key anti-patterns** (❌ don't do this)
+
+```
+Example — distilled clerk-auth skill for a quick task:
+
+"Follow these patterns for auth:
+1. Wrap app root with ClerkProvider
+2. Use useAuth() hook for auth state — not useUser()
+3. Protect routes with auth() in server components
+4. Store CLERK_PUBLISHABLE_KEY in .env.local, never in code
+5. Don't use getServerSideProps with Clerk — use server components instead"
+```
+
+This fits in one prompt message and gives the agent the key guardrails without loading a 200-line SKILL.md.
+
+---
+
+## When to Upgrade to AAS Core
+
+Use the lightweight paths above until you hit one of these signals:
+
+| Signal | Action |
+|--------|--------|
+| Same skill needed on 3+ projects | Install it locally via AAS |
+| Team members need the same skills | Set up AAS Core + `aas-stack.json` |
+| Skills conflict with each other | Use `compose_stack` for validation |
+| You need reproducible skill history | Use `aas-stack.json` manifest |
+| More than 5 skills for a project | Full AAS workflow pays for itself |
+
+---
+
+## Quick Reference: Useful Skills for Common Small Tasks
+
+| Task | Skill to grab |
+|------|--------------|
+| React component | `react-patterns` |
+| TypeScript types | `typescript-pro` |
+| REST API | `api-patterns` |
+| Database schema | `database-design` |
+| Auth setup | `clerk-auth` |
+| Form validation | `zod-validation-expert` |
+| Git workflow | `github` |
+| Docker setup | `docker-expert` |
+| Write good tests | `tdd-workflow` |
+| Debug a bug | `systematic-debugging` |
+| Code review | `code-reviewer` |
+| Write docs | `documentation` |
+
+---
+
+## Examples
+
+### Example 1: Quick fix on a solo project
+```
+Task: "Fix N+1 query in my Express app"
+Micro-stack: just database-optimizer
+Method: curl the skill raw URL, paste into ChatGPT/Claude
+Result: Skill provides query analysis steps + fix patterns — done in 5 min
+```
+
+### Example 2: Prototype with 2 skills
+```
+Task: "Prototype a React dashboard with charts"
+Micro-stack: react-patterns + claude-d3js-skill
+Method: fetch both, compose a combined context block
+Result: Agent follows both skill patterns, clean prototype in 1 session
+```
+
+### Example 3: Inline distillation for a constrained environment
+```
+Environment: corporate laptop, no npm, no curl access to GitHub
+Method: Copy SKILL.md from GitHub browser UI, paste key steps into Copilot Chat
+Result: Got the guardrails I needed without any tooling setup
+```
+
+---
+
+## Best Practices
+
+- ✅ Lightweight is fine for 1–3 skill tasks — don't over-engineer
+- ✅ Distill to essentials when pasting full skills makes the prompt too long
+- ✅ Cache raw skill URLs locally if you use them repeatedly
+- ✅ Know when to upgrade — lightweight doesn't scale to team workflows
+- ❌ Don't try to manage 10+ skills in lightweight mode — use AAS Core
+- ❌ Don't skip skill quality check even in lightweight mode — use `skill-quality-auditor` first
+- ❌ Don't use lightweight mode for production deployments — reproducibility matters
+
+## Common Pitfalls
+
+- **Problem:** Pasted skill is 300 lines and dominates the agent's context window  
+  **Solution:** Use Path 3 (inline distillation) — extract the 5–10 most important rules
+
+- **Problem:** Two micro-stack skills give conflicting advice  
+  **Solution:** Read both, identify conflict, explicitly tell the agent which wins
+
+- **Problem:** Skill was updated after you saved a local copy  
+  **Solution:** Always fetch fresh from GitHub raw URL; don't reuse saved copies after 30 days
+
+## Additional Resources
+
+- [AAS Catalog](https://github.com/sickn33/agentic-awesome-skills/blob/main/CATALOG.md)
+- [AAS Workbench](https://sickn33.github.io/agentic-awesome-skills/workbench) — browser-based skill review
+- [aas-skill-selector](../aas-skill-selector/SKILL.md) — when you're ready for structured selection
+- [skill-quality-auditor](../skill-quality-auditor/SKILL.md) — audit before trusting any skill

--- a/skills/aas-skill-selector/SKILL.md
+++ b/skills/aas-skill-selector/SKILL.md
@@ -1,0 +1,211 @@
+---
+name: aas-skill-selector
+description: Guide an agent through structured, semantic skill selection from the AAS catalog. Use when the agent must choose the right skills from a large catalog for a specific project, or when previous skill selection produced irrelevant or redundant results.
+category: meta
+risk: safe
+source: community
+source_type: community
+date_added: "2026-07-28"
+author: sickn33-contributor
+tags: [skill-selection, aas, catalog, planning, meta, agent-first]
+tools: [claude, codex, gemini, cursor, antigravity]
+---
+
+# AAS Skill Selector
+
+## Overview
+
+AAS Core deliberately does **not** rank or recommend skills — the agent picks.
+This is a feature, not a bug. But it means **agent judgment is the quality gate**.
+
+Without a structured selection process, agents tend to:
+- Pick the first matching skill rather than the best one
+- Stop at a minimal shortlist (3–5 skills) when 15–20 may be warranted
+- Miss entire capability areas (e.g., security, observability, accessibility)
+- Select redundant skills that overlap heavily
+- Anchor on skill names instead of reading actual content
+
+This skill gives the agent a **repeatable, coverage-driven selection protocol**
+that produces a non-redundant, project-appropriate skill stack.
+
+---
+
+## When to Use This Skill
+
+- Use when starting a new project and selecting an AAS skill stack
+- Use when your current skill stack feels incomplete or produces gaps
+- Use when agent selected skills but missed obvious capability areas
+- Use when you need to justify *why* each skill was chosen
+- Use before running `compose_stack` to validate your selection
+
+---
+
+## Selection Protocol (5 Phases)
+
+### Phase 1: Project Surface Mapping
+
+Before searching the catalog, map the full project surface. Do not skip areas even if they seem out of scope.
+
+```
+Architecture layer:
+  □ Language(s) and runtime(s)
+  □ Framework(s)
+  □ Database(s)
+  □ External APIs / integrations
+  □ Auth model
+
+Domain layer:
+  □ Core business logic patterns
+  □ Data models and relationships
+  □ Workflows and state machines
+
+Quality layer:
+  □ Testing strategy (unit / integration / e2e)
+  □ Observability (logging, metrics, tracing)
+  □ Error handling and resilience
+
+Security layer:
+  □ Auth and access control
+  □ Input validation
+  □ Secrets and credentials
+  □ Dependency vulnerability surface
+
+Delivery layer:
+  □ CI/CD pipeline
+  □ Deployment target (cloud/container/serverless)
+  □ Infrastructure as code
+
+UX layer (if applicable):
+  □ Frontend framework
+  □ Accessibility
+  □ Performance budget
+  □ Responsive/mobile
+
+Maintenance layer:
+  □ Documentation
+  □ Dependency management
+  □ Upgrade and migration path
+```
+
+### Phase 2: Per-Area Catalog Search
+
+For each surface area identified in Phase 1:
+1. Search the AAS catalog with `search_skills <area-keyword>`
+2. Read the top 3–5 candidate skills with `get_skill <id>`
+3. Compare candidates on: depth, freshness, specificity, tool compatibility
+4. Pick the **best fit** — not just the first result
+
+```
+Rule: If you found 0 candidates for an area → record as a catalog gap.
+Rule: If you found 1 candidate → note it but flag low confidence.
+Rule: If you found 3+ candidates → compare and pick the deepest one.
+```
+
+### Phase 3: Redundancy Elimination
+
+Before finalizing, scan your selected list for overlaps:
+
+```
+For each pair of selected skills, ask:
+  - Do they solve the same problem?
+  - Do their instructions conflict?
+  - Would installing both confuse the agent?
+
+If yes → keep the one with higher body depth score (see skill-quality-auditor).
+```
+
+Common redundancy traps:
+- `react-patterns` + `react-best-practices` + `react-component-performance` (pick 1–2)
+- `security-auditor` + `security-scanning-security-sast` (often overlapping)
+- Framework skill + language skill (e.g., `nextjs-best-practices` already covers React basics)
+
+### Phase 4: Coverage Ledger
+
+Produce a capability ledger — one row per surface area:
+
+| Surface Area     | Selected Skill(s)         | Gap? | Notes |
+|------------------|---------------------------|------|-------|
+| Auth             | clerk-auth                | No   | |
+| Database         | neon-postgres             | No   | |
+| Testing (E2E)    | playwright-skill          | No   | |
+| Observability    | —                         | YES  | No good AAS skill found |
+| Accessibility    | ui-a11y                   | No   | |
+
+**Do not finalize stack until every surface area has an entry.**
+
+### Phase 5: Selection Evidence
+
+For each selected skill, produce a one-line justification:
+```
+skill-id: "Selected because it covers [specific gap] at [depth level].
+           Alternatives [alt1, alt2] were considered but [reason rejected]."
+```
+
+This becomes the `aas-selection-evidence.json` payload when using AAS Core.
+
+---
+
+## Examples
+
+### Example 1: React Flow pipeline builder project
+```
+Surface map:
+  Language: JavaScript/React
+  Framework: React Flow
+  Backend: FastAPI (Python)
+  Auth: JWT
+  Infra: Docker + Vercel
+
+Search results → selected stack:
+  react-patterns           → React component patterns
+  react-flow-node-ts       → React Flow node creation
+  react-state-management   → State across nodes
+  fastapi-pro              → Backend API
+  python-testing-patterns  → Backend tests
+  clerk-auth               → Auth (JWT compatible)
+  docker-expert            → Containerization
+  vercel-deployment        → Deploy
+
+Redundancy check: react-patterns + react-flow-node-ts → no overlap (different focus)
+Coverage gap: Observability (no suitable skill found)
+```
+
+### Example 2: Recovering from a bad selection
+```
+Bad selection: agent chose 4 overlapping React skills, missed security entirely
+
+Fix with this skill:
+  Phase 1 → discovered: auth, input validation were unmapped
+  Phase 3 → removed 2 redundant React skills
+  Phase 2 → added: security-auditor, clerk-auth
+  Result: 6 skills, full coverage, zero redundancy
+```
+
+---
+
+## Best Practices
+
+- ✅ Complete the surface map BEFORE searching — don't search first and map after
+- ✅ Read skill bodies, not just names — `get_skill` is mandatory for final candidates
+- ✅ Record catalog gaps — they're valuable feedback for AAS contributors
+- ✅ Keep the ledger — it's your justification and diff baseline for future updates
+- ❌ Don't stop at 5 skills for a non-trivial project — coverage matters more than brevity
+- ❌ Don't select a skill just because its name matches a keyword
+- ❌ Don't skip the redundancy pass — conflicting skills create agent confusion
+
+## Common Pitfalls
+
+- **Problem:** Agent selects 20 skills but half are redundant  
+  **Solution:** Phase 3 redundancy elimination — keep the deepest skill per capability area
+
+- **Problem:** Security and observability always get missed  
+  **Solution:** Phase 1 surface map is mandatory — these areas must have explicit entries
+
+- **Problem:** Agent can't distinguish between 3 similar React skills  
+  **Solution:** Use `skill-quality-auditor` to score each, pick highest body-depth winner
+
+## Additional Resources
+
+- [AAS Core Guide](https://github.com/sickn33/agentic-awesome-skills/blob/v15.5.1/docs/users/aas-core.md)
+- [skill-quality-auditor](../skill-quality-auditor/SKILL.md) — score candidates before selection
+- [AAS MCP compose_stack](https://github.com/sickn33/agentic-awesome-skills) — validate final selection

--- a/skills/skill-apply-safe/SKILL.md
+++ b/skills/skill-apply-safe/SKILL.md
@@ -1,0 +1,288 @@
+---
+name: skill-apply-safe
+description: Safely apply AAS skills to a project with dry-run preview, staged rollout, and rollback. Use when applying skills from an aas-stack.json plan, or when skill application previously failed or left the project in a broken state.
+category: meta
+risk: unknown
+source: community
+source_type: community
+date_added: "2026-07-28"
+author: sickn33-contributor
+tags: [skill-apply, rollback, recovery, aas, safe-apply, staged]
+tools: [claude, codex, gemini, cursor, antigravity]
+---
+
+# Skill Apply Safe
+
+## Overview
+
+AAS Core's `apply` and `recovery` paths are explicitly experimental and outside
+the supported preview path (as of V15.5.1). The safe workflow ends at `aas stack plan`.
+
+But agents still need to **actually apply skills** — copy files, edit configs, install
+packages, scaffold patterns. Without a protocol, application is opaque and irreversible.
+
+This skill provides a **safe, staged, reversible apply protocol** that works on top
+of any AAS plan — adding the rollback, preview, and verification layer that
+Core currently doesn't provide.
+
+---
+
+## When to Use This Skill
+
+- Use when executing an `aas stack plan` output (applying a validated skill stack)
+- Use when a previous skill application broke the project
+- Use when applying multiple skills and ordering matters
+- Use when you need to apply skills to a team project (others will be affected)
+- Use to recover from a partial or failed skill application
+
+---
+
+## Safety Principles
+
+Before writing a single file:
+
+1. **Snapshot first** — always capture a restore point before any mutation
+2. **Dry-run by default** — preview what will change before changing it
+3. **One skill at a time** — never batch-apply; apply → verify → continue
+4. **Human checkpoint** — stop before irreversible steps (package installs, schema migrations)
+5. **Rollback must be tested** — know the restore path before the apply path
+
+---
+
+## Apply Protocol (4 Stages)
+
+### Stage 0: Pre-Flight Checks
+
+Before applying anything, verify:
+
+```bash
+# 1. Confirm clean working tree
+git status
+# Expected: nothing to commit, working tree clean
+# If dirty → stash or commit first
+
+# 2. Confirm current branch is not main/master
+git branch --show-current
+# If on main → create a feature branch first
+git checkout -b apply/aas-skill-stack
+
+# 3. Snapshot state
+git stash push -m "pre-aas-apply snapshot $(date +%Y%m%d-%H%M%S)"
+# OR
+git tag pre-aas-apply-$(date +%Y%m%d)
+
+# 4. Verify plan file exists and is valid
+cat aas-stack.json | jq '.skills | length'
+# Must return > 0
+```
+
+**Stop condition:** If git working tree is dirty AND stash fails → do not proceed.
+
+---
+
+### Stage 1: Dry-Run Preview
+
+For each skill in the plan, list what it would change **without changing it**:
+
+```
+Skill: react-patterns
+  Would add:    src/patterns/hooks.js
+  Would modify: src/App.js (add error boundary pattern)
+  Would add:    .eslintrc (react recommended rules)
+  Would NOT:    install packages (requires human approval)
+
+Skill: clerk-auth
+  Would add:    src/auth/ClerkProvider.jsx
+  Would modify: src/index.js (wrap with ClerkProvider)
+  Would add:    .env.example (CLERK_PUBLISHABLE_KEY placeholder)
+  Would install: @clerk/nextjs (REQUIRES HUMAN APPROVAL)
+```
+
+**Output format:** Print a full change manifest before proceeding.  
+**Human checkpoint:** Ask for approval before Stage 2.
+
+---
+
+### Stage 2: Staged Application (One Skill at a Time)
+
+Apply skills in dependency order:
+1. Config/tooling skills (linting, formatting, tsconfig)
+2. Core architecture skills (auth, database, state)
+3. Feature-layer skills (UI patterns, components)
+4. Testing/observability skills
+5. Deployment/infra skills
+
+For each skill:
+
+```bash
+# Apply one skill
+# (copy files, scaffold patterns per skill instructions)
+
+# Immediately verify
+npm run build 2>&1 | tail -20
+# OR
+python -m pytest --co -q 2>&1 | tail -10
+
+# If verify fails → rollback THIS skill only (not the whole stack)
+git diff --name-only HEAD
+git checkout HEAD -- <files changed by this skill>
+```
+
+**Stop condition:** If any skill application breaks the build → stop, rollback that skill, log the gap, continue with the next.
+
+---
+
+### Stage 3: Package Install Checkpoint
+
+Package installs are **irreversible** without lockfile surgery. Always require explicit approval:
+
+```
+⚠️  HUMAN CHECKPOINT — Package Installation Required
+
+The following packages will be installed:
+  @clerk/nextjs@^5.0.0
+  @tanstack/react-query@^5.0.0
+
+This will:
+  - Modify package.json
+  - Regenerate package-lock.json / yarn.lock
+  - Download ~45MB of dependencies
+
+Proceed? [y/N]
+```
+
+Only continue after explicit human confirmation.
+
+```bash
+# Install with exact versions (reproducible)
+npm install --save-exact @clerk/nextjs@5.0.0
+
+# Verify install didn't break anything
+npm run build
+npm test
+```
+
+---
+
+### Stage 4: Post-Apply Verification
+
+After all skills are applied:
+
+```bash
+# Full build
+npm run build
+
+# Full test suite
+npm test
+
+# Lint
+npm run lint
+
+# Type check (if TypeScript)
+npx tsc --noEmit
+
+# Git diff summary
+git diff --stat HEAD~1
+```
+
+Produce a verification report:
+
+| Check | Status | Notes |
+|-------|--------|-------|
+| Build | ✅/❌  | |
+| Tests | ✅/❌  | |
+| Lint  | ✅/❌  | |
+| Types | ✅/❌  | |
+
+**If any check fails:** do NOT merge to main. Roll back failing skills, document the gap.
+
+---
+
+## Rollback Procedures
+
+### Rollback a single skill
+```bash
+# Find files changed by that skill
+git diff --name-only HEAD~1 HEAD
+
+# Restore those files only
+git checkout HEAD~1 -- <file1> <file2>
+
+# Verify restore
+npm run build
+```
+
+### Rollback the entire apply session
+```bash
+# Return to pre-apply snapshot
+git checkout pre-aas-apply-<date>
+# OR
+git stash pop
+
+# Verify clean state
+npm run build && npm test
+```
+
+### Recovery from broken state
+```bash
+# Hard reset to last known good commit
+git log --oneline -10
+git reset --hard <last-good-commit-hash>
+
+# Verify
+git status
+npm run build
+```
+
+---
+
+## Examples
+
+### Example 1: Clean apply workflow
+```
+Stage 0: git status → clean ✅ | git tag pre-aas-apply-20260728 ✅
+Stage 1: Dry-run shows 12 file changes, 2 package installs → approved
+Stage 2: Applied 6 skills one-by-one, all builds pass
+Stage 3: Human approved 2 package installs → installed successfully
+Stage 4: Build ✅ | Tests 47/47 ✅ | Lint ✅ | Types ✅
+Result: Committed as apply/aas-skill-stack → PR opened
+```
+
+### Example 2: Recovery from failed apply
+```
+Problem: clerk-auth skill modified index.js, broke React tree
+Stage 2 verify: build failed with "ClerkProvider missing publishable key"
+Rollback: git checkout HEAD -- src/index.js
+Build restored ✅
+Resolution: Added CLERK_PUBLISHABLE_KEY to .env before re-applying
+```
+
+---
+
+## Best Practices
+
+- ✅ Always tag or stash before applying — git history is your safety net
+- ✅ Apply one skill at a time — never batch-apply without per-skill verification
+- ✅ Treat package installs as a human decision, not an automatic step
+- ✅ Keep the verification report — it's your audit trail
+- ❌ Don't apply directly to main — always use a branch
+- ❌ Don't skip dry-run — surprises at apply time are expensive
+- ❌ Don't assume a passing `aas stack plan` means safe to apply unattended
+
+## Common Pitfalls
+
+- **Problem:** Skill modifies a shared config file (e.g., `.eslintrc`) that two skills both need  
+  **Solution:** Apply config-touching skills first; later skills should extend, not replace
+
+- **Problem:** Package install pulls in a breaking major version  
+  **Solution:** Use `--save-exact` and pin versions; review changelog before installing
+
+- **Problem:** Apply session interrupted halfway through  
+  **Solution:** Use `git stash` before each skill; rollback to last successful stash on interrupt
+
+## Additional Resources
+
+- [AAS Core Guide — Preview Status](https://github.com/sickn33/agentic-awesome-skills/blob/v15.5.1/docs/users/aas-core.md)
+- [AAS CLI: aas stack plan](https://github.com/sickn33/agentic-awesome-skills)
+- [aas-skill-selector](../aas-skill-selector/SKILL.md) — select the right stack before applying
+- [skill-quality-auditor](../skill-quality-auditor/SKILL.md) — audit skills before applying

--- a/skills/skill-apply-safe/SKILL.md
+++ b/skills/skill-apply-safe/SKILL.md
@@ -118,14 +118,29 @@ For each skill:
 # Apply one skill
 # (copy files, scaffold patterns per skill instructions)
 
+# Track what was added (new untracked files) BEFORE applying
+# so we can clean them up if rollback is needed
+$BEFORE_FILES = git ls-files --others --exclude-standard
+
 # Immediately verify
-npm run build 2>&1 | tail -20
+npm run build 2>&1 | Select-Object -Last 20
 # OR
-python -m pytest --co -q 2>&1 | tail -10
+python -m pytest --co -q 2>&1 | Select-Object -Last 10
 
 # If verify fails → rollback THIS skill only (not the whole stack)
+# Step 1: restore modified tracked files
 git diff --name-only HEAD
-git checkout HEAD -- <files changed by this skill>
+git checkout HEAD -- <tracked files changed by this skill>
+
+# Step 2: remove newly added files (untracked — not in HEAD)
+# git checkout HEAD cannot restore these; delete them explicitly
+$AFTER_FILES = git ls-files --others --exclude-standard
+$NEW_FILES = Compare-Object $BEFORE_FILES $AFTER_FILES | Where-Object { $_.SideIndicator -eq '=>' } | Select-Object -ExpandProperty InputObject
+foreach ($f in $NEW_FILES) { Remove-Item $f -Force }
+
+# Step 3: verify rollback is clean
+git status  # should show nothing staged/unstaged from this skill
+npm run build  # should pass again
 ```
 
 **Stop condition:** If any skill application breaks the build → stop, rollback that skill, log the gap, continue with the next.
@@ -202,13 +217,17 @@ Produce a verification report:
 
 ### Rollback a single skill
 ```bash
-# Find files changed by that skill
+# Find tracked files changed by that skill
 git diff --name-only HEAD~1 HEAD
 
-# Restore those files only
+# Restore modified tracked files
 git checkout HEAD~1 -- <file1> <file2>
 
-# Verify restore
+# Remove any files that were ADDED (new) by that skill
+# These are not in HEAD~1 so checkout cannot restore them — delete explicitly
+git diff --name-only --diff-filter=A HEAD~1 HEAD | ForEach-Object { Remove-Item $_ -Force }
+
+# Verify full restore
 npm run build
 ```
 

--- a/skills/skill-quality-auditor/SKILL.md
+++ b/skills/skill-quality-auditor/SKILL.md
@@ -49,7 +49,7 @@ Check required fields exist and are not placeholder values:
 ✅ name        — slug-style, matches folder name
 ✅ description — one meaningful sentence (not "TODO" or blank)
 ✅ category    — valid category (development/security/testing/infra/etc.)
-✅ risk        — one of: safe | low | medium | high | critical
+✅ risk        — one of: none | safe | critical | offensive | unknown
 ✅ date_added  — valid ISO date
 ✅ tags        — at least 2 relevant tags
 ✅ tools       — at least one supported tool listed
@@ -173,7 +173,8 @@ Verdict: USE WITH CAUTION — verify React 19 hook patterns still apply
 Input: skills/deploy-helper/SKILL.md
 Result:
   Body Depth   ❌ — 8 lines, no examples
-  Safety       ❌ — risk: safe but body has: curl https://example.com | sh
+  Safety       ❌ — risk: safe but body pipes a remote download into sh
+                   (pattern: curl <url> piped to shell interpreter)
   Freshness    ❌ — date_added: 2023-01
 
 Verdict: DO NOT INSTALL

--- a/skills/skill-quality-auditor/SKILL.md
+++ b/skills/skill-quality-auditor/SKILL.md
@@ -1,0 +1,207 @@
+---
+name: skill-quality-auditor
+description: Audit any SKILL.md file for quality, completeness, and reliability. Use when reviewing community skills before installing, evaluating whether a skill is thin or outdated, or preparing a skill for contribution to agentic-awesome-skills.
+category: meta
+risk: safe
+source: community
+source_type: community
+date_added: "2026-07-28"
+author: sickn33-contributor
+tags: [skill-review, quality, audit, aas, meta]
+tools: [claude, codex, gemini, cursor, antigravity]
+---
+
+# Skill Quality Auditor
+
+## Overview
+
+The AAS catalog has 2,000+ community skills — quality varies widely. Some are excellent,
+battle-tested playbooks. Others are thin stubs, outdated, or outright wrong.
+
+This skill gives the agent a structured rubric to **audit any SKILL.md before trusting it**,
+so you don't install and rely on a bad skill without knowing it.
+
+Use it when:
+- Evaluating a community skill before installing
+- Reviewing a skill PR before merging
+- Spot-checking skills in your local catalog
+- Validating your own skill before contributing
+
+---
+
+## When to Use This Skill
+
+- Use when you find a skill and want to know if it's trustworthy
+- Use when a skill produces wrong or inconsistent agent behavior
+- Use before accepting a skill PR contribution
+- Use when a skill hasn't been updated in 6+ months
+- Use when the skill description and body don't match what it actually does
+
+---
+
+## Audit Rubric (7 Dimensions)
+
+Run each dimension. Score: ✅ Pass / ⚠️ Warn / ❌ Fail.
+
+### 1. Frontmatter Completeness
+Check required fields exist and are not placeholder values:
+```
+✅ name        — slug-style, matches folder name
+✅ description — one meaningful sentence (not "TODO" or blank)
+✅ category    — valid category (development/security/testing/infra/etc.)
+✅ risk        — one of: safe | low | medium | high | critical
+✅ date_added  — valid ISO date
+✅ tags        — at least 2 relevant tags
+✅ tools       — at least one supported tool listed
+```
+Flag: missing fields, generic descriptions like "helps with coding", stale dates (>18 months).
+
+### 2. Trigger Precision
+Read the `description` field. Ask:
+- Does it say **when** to invoke the skill?
+- Would an agent reading 20 skills pick this one for the right task?
+- Does it avoid being so broad it fires on everything?
+
+```
+✅ Good: "Audit REST API endpoints for OWASP Top 10 vulnerabilities"
+❌ Bad:  "Helps with APIs"
+❌ Bad:  "A skill for developers"
+```
+
+### 3. Body Depth Gate
+The SKILL.md body must have more than a title and a paragraph. Check for:
+```
+✅ Concrete steps or workflow (not just aspirational text)
+✅ At least one example (code block, command, or sample output)
+✅ At least one best practice or pitfall
+✅ Clear success condition — agent knows when it's done
+❌ Warn if body < 40 lines
+❌ Fail if no examples at all
+❌ Fail if body is only marketing text with no actionable instructions
+```
+
+### 4. Safety & Risk Alignment
+If the skill involves:
+- Shell commands → must document failure modes and reversibility
+- Network calls → must specify what data leaves the machine
+- Credential access → must have explicit credential handling guidance
+- File mutations → must specify backup or dry-run option
+
+```
+✅ risk: safe   → zero shell, zero network, zero mutations
+✅ risk: medium → documents what it does, rollback exists
+❌ Fail if risk: safe but body contains rm -rf, curl piped to sh, etc.
+```
+
+### 5. Freshness
+```
+✅ date_added within 12 months         → likely current
+⚠️ date_added 12–24 months ago        → check tool API compatibility
+❌ date_added > 24 months              → assume outdated unless verified
+❌ references deprecated APIs or tools → fail immediately
+```
+Check body for: version-pinned commands, deprecated flags, sunset services.
+
+### 6. Tool Compatibility
+`tools:` field must list agents the skill was actually tested with.
+```
+✅ tools: [claude, gemini] tested and working
+⚠️ tools: [claude] — may not work on Codex or Cursor
+❌ tools: [] or missing — unknown compatibility, use with caution
+```
+
+### 7. Uniqueness
+Search the catalog for 3 similar skills. If near-duplicates exist:
+```
+✅ This skill has distinct scope or depth
+⚠️ Overlaps with another skill — note the better one
+❌ This skill is a shallow copy of a better existing skill — recommend removing
+```
+
+---
+
+## How to Run the Audit
+
+### Step 1: Load the skill
+```bash
+cat skills/<skill-name>/SKILL.md
+```
+
+### Step 2: Score each dimension
+Fill in the table:
+
+| Dimension             | Score | Notes |
+|-----------------------|-------|-------|
+| Frontmatter           | ✅/⚠️/❌ | |
+| Trigger Precision     | ✅/⚠️/❌ | |
+| Body Depth            | ✅/⚠️/❌ | |
+| Safety Alignment      | ✅/⚠️/❌ | |
+| Freshness             | ✅/⚠️/❌ | |
+| Tool Compatibility    | ✅/⚠️/❌ | |
+| Uniqueness            | ✅/⚠️/❌ | |
+
+### Step 3: Issue verdict
+
+| Outcome | Criteria |
+|---------|----------|
+| **TRUST** | 6–7 ✅, zero ❌ |
+| **USE WITH CAUTION** | 4–5 ✅, at most 2 ⚠️ |
+| **DO NOT INSTALL** | Any ❌ in Safety, or 3+ ❌ total |
+| **NEEDS UPDATE** | Freshness ❌ or ⚠️ with otherwise passing skill |
+
+---
+
+## Examples
+
+### Example 1: Auditing a community skill
+```
+Input: skills/react-patterns/SKILL.md
+Result:
+  Frontmatter      ✅ — all fields present
+  Trigger          ✅ — clear description
+  Body Depth       ✅ — 120 lines, 4 examples
+  Safety           ✅ — risk: safe, no mutations
+  Freshness        ⚠️ — date_added: 2024-01 (18 months ago), check hooks API
+  Compatibility    ✅ — tools: [claude, cursor]
+  Uniqueness       ⚠️ — overlaps with react-best-practices, but more depth here
+
+Verdict: USE WITH CAUTION — verify React 19 hook patterns still apply
+```
+
+### Example 2: Flagging a bad skill
+```
+Input: skills/deploy-helper/SKILL.md
+Result:
+  Body Depth   ❌ — 8 lines, no examples
+  Safety       ❌ — risk: safe but body has: curl https://example.com | sh
+  Freshness    ❌ — date_added: 2023-01
+
+Verdict: DO NOT INSTALL
+```
+
+---
+
+## Best Practices
+
+- ✅ Always audit before using a community skill in production agent workflows
+- ✅ Re-audit after 6 months — APIs and tools change
+- ✅ If a skill partially passes, fork and update it rather than discarding
+- ❌ Don't trust star count or PR merges as a quality signal
+- ❌ Don't skip the safety dimension even for "safe" skills
+
+## Common Pitfalls
+
+- **Problem:** Skill looks complete but description is too vague to trigger reliably  
+  **Solution:** Rewrite description to name the exact scenario, tool, and outcome
+
+- **Problem:** Skill was written for Claude 2 and uses outdated prompting patterns  
+  **Solution:** Check tool version in frontmatter; test on your current agent version
+
+- **Problem:** Two skills in catalog do the same thing  
+  **Solution:** Keep the one with higher body depth score; file a deprecation PR for the other
+
+## Additional Resources
+
+- [AAS Contributing Guide](https://github.com/sickn33/agentic-awesome-skills/blob/main/CONTRIBUTING.md)
+- [AAS Skill Template](https://github.com/sickn33/agentic-awesome-skills/blob/main/docs/contributors/skill-template.md)
+- [skill-audit skill](https://github.com/sickn33/agentic-awesome-skills/tree/main/skills/skill-audit)


### PR DESCRIPTION
## Summary

This PR adds 4 community meta-skills that directly address known limitations of AAS Core, forming a coherent meta-layer on top of the existing catalog.

---

## Skills Added

### 1. \skill-quality-auditor\
**Addresses:** Quality varies across 2,000+ community skills

A 7-dimension audit rubric agents can use to evaluate any SKILL.md before trusting or installing it:
- Frontmatter completeness
- Trigger precision  
- Body depth gate
- Safety & risk alignment
- Freshness check
- Tool compatibility
- Uniqueness / redundancy detection

Produces a TRUST / USE WITH CAUTION / DO NOT INSTALL / NEEDS UPDATE verdict.

---

### 2. \as-skill-selector\
**Addresses:** AAS Core does not rank or recommend — agent judgment is the quality gate

A 5-phase structured selection protocol:
1. Full project surface mapping (architecture → domain → quality → security → delivery → UX → maintenance)
2. Per-area catalog search with multi-candidate comparison
3. Redundancy elimination
4. Coverage ledger (every surface area must have an entry or a documented gap)
5. Selection evidence output (feeds into \as-selection-evidence.json\)

---

### 3. \skill-apply-safe\
**Addresses:** Apply and recovery are experimental and outside the supported preview path

A 4-stage safe apply protocol that works on top of any \as stack plan\ output:
- Stage 0: Pre-flight checks (clean working tree, branch, snapshot/tag)
- Stage 1: Dry-run change manifest with human approval checkpoint
- Stage 2: One-skill-at-a-time staged application with per-skill verification + rollback
- Stage 3: Human checkpoint for package installs (irreversible)
- Stage 4: Full post-apply verification report

Includes rollback procedures for single skill, full session, and broken state recovery.

---

### 4. \as-lightweight\
**Addresses:** Full AAS Core infrastructure is overkill for small/simple tasks

3 zero-setup usage paths:
- **Browse & Copy** — fetch raw SKILL.md from GitHub, paste into agent context
- **Micro-stack** — 1–3 skills via curl, no npm or MCP needed
- **Inline mode** — distill a skill to its 5–10 key rules for constrained environments

Also includes a quick-reference table (12 common tasks → recommended skill) and a clear upgrade guide for when to move to AAS Core.

---

## Validation

\\\
npm run validate
✨ All skills passed validation!
\\\

## Skills Cross-Reference

The 4 skills form a coherent workflow:
\\\
skill-quality-auditor → aas-skill-selector → skill-apply-safe
        ↑                       ↑
        └──── aas-lightweight ──┘
          (entry point for quick/simple tasks)
\\\

## Checklist
- [x] Skills follow the canonical template structure
- [x] All frontmatter fields present (name, description, category, risk, source, date_added, author, tags, tools)
- [x] \
pm run validate\ passes with zero errors
- [x] No generated registry artifacts included (CATALOG.md, skills_index.json, data/*.json)
- [x] Allow edits from maintainers enabled