### PR TITLE
fix: allow verified upstream repository renames

### DIFF
--- a/docs/maintainers/merge-batch.md
+++ b/docs/maintainers/merge-batch.md
@@ -42,6 +42,7 @@ Use `--dry-run` to exercise local classification without approving a run or merg
 - fetch the exact base/head objects and classify the complete raw Git diff
 - recompute changed-skill evidence with evaluator code materialized from the trusted `main` commit
 - reject incomplete evidence coverage, deterministic quality/security/provenance regressions, and base/head drift
+- allow only exact `source_repo` transitions recorded in the trusted protected-base provenance exception ledger; unrecorded or malformed transitions still fail closed
 - for external PRs, poll for asynchronously-created fork runs and approve only runs waiting on `action_required` when every path, mode, object, size, and workflow identity is allowlisted
 - for sensitive same-repository source changes, allow the guarded exception only when the PR author is the repository owner and the exact full head SHA is attested; collaborator-authored sensitive changes fail closed under the external safety policy
 - wait for the latest required checks bound to the exact head SHA

--- a/docs/maintainers/pr-autonomy.md
+++ b/docs/maintainers/pr-autonomy.md
@@ -62,7 +62,7 @@ A successful `manual-review-required` check means only that the requirement was 
 4. for external PRs, rejects unsafe paths, modes, symlinks, gitlinks, executable files, unknown types, oversized blobs, incomplete metadata, or non-allowlisted workflows;
 5. verifies workflow event, workflow identity, pull-request number, and head SHA;
 6. recomputes changed-skill evidence over the exact merge-base-to-head record set and requires one-to-one coverage of every skill-content Git record;
-7. rejects operational errors, malformed evidence, incomplete snapshots, score-component regressions, provenance identity regressions, or any other deterministic blocker;
+7. rejects operational errors, malformed evidence, incomplete snapshots, score-component regressions, provenance identity regressions, or any other deterministic blocker; an exact `source_repo` rename may pass only when the trusted protected-base ledger records the skill, old slug, new slug, upstream repository ID, verification date, and canonical GitHub URL;
 8. re-reads both pull-request base and head before and after approval and immediately before merge.
 
 A real merge also requires effective server-side protection for `main`: the four exact GitHub-Actions-owned checks (`pr-policy`, `pr-evidence`, `source-validation`, and `artifact-preview`), strict up-to-date enforcement, pull-request-only changes, administrator enforcement, no applicable ruleset bypass actors, and no merge queue. If that enforcement cannot be proven, `merge:batch` refuses non-dry-run operation. `merge:batch` does not retry base drift automatically or reuse stale evidence; the batch must be rerun from the new tuple. Pre-existing auto-merge state is rejected, and the immediate GitHub merge endpoint must return `merged: true` before post-merge work begins.
@@ -96,7 +96,7 @@ Each phase requires evidence from the previous phase before activation:
 3. Keep `main` protected by stable app-bound checks and remove any newly introduced direct writer.
 4. Add schema-validated fork-safe semantic review whose privileged code always comes from the protected base.
 5. Build deterministic release-candidate pull requests with rendering separated from publication.
-6. Add immutable upstream commit/path/hash provenance and a delta-based exception ledger.
+6. Expand immutable upstream commit/path/hash provenance. The first narrow delta exception ledger now covers maintainer-verified `source_repo` renames only; broader provenance exceptions remain out of scope.
 7. Consider auto-merge only for empirically proven documentation or metadata classes. New skills, security-sensitive content, workflows, installers, releases, provenance exceptions, and policy changes remain human decisions.
 
 Merge queue is not part of the current plan. The repository is personally owned, and its workflows do not currently support a `merge_group` event.

--- a/docs/maintainers/provenance-identity-exceptions.json
+++ b/docs/maintainers/provenance-identity-exceptions.json
@@ -1,0 +1,14 @@
+{
+  "schema_version": 1,
+  "exceptions": [
+    {
+      "skill_id": "modellix",
+      "field": "source_repo",
+      "before": "Modellix/modellix-skill",
+      "after": "Modellix/modellix-plugin",
+      "upstream_repository_id": 1150322983,
+      "verified_at": "2026-07-28",
+      "evidence_url": "https://github.com/Modellix/modellix-plugin"
+    }
+  ]
+}

--- a/skills/antigravity-maintainer-batch-release/SKILL.md
+++ b/skills/antigravity-maintainer-batch-release/SKILL.md
@@ -47,6 +47,7 @@ Before changing anything:
    - `manual-review-required` means Tessl credentials or credits were unavailable, or Tessl did not produce a passing result. Perform the maintainer semantic review and attest with `--reviewed-head <full-40-character-sha>`.
    - Any non-passing Tessl outcome produces `manual-review-required`; complete the semantic review and bind the judgment to the exact head instead of treating a heuristic score as merge authority.
    - Never report `manual-review-required` as “Tessl passed.”
+   - A verified upstream repository rename may bypass the provenance-identity blocker only through an exact entry in the trusted protected-base exception ledger. Record the skill ID, old and new `source_repo`, stable upstream repository ID, verification date, and canonical GitHub URL; all other provenance changes remain blocked.
 
 3. Run checks in parallel where independent.
    - Use the repository validation, test, docs-security, source-credit, reference, warning-budget, and targeted app checks required by the changed files.

--- a/tools/scripts/changed_skill_evidence.py
+++ b/tools/scripts/changed_skill_evidence.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import re
 import tempfile
 from collections import Counter, defaultdict
 from pathlib import Path
@@ -16,13 +17,92 @@ from check_readme_credits import (
     normalize_repo_slug,
     parse_frontmatter,
 )
-from git_change_records import ChangeRecord, list_tree, materialize_tree, read_change_records, read_path
+from git_change_records import (
+    ChangeRecord,
+    list_tree,
+    materialize_tree,
+    read_change_records,
+    read_path,
+    resolve_commit,
+)
 from security_scanner import scan_skill_file
 
 
 SCHEMA_VERSION = 1
 RISK_RANK = {"unknown": -1, "none": 0, "safe": 1, "critical": 2, "offensive": 3}
 SEVERITY_RANK = {"info": 0, "warning": 1, "error": 2}
+PROVENANCE_EXCEPTION_PATH = "docs/maintainers/provenance-identity-exceptions.json"
+DATE_PATTERN = re.compile(r"\d{4}-\d{2}-\d{2}")
+
+
+def load_provenance_exceptions(
+    repo: Path,
+    policy_ref: str,
+) -> tuple[str, set[tuple[str, str, str, str]]]:
+    """Load exact, maintainer-reviewed provenance transitions from trusted policy."""
+    policy_oid = resolve_commit(repo, policy_ref)
+    payload = read_path(repo, policy_oid, PROVENANCE_EXCEPTION_PATH)
+    if payload is None:
+        return policy_oid, set()
+    try:
+        document = json.loads(payload.decode("utf-8"))
+    except (UnicodeDecodeError, json.JSONDecodeError) as error:
+        raise ValueError(f"Invalid {PROVENANCE_EXCEPTION_PATH}: {error}") from error
+    if not isinstance(document, dict) or document.get("schema_version") != 1:
+        raise ValueError(f"Invalid {PROVENANCE_EXCEPTION_PATH}: schema_version must be 1")
+    entries = document.get("exceptions")
+    if not isinstance(entries, list):
+        raise ValueError(f"Invalid {PROVENANCE_EXCEPTION_PATH}: exceptions must be a list")
+
+    allowed: set[tuple[str, str, str, str]] = set()
+    required_fields = {
+        "skill_id",
+        "field",
+        "before",
+        "after",
+        "upstream_repository_id",
+        "verified_at",
+        "evidence_url",
+    }
+    for index, entry in enumerate(entries):
+        if not isinstance(entry, dict) or set(entry) != required_fields:
+            raise ValueError(
+                f"Invalid {PROVENANCE_EXCEPTION_PATH}: exception {index} has unexpected fields"
+            )
+        skill_id = entry["skill_id"]
+        field = entry["field"]
+        before = normalize_repo_slug(entry["before"])
+        after = normalize_repo_slug(entry["after"])
+        repository_id = entry["upstream_repository_id"]
+        verified_at = entry["verified_at"]
+        evidence_url = entry["evidence_url"]
+        if not isinstance(skill_id, str) or not skill_id or "/" in skill_id:
+            raise ValueError(f"Invalid {PROVENANCE_EXCEPTION_PATH}: exception {index} skill_id")
+        if field != "source_repo":
+            raise ValueError(f"Invalid {PROVENANCE_EXCEPTION_PATH}: exception {index} field")
+        if (
+            not isinstance(before, str)
+            or not SOURCE_REPO_PATTERN.fullmatch(before)
+            or not isinstance(after, str)
+            or not SOURCE_REPO_PATTERN.fullmatch(after)
+            or before == after
+        ):
+            raise ValueError(f"Invalid {PROVENANCE_EXCEPTION_PATH}: exception {index} transition")
+        if not isinstance(repository_id, int) or isinstance(repository_id, bool) or repository_id <= 0:
+            raise ValueError(f"Invalid {PROVENANCE_EXCEPTION_PATH}: exception {index} repository id")
+        if not isinstance(verified_at, str) or not DATE_PATTERN.fullmatch(verified_at):
+            raise ValueError(f"Invalid {PROVENANCE_EXCEPTION_PATH}: exception {index} verified_at")
+        if (
+            not isinstance(evidence_url, str)
+            or not evidence_url.startswith("https://github.com/")
+            or normalize_repo_slug(evidence_url) != after
+        ):
+            raise ValueError(f"Invalid {PROVENANCE_EXCEPTION_PATH}: exception {index} evidence_url")
+        transition = (skill_id, field, before, after)
+        if transition in allowed:
+            raise ValueError(f"Invalid {PROVENANCE_EXCEPTION_PATH}: duplicate exception {index}")
+        allowed.add(transition)
+    return policy_oid, allowed
 
 
 def canonical_skill_roots(repo: Path, commit_oid: str) -> set[str]:
@@ -264,14 +344,16 @@ def provenance_reasons(
     before: dict[str, object] | None,
     after: dict[str, object] | None,
     readme_credits: dict[str, set[str]],
-) -> list[str]:
+    provenance_exceptions: set[tuple[str, str, str, str]],
+) -> tuple[list[str], list[str]]:
     if change_type == "deleted" or after is None:
-        return []
+        return [], []
     provenance = after["provenance"]
     source = provenance.get("source")
     source_type = provenance.get("source_type")
     source_repo = provenance.get("source_repo")
     reasons: list[str] = []
+    applied_exceptions: list[str] = []
     source_is_self = isinstance(source, str) and source.strip().lower() == "self"
     before_provenance = before.get("provenance") if before else None
     before_source = before_provenance.get("source") if before_provenance else None
@@ -282,8 +364,22 @@ def provenance_reasons(
     if change_type in {"modified", "renamed"} and before_provenance:
         if not before_is_self or not source_is_self:
             for field in ("source", "source_type", "source_repo"):
-                if before_provenance.get(field) != provenance.get(field):
-                    reasons.append(f"{skill_id}:provenance_identity_changed:{field}")
+                before_value = before_provenance.get(field)
+                after_value = provenance.get(field)
+                if before_value != after_value:
+                    transition = (
+                        (skill_id, field, before_value, after_value)
+                        if field == "source_repo"
+                        and isinstance(before_value, str)
+                        and isinstance(after_value, str)
+                        else None
+                    )
+                    if transition is not None and transition in provenance_exceptions:
+                        applied_exceptions.append(
+                            f"{skill_id}:{field}:{before_value}->{after_value}"
+                        )
+                    else:
+                        reasons.append(f"{skill_id}:provenance_identity_changed:{field}")
 
     needs_full_validation = change_type in {"added", "copied"} or (
         before_provenance is not None and before_is_self and not source_is_self
@@ -297,7 +393,7 @@ def provenance_reasons(
             reasons.append(
                 f"{skill_id}:new_external_skill_missing_readme_credit:{source_type}:{source_repo}"
             )
-    return reasons
+    return reasons, applied_exceptions
 
 
 def _unsafe_counter(entries: list[dict[str, str]], skill_id: str | None) -> Counter[tuple[str, str, str]]:
@@ -312,15 +408,24 @@ def _unsafe_counter(entries: list[dict[str, str]], skill_id: str | None) -> Coun
     )
 
 
-def build_report(repo: str | Path, base_ref: str, head_ref: str) -> dict[str, object]:
+def build_report(
+    repo: str | Path,
+    base_ref: str,
+    head_ref: str,
+    policy_ref: str | None = None,
+) -> dict[str, object]:
     root = Path(repo)
     base_oid, head_oid, records = read_change_records(root, base_ref, head_ref, merge_base=True)
+    policy_oid, provenance_exceptions = load_provenance_exceptions(
+        root, policy_ref or base_ref
+    )
     old_roots = canonical_skill_roots(root, base_oid)
     new_roots = canonical_skill_roots(root, head_oid)
     readme_bytes = read_path(root, head_oid, "README.md") or b""
     readme_credits = extract_credit_repos(readme_bytes.decode("utf-8", "replace"))
     changes: list[dict[str, object]] = []
     all_reasons: list[str] = []
+    all_applied_exceptions: list[str] = []
 
     with tempfile.TemporaryDirectory(prefix="changed-skill-evidence-") as temporary:
         temp_root = Path(temporary)
@@ -375,17 +480,18 @@ def build_report(repo: str | Path, base_ref: str, head_ref: str) -> dict[str, ob
                         )
             comparison_before = None if change_type in {"added", "copied"} else before
             reasons.extend(regression_reasons(effective_id, change_type, comparison_before, after))
-            reasons.extend(
-                provenance_reasons(
-                    effective_id,
-                    change_type,
-                    comparison_before,
-                    after,
-                    readme_credits,
-                )
+            provenance_blockers, applied_exceptions = provenance_reasons(
+                effective_id,
+                change_type,
+                comparison_before,
+                after,
+                readme_credits,
+                provenance_exceptions,
             )
+            reasons.extend(provenance_blockers)
             reasons = sorted(set(reasons))
             all_reasons.extend(reasons)
+            all_applied_exceptions.extend(applied_exceptions)
             changes.append(
                 {
                     "change_type": change_type,
@@ -397,6 +503,7 @@ def build_report(repo: str | Path, base_ref: str, head_ref: str) -> dict[str, ob
                     "unsafe_entries": {"before": before_unsafe, "after": after_unsafe},
                     "blocking": bool(reasons),
                     "reasons": reasons,
+                    "provenance_exceptions_applied": sorted(applied_exceptions),
                 }
             )
 
@@ -408,9 +515,11 @@ def build_report(repo: str | Path, base_ref: str, head_ref: str) -> dict[str, ob
         "head_ref": head_ref,
         "base_oid": base_oid,
         "head_oid": head_oid,
+        "policy_oid": policy_oid,
         "changes": changes,
         "blocking": bool(reasons),
         "reasons": reasons,
+        "provenance_exceptions_applied": sorted(set(all_applied_exceptions)),
     }
 
 
@@ -422,6 +531,10 @@ def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(description="Build changed-skill before/after evidence.")
     parser.add_argument("--base", required=True)
     parser.add_argument("--head", required=True)
+    parser.add_argument(
+        "--policy-ref",
+        help="Trusted policy commit containing provenance exception records (defaults to --base).",
+    )
     parser.add_argument("--output", required=True, type=Path)
     parser.add_argument(
         "--repo",
@@ -435,7 +548,7 @@ def parse_args() -> argparse.Namespace:
 def main() -> int:
     args = parse_args()
     root = args.repo.resolve() if args.repo else find_repo_root(__file__)
-    report = build_report(root, args.base, args.head)
+    report = build_report(root, args.base, args.head, policy_ref=args.policy_ref)
     payload = stable_json(report)
     args.output.parent.mkdir(parents=True, exist_ok=True)
     args.output.write_text(payload, encoding="utf-8")

--- a/tools/scripts/merge_batch.cjs
+++ b/tools/scripts/merge_batch.cjs
@@ -348,6 +348,8 @@ function recomputeChangedSkillEvidence(
         mergeBaseOid,
         "--head",
         headOid,
+        "--policy-ref",
+        evaluatorOid,
         "--output",
         outputPath,
       ],

--- a/tools/scripts/tests/test_changed_skill_evidence.py
+++ b/tools/scripts/tests/test_changed_skill_evidence.py
@@ -432,6 +432,81 @@ class ChangedSkillEvidenceTests(unittest.TestCase):
         self.assertIn("external:provenance_identity_changed:source_type", report["reasons"])
         self.assertIn("external:provenance_identity_changed:source_repo", report["reasons"])
 
+    def test_exact_trusted_repo_rename_exception_allows_only_recorded_transition(self):
+        root, _ = init_repo(with_skill=False)
+        path = write_skill(
+            root,
+            "external",
+            source="community",
+            source_type="community",
+            source_repo="owner/old-name",
+        )
+        git(root, "add", ".")
+        git(root, "commit", "-m", "external base")
+        base = git(root, "rev-parse", "HEAD")
+        path.write_text(
+            path.read_text(encoding="utf-8").replace(
+                "source_repo: owner/old-name", "source_repo: owner/new-name"
+            ),
+            encoding="utf-8",
+        )
+        git(root, "add", ".")
+        git(root, "commit", "-m", "rename upstream")
+        head = git(root, "rev-parse", "HEAD")
+
+        blocked = changed_skill_evidence.build_report(root, base, head)
+        self.assertIn("external:provenance_identity_changed:source_repo", blocked["reasons"])
+
+        ledger = root / changed_skill_evidence.PROVENANCE_EXCEPTION_PATH
+        ledger.parent.mkdir(parents=True)
+        ledger.write_text(
+            json.dumps(
+                {
+                    "schema_version": 1,
+                    "exceptions": [
+                        {
+                            "skill_id": "external",
+                            "field": "source_repo",
+                            "before": "owner/old-name",
+                            "after": "owner/new-name",
+                            "upstream_repository_id": 12345,
+                            "verified_at": "2026-07-28",
+                            "evidence_url": "https://github.com/owner/new-name",
+                        }
+                    ],
+                }
+            ),
+            encoding="utf-8",
+        )
+        git(root, "add", ".")
+        git(root, "commit", "-m", "trusted rename policy")
+        policy = git(root, "rev-parse", "HEAD")
+
+        allowed = changed_skill_evidence.build_report(
+            root, base, head, policy_ref=policy
+        )
+        self.assertFalse(allowed["blocking"])
+        self.assertEqual(
+            allowed["provenance_exceptions_applied"],
+            ["external:source_repo:owner/old-name->owner/new-name"],
+        )
+
+        path.write_text(
+            path.read_text(encoding="utf-8").replace(
+                "source_repo: owner/new-name", "source_repo: owner/other-name"
+            ),
+            encoding="utf-8",
+        )
+        git(root, "add", ".")
+        git(root, "commit", "-m", "unrecorded rename")
+        unrecorded_head = git(root, "rev-parse", "HEAD")
+        unrecorded = changed_skill_evidence.build_report(
+            root, base, unrecorded_head, policy_ref=policy
+        )
+        self.assertIn(
+            "external:provenance_identity_changed:source_repo", unrecorded["reasons"]
+        )
+
     def test_declared_risk_downgrade_blocks(self):
         before = {
             "audit": {"findings": {}},

--- a/walkthrough.md
+++ b/walkthrough.md
@@ -1,3 +1,7 @@
+# Maintenance Walkthrough - 2026-07-28
+
+- Added a fail-closed provenance exception ledger for maintainer-verified upstream repository renames. The initial Modellix entry records that `Modellix/modellix-skill` and `Modellix/modellix-plugin` resolve to GitHub repository ID `1150322983`; only the exact recorded transition is allowed, while unrelated provenance changes remain blocked.
+
 # Maintenance Walkthrough - 2026-07-26
 
 - Imported the MIT-licensed `fedora-hyprland-installer` contribution from


### PR DESCRIPTION
## Summary

- add a trusted, fail-closed ledger for exact maintainer-verified `source_repo` renames
- record the Modellix rename using stable GitHub repository ID `1150322983`
- bind `merge:batch` evidence to the protected-base policy commit
- keep every unrecorded or malformed provenance transition blocked
- update maintainer policy, canonical maintainer skill, tests, and walkthrough

## Verification

- `npm run chain`
- `npm run validate:references`
- `npm run check:warning-budget`
- `npm run security:docs`
- `npm test` (102 local test files)
- exact #1009 evidence recomputation: `blocking: false`, one recorded exception applied

## Quality Bar Checklist ✅

- [x] Current protected-base instructions were re-read
- [x] Workflow policy, maintainer docs, canonical skill, and regression tests change together
- [x] Unrecorded provenance changes remain fail-closed
- [x] Generated registries and plugin mirrors are excluded
- [x] Maintainer edits are allowed
