### PR TITLE
fix: update Supabase client to 2.111.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Updated the catalog web app from `@supabase/supabase-js` 2.110.0 to 2.111.0, including the auth fix for overlapping PKCE flows, while preserving platform-specific native package metadata in the lockfile.
+
+### Validation
+
+- Passed the repository test suite, web-app tests and production build, dependency audit, skill/reference validation, documentation security, and warning-budget checks.
+
 ## [15.6.0] - 2026-07-28 - "Browser Automation and Performance RCA"
 
 > Added safety-hardened browser automation and evidence-first performance troubleshooting while preserving verified upstream provenance across the catalog.

--- a/apps/web-app/package-lock.json
+++ b/apps/web-app/package-lock.json
@@ -11,7 +11,7 @@
         "@fontsource/jetbrains-mono": "^5.2.8",
         "@fontsource/outfit": "^5.2.8",
         "@phosphor-icons/react": "^2.1.10",
-        "@supabase/supabase-js": "^2.110.0",
+        "@supabase/supabase-js": "^2.111.0",
         "github-markdown-css": "^5.9.0",
         "highlight.js": "^11.11.1",
         "react": "^19.2.7",
@@ -1092,9 +1092,9 @@
       "license": "MIT"
     },
     "node_modules/@supabase/auth-js": {
-      "version": "2.110.0",
-      "resolved": "https://registry.npmjs.org/@supabase/auth-js/-/auth-js-2.110.0.tgz",
-      "integrity": "sha512-Mi288WCTp6wxMFCOu/UgzgHEXODjdl2uVTLqK11eanzGZaldU3RyP8Am+ZbNuVzFP+5+iOvppxzv7N5Ym84xTg==",
+      "version": "2.111.0",
+      "resolved": "https://registry.npmjs.org/@supabase/auth-js/-/auth-js-2.111.0.tgz",
+      "integrity": "sha512-hbRLgyQZEX0SDyF4LYXpv94qOIQyFATfpT5SIs2V0SisHnisVRkYgiPQWzv80l4S2mO3qof78rmoH9j5zoFsYQ==",
       "license": "MIT",
       "dependencies": {
         "tslib": "2.8.1"
@@ -1104,9 +1104,9 @@
       }
     },
     "node_modules/@supabase/functions-js": {
-      "version": "2.110.0",
-      "resolved": "https://registry.npmjs.org/@supabase/functions-js/-/functions-js-2.110.0.tgz",
-      "integrity": "sha512-Fde5wlY8ZZy+9yqrWlQHo8MacSyUBArBEtN2boB4thJQigPnQD/cc61qZN0n3I1L0gwhWtHYwIMnOBKxSvF6Hw==",
+      "version": "2.111.0",
+      "resolved": "https://registry.npmjs.org/@supabase/functions-js/-/functions-js-2.111.0.tgz",
+      "integrity": "sha512-RW/OCsd6MO592zU8ifzP8/f8XzxxIdpb+Up5XaOtE26Fw+3zTp475WX7+GuuktiD1WF8pFUDe6khUPbMp77RCw==",
       "license": "MIT",
       "dependencies": {
         "tslib": "2.8.1"
@@ -1116,15 +1116,15 @@
       }
     },
     "node_modules/@supabase/phoenix": {
-      "version": "0.4.4",
-      "resolved": "https://registry.npmjs.org/@supabase/phoenix/-/phoenix-0.4.4.tgz",
-      "integrity": "sha512-Gt0pqoXuIqX/8dvG0OKp/wMCobXNH3klNbUPBNyOfN0YA1IswrM3HyWFMOPk1Jy+BRaIyDPcFx4jLBwHNmlyfQ==",
+      "version": "0.4.5",
+      "resolved": "https://registry.npmjs.org/@supabase/phoenix/-/phoenix-0.4.5.tgz",
+      "integrity": "sha512-aAn9H9ovVyeApKy11OWOrrOGq8DV68yWeH4ud2lN9fzn4aO8Zb5GLL9m1pUg9nLqIcT+ZDfAcsZe0E/nqdv2lw==",
       "license": "MIT"
     },
     "node_modules/@supabase/postgrest-js": {
-      "version": "2.110.0",
-      "resolved": "https://registry.npmjs.org/@supabase/postgrest-js/-/postgrest-js-2.110.0.tgz",
-      "integrity": "sha512-ZbC1QZL3jcvBUfVKjJbgRM27G4Mg3Zzqdm44m5pJafe1e52Cli793EOnwQucomBAGEUDd03Nzaf7XV3ji/XexQ==",
+      "version": "2.111.0",
+      "resolved": "https://registry.npmjs.org/@supabase/postgrest-js/-/postgrest-js-2.111.0.tgz",
+      "integrity": "sha512-pcqeDsnWP0lx9GawduYxNZJHeuTm53O7L0SC8RF8tniV3GWIPY6me6OTdnwzdwNUmNy1dzUVtSyIfE6+OflzPQ==",
       "license": "MIT",
       "dependencies": {
         "tslib": "2.8.1"
@@ -1134,12 +1134,12 @@
       }
     },
     "node_modules/@supabase/realtime-js": {
-      "version": "2.110.0",
-      "resolved": "https://registry.npmjs.org/@supabase/realtime-js/-/realtime-js-2.110.0.tgz",
-      "integrity": "sha512-Wn2AWpneZuDFTkp/65tqctvoh+3JvyTjMam8sTMqVWy5BgkU8zAvFwilPYPPPhkINeKF8NAJKP7FclJ2iGCUMw==",
+      "version": "2.111.0",
+      "resolved": "https://registry.npmjs.org/@supabase/realtime-js/-/realtime-js-2.111.0.tgz",
+      "integrity": "sha512-6oRf/vZyRwg8f8GbFSJkrD2w4HAu/yTvyMViHXHS+H5hNJzdXCrUR7cP5oW7daT3YlRnzRPY9LcGSJKZAmfMSg==",
       "license": "MIT",
       "dependencies": {
-        "@supabase/phoenix": "0.4.4",
+        "@supabase/phoenix": "0.4.5",
         "tslib": "2.8.1"
       },
       "engines": {
@@ -1147,9 +1147,9 @@
       }
     },
     "node_modules/@supabase/storage-js": {
-      "version": "2.110.0",
-      "resolved": "https://registry.npmjs.org/@supabase/storage-js/-/storage-js-2.110.0.tgz",
-      "integrity": "sha512-71+gU3HrhiylAhftY6FmO5PPdcsScnVcS766CVD+vTYK9qTDLbrx8FhgBYbqGm3iV/wkTfzrNJfjGsMeFRkJRQ==",
+      "version": "2.111.0",
+      "resolved": "https://registry.npmjs.org/@supabase/storage-js/-/storage-js-2.111.0.tgz",
+      "integrity": "sha512-UEViNmTzVOxE8dqUA81wls+n9xgmlvSFfhfwo6QxrO4kQOytCYyw3ciYFoi4XoD4Jl95NJ3jnndHN5iIudWzqw==",
       "license": "MIT",
       "dependencies": {
         "iceberg-js": "^0.8.1",
@@ -1160,16 +1160,16 @@
       }
     },
     "node_modules/@supabase/supabase-js": {
-      "version": "2.110.0",
-      "resolved": "https://registry.npmjs.org/@supabase/supabase-js/-/supabase-js-2.110.0.tgz",
-      "integrity": "sha512-8yI84VJiEVW4zxZpLUmxXmjzQ7O2St9X/ymzlBETDHTURPWG3LmvbSiibq+7dqAJmyoUfxZnSfXeM4HCM8s4XQ==",
+      "version": "2.111.0",
+      "resolved": "https://registry.npmjs.org/@supabase/supabase-js/-/supabase-js-2.111.0.tgz",
+      "integrity": "sha512-9q0/AULthQnWeiDh1vGyjoJZbSY04bu6qHcWit70pqEYn5Kv/dkCPY62Ja1123jEnJbB9Vd2pjY7Kvk/lK3peA==",
       "license": "MIT",
       "dependencies": {
-        "@supabase/auth-js": "2.110.0",
-        "@supabase/functions-js": "2.110.0",
-        "@supabase/postgrest-js": "2.110.0",
-        "@supabase/realtime-js": "2.110.0",
-        "@supabase/storage-js": "2.110.0"
+        "@supabase/auth-js": "2.111.0",
+        "@supabase/functions-js": "2.111.0",
+        "@supabase/postgrest-js": "2.111.0",
+        "@supabase/realtime-js": "2.111.0",
+        "@supabase/storage-js": "2.111.0"
       },
       "engines": {
         "node": ">=22.0.0"

--- a/apps/web-app/package.json
+++ b/apps/web-app/package.json
@@ -19,7 +19,7 @@
     "@fontsource/jetbrains-mono": "^5.2.8",
     "@fontsource/outfit": "^5.2.8",
     "@phosphor-icons/react": "^2.1.10",
-    "@supabase/supabase-js": "^2.110.0",
+    "@supabase/supabase-js": "^2.111.0",
     "github-markdown-css": "^5.9.0",
     "highlight.js": "^11.11.1",
     "react": "^19.2.7",


### PR DESCRIPTION
## Summary

- Upgrade the catalog web app from `@supabase/supabase-js` 2.110.0 to the current 2.111.0 release.
- Regenerate only the Supabase dependency records in `apps/web-app/package-lock.json`.
- Preserve all existing `libc` selectors for platform-specific native packages that Snyk PR #1024 removed incidentally.
- Document the update and completed validation under `CHANGELOG.md` `Unreleased`.

This supersedes #1024 with a current, minimal lockfile update.

## Change Classification

- [ ] Skill PR
- [ ] Docs PR
- [x] Infra PR

## Quality Bar Checklist

- [x] **Standards**: Read the repository quality and security guidance.
- [x] **Dependency scope**: The package and lockfile changes are limited to Supabase 2.111.0 and its direct internal packages.
- [x] **Native metadata**: Existing GNU/musl `libc` selectors remain intact.
- [x] **Local tests**: `npm run test` and `npm run app:test` passed.
- [x] **Production build**: `npm run app:build` passed.
- [x] **Repository checks**: Validation, reference validation, documentation security, and warning-budget checks passed.
- [x] **Dependency audit**: `npm audit --package-lock-only` reported zero vulnerabilities.
- [x] **Source-only PR**: No generated catalog or sitemap artifacts are included.
- [x] **Maintainer edits**: Enabled by the same-repository maintainer branch.

## Upstream

- Supabase release: https://github.com/supabase/supabase-js/releases/tag/v2.111.0
- Replaces: #1024
