### PR TITLE
fix: bound changed-skill evidence lookup

### DIFF
--- a/.github/MAINTENANCE.md
+++ b/.github/MAINTENANCE.md
@@ -153,6 +153,8 @@ Before ANY commit that adds/modifies skills, run the chain:
 
 For every canonical `SKILL.md` or tracked bundle-file change, run validation, reference validation, documentation security, changed-skill evidence, and relevant tests. Review semantics, provenance, declared risk, limitations, and bundled files directly. The separate `skill-review` workflow or an exact-head maintainer attestation remains authoritative; local heuristic scores and inferred risk labels are not merge gates.
 
+Changed-skill evidence resolves canonical ownership from the changed path's ancestors rather than scanning the complete skill registry for every Git record. Keep this lookup bounded so repository-wide maintenance batches remain inside the trusted evaluator timeout.
+
 1.  **CI is green** — Validation, warning-budget enforcement, README source-credit checks, reference checks, tests, and generated artifact steps passed (see [`.github/workflows/ci.yml`](workflows/ci.yml)). If the PR changes anything under `skills/**` or `plugins/**/skills/**`, the separate [`skill-review` workflow](workflows/skill-review.yml) must also report a truthful outcome.
 2.  **Generated drift understood** — On pull requests, generator drift is informational only. Do not block a good PR solely because canonical artifacts would be regenerated. Also do not accept PRs that directly edit `CATALOG.md`, `skills_index.json`, or `data/*.json`; those files are `main`-owned.
 3.  **Quality Bar** — PR description confirms the [Quality Bar Checklist](.github/PULL_REQUEST_TEMPLATE.md) (metadata, risk label, credits if applicable).

--- a/skills/antigravity-maintainer-batch-release/SKILL.md
+++ b/skills/antigravity-maintainer-batch-release/SKILL.md
@@ -43,6 +43,7 @@ Before changing anything:
    - Run `npm run validate`, `npm run validate:references`, `npm run security:docs`, changed-skill evidence, and the relevant tests.
    - Treat the entire tracked `skills/<skill-id>/**` subtree as skill content. Inspect semantics, safety, provenance, declared risk, limitations, and every bundled file directly, including nested examples, scripts, lockfiles, references, and assets. Never reduce evidence or review to `SKILL.md` or a fixed support-directory allowlist.
    - Require changed-skill evidence to cover every Git record in each changed canonical skill subtree. Require the `skill-review` workflow for changes under `skills/**` or `plugins/**/skills/**`; its reusable result must be keyed by the complete nearest skill-directory fingerprint on the exact current head SHA.
+   - Keep canonical skill ownership lookup proportional to changed-path depth, not total registry size, so repository-wide evidence remains inside the trusted evaluator timeout.
    - `review` means Tessl semantic review actually ran or a valid identical-content result was reused.
    - `manual-review-required` means Tessl credentials or credits were unavailable, or Tessl did not produce a passing result. Perform the maintainer semantic review and attest with `--reviewed-head <full-40-character-sha>`.
    - Any non-passing Tessl outcome produces `manual-review-required`; complete the semantic review and bind the judgment to the exact head instead of treating a heuristic score as merge authority.

--- a/tools/scripts/changed_skill_evidence.py
+++ b/tools/scripts/changed_skill_evidence.py
@@ -118,11 +118,14 @@ def canonical_skill_id(path: str | None, roots: set[str]) -> str | None:
     if path is None or not path.startswith("skills/"):
         return None
     relative = path[len("skills/") :]
-    candidates = [
-        root
-        for root in roots
-        if relative == f"{root}/SKILL.md" or relative.startswith(f"{root}/")
-    ]
+    parts = relative.split("/")
+    candidates = []
+    for end in range(1, len(parts)):
+        root = "/".join(parts[:end])
+        if root in roots and (
+            relative == f"{root}/SKILL.md" or relative.startswith(f"{root}/")
+        ):
+            candidates.append(root)
     return max(candidates, key=lambda root: (root.count("/"), len(root))) if candidates else None
 
 

--- a/tools/scripts/tests/test_changed_skill_evidence.py
+++ b/tools/scripts/tests/test_changed_skill_evidence.py
@@ -96,6 +96,23 @@ def init_repo(*, with_skill: bool = True) -> tuple[Path, str]:
 
 
 class ChangedSkillEvidenceTests(unittest.TestCase):
+    def test_canonical_skill_lookup_checks_only_path_ancestors(self):
+        class NonIterableRoots(set):
+            def __iter__(self):
+                raise AssertionError("canonical lookup must not scan every skill root")
+
+        roots = NonIterableRoots({"parent", "parent/child", "unrelated"})
+
+        self.assertEqual(
+            changed_skill_evidence.canonical_skill_id(
+                "skills/parent/child/references/example.md", roots
+            ),
+            "parent/child",
+        )
+        self.assertIsNone(
+            changed_skill_evidence.canonical_skill_id("docs/example.md", roots)
+        )
+
     def test_mixed_copy_and_rename_keep_distinct_change_types(self):
         root, base = init_repo()
         original = root / "skills/example/SKILL.md"


### PR DESCRIPTION
# Pull Request Description

Bound canonical skill ownership resolution by changed-path depth instead of scanning every canonical skill root for every Git record. This removes the quadratic bottleneck that caused repository-wide changed-skill evidence and `merge:batch` to exceed the trusted 120-second evaluator timeout.

Includes a regression test whose root set cannot be iterated, plus matching maintainer documentation and canonical maintainer-skill guidance.

## Change Classification

- [x] Skill PR
- [x] Docs PR
- [x] Infra PR

## Quality Bar Checklist ✅

- [x] Standards and security guardrails reviewed.
- [x] `npm run validate`
- [x] `npm run validate:references`
- [x] `npm run security:docs`
- [x] `python3 -m unittest tools.scripts.tests.test_changed_skill_evidence`
- [x] Manual logic and failure-mode review completed.
- [x] Source-only PR; no generated registries or mirrors included.
- [x] Maintainer edits enabled by same-repository branch.

## Screenshots

Not applicable.
