### PR TITLE
fix: extend trusted evidence timeout

### DIFF
--- a/.github/MAINTENANCE.md
+++ b/.github/MAINTENANCE.md
@@ -153,7 +153,7 @@ Before ANY commit that adds/modifies skills, run the chain:
 
 For every canonical `SKILL.md` or tracked bundle-file change, run validation, reference validation, documentation security, changed-skill evidence, and relevant tests. Review semantics, provenance, declared risk, limitations, and bundled files directly. The separate `skill-review` workflow or an exact-head maintainer attestation remains authoritative; local heuristic scores and inferred risk labels are not merge gates.
 
-Changed-skill evidence resolves canonical ownership from the changed path's ancestors rather than scanning the complete skill registry for every Git record. Keep this lookup bounded so repository-wide maintenance batches remain inside the trusted evaluator timeout.
+Changed-skill evidence resolves canonical ownership from the changed path's ancestors rather than scanning the complete skill registry for every Git record. Keep this lookup bounded and preserve the five-minute trusted evaluator budget so repository-wide maintenance batches can complete without weakening fail-closed evidence checks.
 
 1.  **CI is green** — Validation, warning-budget enforcement, README source-credit checks, reference checks, tests, and generated artifact steps passed (see [`.github/workflows/ci.yml`](workflows/ci.yml)). If the PR changes anything under `skills/**` or `plugins/**/skills/**`, the separate [`skill-review` workflow](workflows/skill-review.yml) must also report a truthful outcome.
 2.  **Generated drift understood** — On pull requests, generator drift is informational only. Do not block a good PR solely because canonical artifacts would be regenerated. Also do not accept PRs that directly edit `CATALOG.md`, `skills_index.json`, or `data/*.json`; those files are `main`-owned.

--- a/skills/antigravity-maintainer-batch-release/SKILL.md
+++ b/skills/antigravity-maintainer-batch-release/SKILL.md
@@ -43,7 +43,7 @@ Before changing anything:
    - Run `npm run validate`, `npm run validate:references`, `npm run security:docs`, changed-skill evidence, and the relevant tests.
    - Treat the entire tracked `skills/<skill-id>/**` subtree as skill content. Inspect semantics, safety, provenance, declared risk, limitations, and every bundled file directly, including nested examples, scripts, lockfiles, references, and assets. Never reduce evidence or review to `SKILL.md` or a fixed support-directory allowlist.
    - Require changed-skill evidence to cover every Git record in each changed canonical skill subtree. Require the `skill-review` workflow for changes under `skills/**` or `plugins/**/skills/**`; its reusable result must be keyed by the complete nearest skill-directory fingerprint on the exact current head SHA.
-   - Keep canonical skill ownership lookup proportional to changed-path depth, not total registry size, so repository-wide evidence remains inside the trusted evaluator timeout.
+   - Keep canonical skill ownership lookup proportional to changed-path depth, not total registry size, and preserve the five-minute trusted evaluator budget so repository-wide evidence completes without weakening fail-closed checks.
    - `review` means Tessl semantic review actually ran or a valid identical-content result was reused.
    - `manual-review-required` means Tessl credentials or credits were unavailable, or Tessl did not produce a passing result. Perform the maintainer semantic review and attest with `--reviewed-head <full-40-character-sha>`.
    - Any non-passing Tessl outcome produces `manual-review-required`; complete the semantic review and bind the judgment to the exact head instead of treating a heuristic score as merge authority.

--- a/tools/scripts/merge_batch.cjs
+++ b/tools/scripts/merge_batch.cjs
@@ -36,7 +36,7 @@ const DISALLOWED_COAUTHOR_TRAILER_PATTERNS = [
 ];
 const FULL_SHA_PATTERN = /^[0-9a-f]{40}$/u;
 const EVIDENCE_SCHEMA_VERSION = 1;
-const EVIDENCE_TIMEOUT_MS = 120_000;
+const EVIDENCE_TIMEOUT_MS = 300_000;
 const MAX_EVIDENCE_BYTES = 8 * 1024 * 1024;
 const APPROVAL_WORKFLOW_PATHS = new Set([
   ".github/workflows/actionlint.yml",
@@ -1314,6 +1314,7 @@ if (require.main === module) {
 }
 
 module.exports = {
+  EVIDENCE_TIMEOUT_MS,
   approvalWorkflowPaths: APPROVAL_WORKFLOW_PATHS,
   approveActionRequiredRuns,
   approveWorkflowRun,

--- a/tools/scripts/tests/merge_batch.test.js
+++ b/tools/scripts/tests/merge_batch.test.js
@@ -8,6 +8,12 @@ const HEAD_SHA = "2".repeat(40);
 const BLOB_SHA = "3".repeat(40);
 const ZERO_SHA = "0".repeat(40);
 
+assert.strictEqual(
+  mergeBatch.EVIDENCE_TIMEOUT_MS,
+  300_000,
+  "repository-wide trusted evidence must have a five-minute execution budget",
+);
+
 function makeCheckRun(name, status, conclusion, startedAt, id, suiteId = 1) {
   return {
     name,


### PR DESCRIPTION
# Pull Request Description

Extend the trusted changed-skill evaluator budget from two to five minutes. A measured 940-skill evidence run completes in about 2m35s after the bounded path-lookup fix, so the previous 120-second limit still terminated valid repository-wide maintenance batches.

The evaluator remains fail-closed; only its execution budget changes. Includes a regression assertion plus matching maintainer documentation and canonical maintainer-skill guidance.

## Change Classification

- [x] Skill PR
- [x] Docs PR
- [x] Infra PR

## Validation

- `node tools/scripts/tests/merge_batch.test.js`
- `npm run validate`
- `npm run validate:references`
- `npm run security:docs`

Source-only; no generated artifacts included.
