### PR TITLE
fix: require explicit Antigravity skill selection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Made direct Antigravity installation fail closed before cloning or writing when no skill selection is supplied. The installer now directs users to let a Codex or Claude agent choose exact IDs through the read-only AAS Core MCP, preview the resulting `--skills` install, and use `--all` only as explicit acceptance of full-catalog context and crash-loop risk. Other host targets retain their existing behavior.
+
 ## [15.7.0] - 2026-07-29 - "Risk Metadata and Installation Hardening"
 
 > Completed semantic risk classification across the catalog, hardened skill installation and maintainer evidence boundaries, and added a consent-gated backend provisioning skill.

--- a/README.md
+++ b/README.md
@@ -115,11 +115,11 @@ Use direct installation when your host does not yet have a native AAS Core adapt
 - **Full library install** when you want every skill available in a local skills directory.
 - **Bundles and workflows** when you want role-based recommendations or ordered execution playbooks.
 
-### Full library install
+### Direct skill install
 
 ```bash
-# Default: ~/.agents/skills (Antigravity 2.0 global). Use --path for other locations.
-npx agentic-awesome-skills
+# Antigravity: preview an exact, agent-selected set before writing.
+npx agentic-awesome-skills --antigravity --skills brainstorming,systematic-debugging --dry-run
 
 # Antigravity CLI slash commands (agy): ~/.gemini/antigravity-cli/skills/<skill>/SKILL.md
 npx agentic-awesome-skills --agy
@@ -127,15 +127,34 @@ npx agentic-awesome-skills --agy
 
 The npm installer uses a shallow, release-pinned clone by default so first-run installs stay lighter than a full repository history checkout while matching the published npm package version. Use `--tag main` only when you intentionally want the current repository tip.
 
-For backward compatibility, running the installer without selectors installs the
-entire catalog. The CLI now prints the catalog's risk summary first: a full
-install includes `unknown`, `critical`, and authorized-use-only `offensive`
+Antigravity watches `~/.agents/skills` and may load enough installed instructions
+to exhaust its context, slow startup, trigger truncation errors, or enter a crash
+loop. For that target, the installer stops before cloning or writing unless you
+provide `--skills`, a metadata filter, or the explicit `--all` override. The bare
+`npx agentic-awesome-skills` command uses the same protected Antigravity target.
+
+The recommended flow is to ask Codex or Claude with the read-only AAS Core MCP
+configured to inspect the project, search the complete catalog, and choose exact
+skill IDs. AAS MCP selects and validates IDs but does not install them; the agent
+or user then previews the direct installation with the command above and repeats
+it without `--dry-run` after review.
+
+Other direct-install targets retain the legacy-compatible full-catalog behavior
+when no selectors are supplied. The CLI prints the catalog's risk summary first:
+a full install includes `critical` and authorized-use-only `offensive`
 instructions. Installation copies files; it does not execute their commands,
 but an agent may act on an installed skill later. Prefer an exact reviewed set:
 
 ```bash
 npx agentic-awesome-skills audit --skills brainstorming,backend-dev-guidelines
 npx agentic-awesome-skills --skills brainstorming,backend-dev-guidelines --dry-run
+```
+
+If you deliberately accept the context and crash-loop risk, the complete
+Antigravity catalog remains available through explicit consent:
+
+```bash
+npx agentic-awesome-skills --antigravity --all
 ```
 
 The audit reads the selected skill directories without executing them and
@@ -213,7 +232,7 @@ Use the same repository, but install or invoke it in the way your host expects.
 | Gemini CLI     | `npx agentic-awesome-skills --gemini`                              | `Use brainstorming to plan a feature`                |
 | Codex CLI      | [AAS Core local MCP preview](docs/users/codex-cli-skills.md) or `npx agentic-awesome-skills --codex` | Ask Codex to choose and compose an AAS stack |
 | Autohand Code  | `npx agentic-awesome-skills --path ~/.autohand/skills` or `--path .autohand/skills` | `Use brainstorming to plan a feature`                |
-| Antigravity IDE | `npx agentic-awesome-skills --antigravity`                        | `Use @brainstorming to plan a feature`               |
+| Antigravity IDE | `npx agentic-awesome-skills --antigravity --skills <ids> --dry-run` | Ask an MCP-enabled agent to choose exact IDs first |
 | Antigravity CLI (`agy`) | `npx agentic-awesome-skills --agy`                        | `/brainstorming help me plan a feature`              |
 | Kiro CLI       | `npx agentic-awesome-skills --kiro`                                | `Use brainstorming to plan a feature`                |
 | Kiro IDE       | `npx agentic-awesome-skills --path ~/.kiro/skills`                 | `Use @brainstorming to plan a feature`               |
@@ -244,7 +263,11 @@ The supported path covers complete local catalog search and inspection, agent-ow
 
 For AAS Core, follow the [preview guide](https://github.com/sickn33/agentic-awesome-skills/blob/v15.7.0/docs/users/aas-core.md) and use only a package release whose notes explicitly state that it includes Core. Release 14.6.0 predates Core; Core-capable releases begin with the 15.x line.
 
-For direct skill distribution, run `npx agentic-awesome-skills` for the default full-library install. Use a tool-specific flag such as `--codex`, `--cursor`, `--gemini`, `--claude`, or `--antigravity` when you want the legacy installer to place skills in the directory your assistant already watches.
+For direct skill distribution, use a tool-specific flag such as `--codex`,
+`--cursor`, `--gemini`, or `--claude` to place skills in the directory your
+assistant watches. The default target is Antigravity; it requires `--skills`, a
+metadata filter, or explicit `--all` consent before cloning or writing because a
+full watched catalog can exhaust context or trigger a crash loop.
 
 For Autohand Code, use the installer with a custom path:
 

--- a/docs/users/faq.md
+++ b/docs/users/faq.md
@@ -31,10 +31,12 @@ Skills are specialized instruction files that teach AI assistants how to handle 
 
 **No.** With AAS Core, ask the agent to inspect the project and choose the exact skills from the complete catalog. On a broad direct install, all skills may be present locally while the host loads only the skills it invokes.
 
-The direct installer keeps its historical full-catalog default for compatibility,
-but now shows the risk distribution before writing. Use `audit --skills <ids>` to
-read an exact selection and its bundled files without executing them, then use
-the same `--skills` selection with `--dry-run` before installation.
+The direct installer keeps its historical full-catalog default for other hosts,
+but Antigravity requires an exact selection, metadata filter, or explicit
+`--all` consent because its watched directory can overload the host. Use
+`audit --skills <ids>` to read an exact selection and its bundled files without
+executing them, then use the same `--skills` selection with `--dry-run` before
+installation.
 
 Use [Starter Packs](bundles.md) as human-curated presets when you want a fixed starting point.
 
@@ -156,7 +158,10 @@ The package publishes separate `agentic-awesome-skills`, `aas`, and `aas-mcp` bi
 It depends on how you install:
 
 - **Using the installer CLI (`npx agentic-awesome-skills`)**:
-  The default install target is `~/.agents/skills/` for Antigravity's global library.
+  The default target is `~/.agents/skills/` for Antigravity's global library.
+  Because Antigravity may overload when the complete catalog is present, the
+  installer requires `--skills`, a metadata filter, or explicit `--all` consent
+  before cloning or changing that target.
 - **Using a tool-specific flag**:
   Use `--claude`, `--cursor`, `--gemini`, `--codex`, `--kiro`, or `--antigravity` to target the matching tool path automatically.
 - **Using a manual clone or custom workspace path**:
@@ -171,6 +176,13 @@ git clone https://github.com/sickn33/agentic-awesome-skills.git .agent/skills
 ```
 
 For direct skill distribution, the installer CLI performs a lighter shallow clone of the current library. Manual `git clone` remains appropriate when you want the full repository history or plan to contribute from the same checkout. For Codex or Claude users who want project-specific agent selection with reproducible state, start with AAS Core instead of treating a full-library install as the primary product path.
+
+For Antigravity, ask a Codex or Claude agent with the read-only AAS Core MCP
+configured to inspect the project and choose exact IDs, then preview the selected
+set with `npx agentic-awesome-skills --antigravity --skills <ids> --dry-run`.
+AAS MCP selects and validates IDs but does not install them. The complete catalog
+requires the explicit `npx agentic-awesome-skills --antigravity --all` override
+because it can exhaust context or trigger a truncation crash loop.
 
 **Tool-specific paths:**
 
@@ -236,10 +248,11 @@ So it is normal for the **full library** to be larger than the **plugin-safe** p
 **Yes.** Use the same standard install flow as other platforms:
 
 ```bash
-npx agentic-awesome-skills
+npx agentic-awesome-skills --antigravity --skills brainstorming --dry-run
 ```
 
-If you have an older clone created around the removed symlink workaround, reinstall into a fresh directory or rerun `npx agentic-awesome-skills`.
+If you have an older clone created around the removed symlink workaround,
+reinstall into a fresh directory or rerun the installer with an exact selection.
 
 For AAS Core MCP configuration, native Windows 10 and 11 with Node.js 22 are supported preview targets. A preview failure with `AAS_ADAPTER_WINDOWS_ACL_FAILED` refers to the Codex/Claude configuration directory or file checked with PowerShell `Get-Acl`, not the AAS cache and not `icacls`. Read the returned `path`, `phase`, `status`, and bounded diagnostic; correct the named configuration-path ownership problem, then rerun preview. Never add `--approve` before an approval digest is produced. See the [AAS Core Windows notes](aas-core.md#native-windows-and-codex).
 

--- a/docs/users/getting-started.md
+++ b/docs/users/getting-started.md
@@ -42,21 +42,33 @@ If you prefer a marketplace-style install for **Claude Code** or **Codex**, use 
 **Option A — npx (easiest):**
 
 ```bash
-npx agentic-awesome-skills
+npx agentic-awesome-skills --antigravity --skills brainstorming,systematic-debugging --dry-run
 ```
 
-This clones to `~/.agents/skills` by default. Use `--cursor`, `--claude`, `--gemini`, `--codex`, `--kiro`, or `--agy` to install for a specific tool, or `--path <dir>` for a custom location. Run `npx agentic-awesome-skills --help` for details.
+Antigravity installs to `~/.agents/skills`. Because that host may load enough
+installed instructions to exhaust its context or enter a truncation crash loop,
+the bare command and `--antigravity` now require `--skills`, a metadata filter,
+or the explicit `--all` override. Use `--cursor`, `--claude`, `--gemini`,
+`--codex`, `--kiro`, or `--agy` for other tool paths, or `--path <dir>` for a
+custom location. Run `npx agentic-awesome-skills --help` for details.
 The installer uses a shallow clone by default so you get the current library without paying for the full git history on first install.
 
-With no selector, the legacy-compatible default installs the complete catalog
-and prints a risk summary before writing. That includes `unknown`, `critical`,
-and authorized-use-only `offensive` skills. Installed text is not automatically
-executed, but it can influence an agent when loaded, so review an exact set first:
+For Antigravity, ask a Codex or Claude agent with the read-only AAS Core MCP
+configured to inspect the project, search the complete catalog, and choose exact
+skill IDs. AAS MCP does not install them; after selection, have the agent run the
+preview command above, show you the plan, and repeat it without `--dry-run` only
+after review. Other direct-install targets keep the legacy-compatible complete
+catalog behavior when no selector is supplied and print a risk summary before
+writing. Installed text is not automatically executed, but it can influence an
+agent when loaded, so review an exact set first:
 
 ```bash
 npx agentic-awesome-skills audit --skills brainstorming,backend-dev-guidelines
 npx agentic-awesome-skills --skills brainstorming,backend-dev-guidelines --dry-run
 ```
+
+Use `npx agentic-awesome-skills --antigravity --all` only when you deliberately
+accept the full catalog's context, truncation, and crash-loop risk.
 
 You can also ask your agent to read the selected `SKILL.md` and every bundled
 file before installation. The static audit reports risky capabilities; it does

--- a/tools/bin/install.js
+++ b/tools/bin/install.js
@@ -194,7 +194,7 @@ Options:
   --gemini       Install to ~/.gemini/skills (Gemini CLI)
   --codex        Install to ~/.codex/skills (Codex CLI)
   --kiro         Install to ~/.kiro/skills (Kiro CLI)
-  --antigravity  Install to ~/.agents/skills (Antigravity IDE / OpenCode-style layout)
+  --antigravity  Install to ~/.agents/skills; requires a selection or explicit --all
   --agy          Install to ~/.gemini/antigravity-cli/skills (Antigravity CLI slash commands)
   --path <dir>   Install to <dir> (default: ~/.agents/skills)
   --risk <csv>     Install only skills matching these risk labels
@@ -213,6 +213,7 @@ Examples:
   npx agentic-awesome-skills --cursor --risk safe,none
   npx agentic-awesome-skills --all --dry-run
   npx agentic-awesome-skills --kiro --skills brainstorming
+  npx agentic-awesome-skills --antigravity --skills brainstorming --dry-run
   npx agentic-awesome-skills --antigravity --risk safe,none
   npx agentic-awesome-skills --agy --skills brainstorming
   npx agentic-awesome-skills --path .agents/skills --category development,backend --risk safe,none
@@ -294,6 +295,37 @@ function assertExplicitInstallSelection(opts, selectors, requestedSkills) {
   if (opts.auditOnly && requestedSkills.length === 0) {
     throw new Error("The audit command requires --skills with one or more exact skill ids.");
   }
+}
+
+function buildAntigravitySelectionMessage() {
+  return [
+    "Antigravity installation stopped before cloning or changing files.",
+    "",
+    "Installing the complete AAS catalog into ~/.agents/skills can exhaust the host context, slow startup, trigger truncation errors, or cause a crash loop.",
+    "",
+    "Recommended: ask a Codex or Claude agent with the read-only AAS Core MCP configured to inspect your project, search the complete catalog, and choose the exact skill IDs you need. Then have the agent preview the direct install with:",
+    "",
+    "  npx agentic-awesome-skills --antigravity --skills skill-id-1,skill-id-2 --dry-run",
+    "",
+    "Copyable agent prompt:",
+    "  Inspect this project and use the AAS MCP to search the complete catalog and choose the exact relevant skill IDs. Replace the example IDs and run npx agentic-awesome-skills --antigravity --skills skill-id-1,skill-id-2 --dry-run. Show me the plan and do not install the complete catalog.",
+    "",
+    "AAS MCP selects and validates IDs but does not install skills. After reviewing the dry run, repeat the generated command without --dry-run.",
+    "",
+    "AAS Core setup: https://github.com/sickn33/agentic-awesome-skills/blob/main/docs/users/aas-core.md",
+    "",
+    "If you intentionally accept the Antigravity context and crash-loop risk, use:",
+    "  npx agentic-awesome-skills --antigravity --all",
+    "",
+    "Recovery: https://github.com/sickn33/agentic-awesome-skills/blob/main/docs/users/windows-truncation-recovery.md",
+  ].join("\n");
+}
+
+function assertAntigravityInstallSelection(opts, targets, selectors, requestedSkills) {
+  if (opts.auditOnly || opts.installAll) return;
+  if (requestedSkills.length > 0 || hasInstallSelectors(selectors)) return;
+  if (!targets.some((target) => target.name === "Antigravity")) return;
+  throw new Error(buildAntigravitySelectionMessage());
 }
 
 function buildRiskSummary(repoRoot, installEntries) {
@@ -1075,6 +1107,14 @@ function main() {
     process.exit(1);
   }
 
+  try {
+    assertAntigravityInstallSelection(opts, targets, selectors, requestedSkills);
+  } catch (error) {
+    console.error(`Error: ${error.message}`);
+    process.exitCode = 1;
+    return;
+  }
+
   const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "ag-skills-"));
 
   try {
@@ -1161,6 +1201,7 @@ module.exports = {
   buildCloneArgs,
   buildDryRunPlan,
   buildDryRunTargetPlan,
+  assertAntigravityInstallSelection,
   assertExplicitInstallSelection,
   auditSkillEntries,
   buildRiskSummary,
@@ -1177,6 +1218,7 @@ module.exports = {
   normalizeManifestEntries,
   parseExactSkillArg,
   parseSelectorArg,
+  buildAntigravitySelectionMessage,
   printDryRunPlan,
   parseArgs,
   printImplicitFullInstallWarning,

--- a/tools/scripts/tests/installer_cli_args.test.js
+++ b/tools/scripts/tests/installer_cli_args.test.js
@@ -1,4 +1,6 @@
 const assert = require('assert');
+const fs = require('fs');
+const os = require('os');
 const path = require('path');
 const { spawnSync } = require('child_process');
 const packageVersion = require('../../../package.json').version;
@@ -59,3 +61,59 @@ assert.throws(
   ),
   /audit command requires --skills/i,
 );
+
+const antigravityTarget = [{ name: 'Antigravity', path: '/tmp/.agents/skills' }];
+assert.throws(
+  () => installer.assertAntigravityInstallSelection(
+    installer.parseArgs(['--antigravity']),
+    antigravityTarget,
+    installer.buildInstallSelectors({}),
+    [],
+  ),
+  /installation stopped before cloning or changing files/i,
+);
+assert.doesNotThrow(() => installer.assertAntigravityInstallSelection(
+  installer.parseArgs(['--antigravity', '--skills', 'frontend-design']),
+  antigravityTarget,
+  installer.buildInstallSelectors({}),
+  ['frontend-design'],
+));
+assert.doesNotThrow(() => installer.assertAntigravityInstallSelection(
+  installer.parseArgs(['--antigravity', '--category', 'development']),
+  antigravityTarget,
+  installer.buildInstallSelectors({ categoryArg: 'development' }),
+  [],
+));
+assert.doesNotThrow(() => installer.assertAntigravityInstallSelection(
+  installer.parseArgs(['--antigravity', '--all']),
+  antigravityTarget,
+  installer.buildInstallSelectors({}),
+  [],
+));
+assert.doesNotThrow(() => installer.assertAntigravityInstallSelection(
+  installer.parseArgs(['--codex']),
+  [{ name: 'Codex CLI', path: '/tmp/.codex/skills' }],
+  installer.buildInstallSelectors({}),
+  [],
+));
+
+const isolatedHome = fs.mkdtempSync(path.join(os.tmpdir(), 'installer-antigravity-block-'));
+try {
+  for (const args of [[], ['--antigravity']]) {
+    const blocked = spawnSync(process.execPath, [installerPath, ...args], {
+      encoding: 'utf8',
+      env: { ...process.env, HOME: isolatedHome },
+    });
+    assert.strictEqual(blocked.status, 1);
+    assert.match(blocked.stderr, /context.*crash loop/i);
+    assert.match(blocked.stderr, /AAS Core MCP/i);
+    assert.match(blocked.stderr, /docs\/users\/aas-core\.md/i);
+    assert.match(blocked.stderr, /--antigravity --skills skill-id-1,skill-id-2 --dry-run/i);
+    assert.match(blocked.stderr, /--antigravity --all/i);
+    assert.match(blocked.stderr, /windows-truncation-recovery\.md/i);
+    assert.doesNotMatch(`${blocked.stdout}\n${blocked.stderr}`, /Cloning repository/i);
+  }
+  assert.strictEqual(fs.existsSync(path.join(isolatedHome, '.agents')), false);
+} finally {
+  fs.rmSync(isolatedHome, { recursive: true, force: true });
+}

--- a/walkthrough.md
+++ b/walkthrough.md
@@ -1,3 +1,15 @@
+# Maintenance Walkthrough - 2026-07-30
+
+- Changed only the Antigravity direct-install default: a bare Antigravity target
+  now stops before cloning or writing unless exact skills, metadata filters, or
+  the explicit `--all` override are supplied.
+- Added copyable guidance for an MCP-enabled Codex or Claude agent to inspect the
+  project, choose exact AAS skill IDs, and preview the resulting Antigravity
+  install while preserving AAS MCP's read-only boundary.
+- Added regression coverage proving the blocked path performs no clone or target
+  mutation, explicit selections and `--all` continue, and non-Antigravity hosts
+  retain their existing behavior.
+
 # Maintenance Walkthrough - 2026-07-29
 
 - Hardened the legacy full-catalog installer without breaking its historical


### PR DESCRIPTION
# Pull Request Description

## Summary

Prevents the legacy direct installer from implicitly materializing the complete catalog into Antigravity's watched `~/.agents/skills` directory. Both the bare command and `--antigravity` now stop before cloning or writing unless the user supplies exact skills, metadata filters, or the explicit `--all` override.

The fail-closed message:

- explains the context-exhaustion, truncation, startup, and crash-loop risk;
- gives a copyable prompt for a Codex or Claude agent configured with the read-only AAS Core MCP;
- keeps the MCP boundary truthful: it selects and validates IDs, while the direct installer applies the reviewed set;
- points to AAS Core setup and Windows recovery;
- leaves every non-Antigravity target unchanged.

Prompted by the concrete Windows failure report in Discussion #1045.

## Change Classification

- [ ] Skill PR
- [x] Docs PR
- [x] Infra PR

## Issue Link (Optional)

Discussion: https://github.com/sickn33/agentic-awesome-skills/discussions/1045

## Quality Bar Checklist ✅

**All applicable items are checked; skill-only items are not applicable.**

- [x] **Standards**: I have read `docs/contributors/quality-bar.md` and `docs/contributors/security-guardrails.md`.
- [ ] **Metadata**: Not applicable; no `SKILL.md` changed.
- [ ] **Risk Label**: Not applicable; no skill metadata changed.
- [ ] **Triggers**: Not applicable; no skill changed.
- [ ] **Limitations**: Not applicable; no skill changed.
- [ ] **Security**: Not applicable; no offensive skill changed.
- [x] **Safety scan**: Ran `npm run security:docs`; no findings.
- [ ] **Automated Skill Review**: Not applicable; no `SKILL.md` changed.
- [x] **Manual Logic Review**: Reviewed fail-closed behavior, MCP/install boundary, host scoping, and failure modes.
- [x] **Local Test**: Verified both bare and explicit Antigravity commands stop before clone or target mutation, while selections, filters, `--all`, and non-Antigravity hosts remain allowed.
- [x] **Repo Checks**: Ran validation, reference validation, full repository tests, AAS Core tests/catalog verification, warning budget, npm audit, and npm package dry run.
- [x] **Source-Only PR**: No generated registry artifacts or plugin mirrors are included.
- [ ] **Credits**: Not applicable; no external source content added.
- [ ] **License provenance**: Not applicable; no external skill imported.
- [x] **Maintainer Edits**: Allow edits from maintainers is enabled.

## Validation

- `npm run validate`
- `npm run validate:references`
- `npm run security:docs`
- `npm run test` — 104 tests passed
- `npm run test:aas-v1`
- `npm run check:aas-v1-catalog`
- `npm run check:warning-budget`
- `npm run check:readme-credits -- --base origin/main --head HEAD`
- `npm audit --omit=dev` — 0 vulnerabilities
- `npm pack --dry-run --json` with an isolated writable npm cache

## Screenshots (if applicable)

Not applicable; this is a CLI behavior and documentation change.