### PR TITLE
feat: add agents-generator skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -492,6 +492,7 @@ Key source families include:
 
 ### Community Contributors
 
+- **[OJPalenzuela/agents-generator](https://github.com/OJPalenzuela/agents-generator)**: Source for the `agents-generator` skill - project-specific `AGENTS.md` and companion rule generation with package-manager detection, monorepo handling, dry-run/update modes, backups, and validated commands (MIT).
 - **[sudosubin/gh-attach](https://github.com/sudosubin/gh-attach)**: Source for the `gh-attach` skill - GitHub CLI uploads and downloads of `user-attachments` (screenshots, PDFs, zips, videos), producing repo-scoped URLs for PRs, issues, and READMEs, with GitHub Enterprise Server support (MIT).
 - **[abhinaykrupa/cowork-to-code-bridge](https://github.com/abhinaykrupa/cowork-to-code-bridge)**: Source for the `cowork-to-code-bridge` skill - consent-bound execution on the user's own machine with pinned provenance, narrow scopes, and explicit local-agent limitations (MIT).
 - **[maleksaadi0109/hyprfedora](https://github.com/maleksaadi0109/hyprfedora)**: Source for the `fedora-hyprland-installer` skill - GPU-aware Fedora Hyprland installation, configuration, verification, repair, and removal workflows (MIT).

--- a/skills/agents-generator/SKILL.md
+++ b/skills/agents-generator/SKILL.md
@@ -1,0 +1,163 @@
+---
+name: agents-generator
+description: "Generate project-specific AGENTS.md and companion rules by analyzing a codebase. Supports full, minimal, update, and dry-run modes with package-manager detection, monorepos, backups, managed blocks, confidence scoring, and command validation."
+category: developer-tools
+risk: critical
+source: https://github.com/OJPalenzuela/agents-generator/tree/7a3201208a01bd25e69ad11e665efc1392f5356a
+source_repo: OJPalenzuela/agents-generator
+source_type: community
+date_added: "2026-08-02"
+author: OJPalenzuela
+tags: [agents-md, project-conventions, developer-tools, codebase-analysis, ai-agents]
+tools: [claude, cursor, copilot, opencode, codex, gemini]
+license: MIT
+license_source: https://github.com/OJPalenzuela/agents-generator/blob/7a3201208a01bd25e69ad11e665efc1392f5356a/LICENSE
+allowed-tools: Read Write Edit Bash(ls:*) Bash(git:*) Bash(tree:*) Bash(find:*) Grep Glob WebFetch
+metadata:
+  author: OJPalenzuela
+  version: "1.2.3"
+---
+
+# Skill: agents-generator
+
+> [!WARNING]
+> **[Authorized Use Only]** This skill writes or updates `AGENTS.md`, `.agents/rules/`, optional platform instruction files, and timestamped backups in the target project. Read the detected inputs and proposed outputs first, obtain approval before changing target files, and use it only inside the user's intended project scope.
+
+## When to Use
+
+Use this skill when the user wants to:
+
+- create a complete, project-specific `AGENTS.md` instead of generic agent rules;
+- generate companion rules for detected frameworks, tests, databases, styling, or monorepo packages;
+- create a minimal `AGENTS.md`, preview changes without writing, or update existing instructions after the stack changes.
+
+Do not use it to invent conventions without inspecting the target project, to overwrite instructions outside the user's scope, or to treat generated guidance as a substitute for human review.
+
+Generates a tailored AGENTS.md + `.agents/rules/*.md` for the target project — not a template with placeholders, but a living document that matches the project's real toolchain.
+
+## What you get
+
+From a project that uses **Bun + Next.js 16 + Tailwind + Vitest + Server Actions**, the skill produces:
+
+```
+AGENTS.md
+├── Setup commands: bun install, bun dev, bun run test:run, bun doctor
+├── Verification Cycle: bunx tsc --noEmit → bun run lint → bun run test:run → bun doctor
+├── Conventions: "Bun always. Plain TypeScript types + guards."
+└── Architecture → .agents/rules/architecture.md
+
+.agents/rules/
+├── architecture.md       ← ASCII diagram with real directories, exact versions
+├── frontend-patterns.md  ← Component rules, state locations, trust boundaries
+├── server-actions.md     ← downloadVideo() flow, DownloadResult type, rate limiter
+├── testing.md            ← "74 tests in 5 files", vitest commands, mock patterns
+├── git-workflow.md       ← Conventional commits, pre-commit checks
+└── sdd-workflow.md       ← Preflight defaults, post-apply verification
+```
+
+Rules NOT generated: `backend.md` (no NestJS), `database.md` (no ORM), `i18n.md` (hardcoded Spanish), `forms.md` (manual inputs), `styling.md` (Tailwind in frontend rules).
+
+## Activation Contract
+
+Generate AGENTS.md + `.agents/rules/*.md` for the target project. Never guess — read the project's actual files first.
+
+### Mode selection
+
+| User says | Mode | Output |
+|-----------|------|--------|
+| "simple AGENTS.md", "just the basics", "minimal" | **Minimal** | Single `AGENTS.md` (~30 lines, no rule files) |
+| "full AGENTS.md", "with rules", "complete", or default | **Full** | `AGENTS.md` + `.agents/rules/*.md` |
+| "update AGENTS.md", "refresh", "my stack changed" | **Update** | Diff existing, regenerate only what changed |
+
+### Dry-run mode
+
+If the user asks to "preview", "show what would change", "dry-run": run all detection but do NOT write files. Show detection summary, files that would be created, skipped rules, and sample output.
+
+## Hard Rules
+
+- **Read before writing.** Read `package.json`, all config files, and directory structure before generating anything.
+- **Detect package manager FIRST.** Check lockfiles: `bun.lock`→bun, `pnpm-lock.yaml`→pnpm, `package-lock.json`→npm, `yarn.lock`→yarn. NEVER default to npm. Every command uses the detected PM.
+- **Generate only what applies.** No backend rules for frontend-only. No database rules without ORM.
+- **Auto-format and lint generated files.** Run `[format cmd]` and `[lint cmd]` on generated files only — never the whole project. These are fast, safe operations.
+- **Validate commands.** Every command in output must exist as a script key in `package.json`.
+- **No placeholders.** Scan output for `{{`, `TODO`, `add here`, `...`. Reject if any remain.
+- **Backup first.** If files exist, copy to `.agents/backups/` with timestamp.
+
+## Execution Steps
+
+### Common
+
+1. `git rev-parse --show-toplevel` → project root.
+2. **Detect package manager FIRST**: check lockfiles. `bun.lock`→bun, `pnpm-lock.yaml`→pnpm, `package-lock.json`→npm, `yarn.lock`→yarn. Never default to npm.
+3. Read `package.json` (scripts, deps, workspaces). Save scripts for validation.
+4. Read config files and explore directory structure.
+5. Select mode (ask if ambiguous).
+
+### Full mode
+
+1. Read `assets/agents-full.md` — this is the AGENTS.md structure with all sections and filling rules.
+2. Read project files and fill every placeholder with real data. Never use generic text.
+3. Generate `AGENTS.md` at project root. Wrap content in `<!-- AGENTS-GENERATED-START -->` / `<!-- AGENTS-GENERATED-END -->`.
+4. For each applicable rule category, read the corresponding template from `assets/` and generate the rule file in `.agents/rules/`.
+5. If Claude detected (`.claude/` or `CLAUDE.md`): generate thin `CLAUDE.md` from `assets/claude.md`.
+6. If platform files detected: generate from `assets/platform.md`.
+
+### Minimal mode
+
+1. Read `assets/agents-minimal.md` — 30-line agents.md standard format.
+2. Generate single `AGENTS.md`.
+
+### Update mode
+
+1. Backup existing files.
+2. Re-detect project state.
+3. Diff old vs new. Regenerate only changed categories.
+
+### Post-generation
+
+- Run `[format cmd]` on the generated files only.
+- Run `[lint cmd]` on the generated files only.
+- Scan for `{{`, `TODO`, `...`. Fix any found.
+- Verify all commands exist in package.json scripts.
+- If AGENTS.md > 300 lines, warn. If > 500, move content to rule files.
+- Summarize all changes using conventional commit format before declaring done.
+- Report: what was detected, generated, skipped, and confidence score.
+
+## Output Contract
+
+Return:
+- Mode used and why
+- Files created/modified
+- Detection summary (all categories)
+- Rules generated and skipped (with reason)
+- Confidence score
+
+## Limitations
+
+- Generated instructions are proposals and require human review before they are adopted or committed.
+- Command validation is limited to scripts and files visible in the target project; it cannot prove that tools, services, or platform-specific commands will work in every environment.
+- The skill does not authorize writes outside the intended project scope or replace project-specific security, build, or deployment review.
+
+## References
+
+| Priority | File | Purpose |
+|----------|------|---------|
+| **Required** | `assets/agents-full.md` | Full AGENTS.md template with all 25+ sections and filling rules |
+| **Required** | `assets/agents-minimal.md` | 30-line agents.md standard template |
+| Full mode | `assets/architecture.md` | Architecture rules template |
+| Full mode | `assets/frontend-patterns.md` | Frontend patterns template |
+| Full mode | `assets/server-actions.md` | Server actions / backend template |
+| Full mode | `assets/testing.md` | Testing strategy template |
+| Full mode | `assets/git-workflow.md` | Git workflow template |
+| Full mode | `assets/sdd-workflow.md` | SDD workflow template |
+| Full mode | `assets/styling.md` | Styling rules template |
+| Full mode | `assets/forms.md` | Form patterns template |
+| Full mode | `assets/database.md` | Database rules template |
+| Full mode | `assets/i18n.md` | i18n rules template |
+| Full mode | `assets/backend.md` | Backend/NestJS template |
+| Conditional | `assets/claude.md` | CLAUDE.md — only if Claude detected |
+| Conditional | `assets/platform.md` | Multi-platform files |
+| Conditional | `assets/agents-nested.md` | Monorepo nested AGENTS.md |
+| Reference | `references/decision-matrix.md` | Full detection logic and edge cases |
+| Reference | `references/example-output/README.md` | Quality benchmark |
+| Reference | `references/template-filling-guide.md` | Placeholder filling rules |

--- a/skills/agents-generator/assets/agents-full.md
+++ b/skills/agents-generator/assets/agents-full.md
@@ -1,0 +1,452 @@
+# AGENTS.md — Template (Full Mode)
+
+Replace `{{PLACEHOLDER}}` markers with detected project values. Remove sections whose condition is not met.
+
+This template produces the **rich** AGENTS.md. For minimal (agents.md standard), use `agents-minimal.md`. For monorepo nested files, use `agents-nested.md`.
+
+```markdown
+# AGENTS.md
+
+> Compatible with the [agents.md](https://agents.md) standard (60k+ projects). Specific rules in `.agents/rules/` — {{RULE_CATEGORIES_LIST}}.
+
+## Project Overview
+
+{{PROJECT_OVERVIEW}}
+
+{{DOC_IMPORTS}}
+
+{{WHO_USES_THIS}}
+
+## Setup commands
+
+{{SETUP_COMMANDS_BULLETS}}
+
+{{READ_THIS_FIRST}}
+
+## Source Files
+
+{{SOURCE_FILE_LIST}}
+
+## Where to edit
+
+{{WHERE_TO_EDIT}}
+
+## Essential Commands
+
+| Command | Purpose | When |
+| ------- | ------- | ---- |
+
+{{ESSENTIAL_COMMANDS}}
+
+{{ENVIRONMENT_VARIABLES}}
+
+## Verification Cycle
+
+{{VERIFICATION_CYCLE_INTRO}}
+```
+
+{{VERIFICATION_CYCLE}}
+
+```
+
+{{E2E_MATRIX}}
+{{MONOREPO_REBUILD_NOTE}}
+
+## Before committing
+
+{{BEFORE_COMMIT_CHECKLIST}}
+
+## Pre-validate
+
+{{PRE_VALIDATE}}
+
+## Code Style
+
+{{CODE_STYLE}}
+
+{{IO_CONTRACT}}
+
+## Hard Rules
+
+{{HARD_RULES}}
+
+## Prohibitions
+
+{{PROHIBITIONS}}
+
+## Boundaries
+
+{{BOUNDARIES}}
+
+{{GENERATED_ARTIFACTS_POLICY}}
+
+{{SUBSYSTEM_RULES}}
+
+## Global Conventions
+
+{{GLOBAL_CONVENTIONS}}
+
+{{ARCHITECTURE_DECISIONS}}
+
+{{DOC_UPDATE_CHECKLIST}}
+
+{{INTENT_ROUTING_TABLE}}
+
+{{ERROR_TAXONOMY}}
+
+{{WRITING_STYLE_GUIDE}}
+
+{{GOTCHAS}}
+
+{{SSH_TROUBLESHOOTING}}
+
+## Definition of Done
+
+{{DEFINITION_OF_DONE}}
+
+{{TASK_GUIDES}}
+
+{{CONTRIBUTION_GUARDRAILS}}
+
+{{VERSIONING_POLICY}}
+
+{{RELEASING_SECTION}}
+
+## PR instructions
+
+{{PR_INSTRUCTIONS}}
+
+{{AGENT_DISCLOSURE}}
+
+{{RULE_FILE_LINKS}}
+
+{{CODEGRAPH_SECTION}}
+```
+
+## Always-included sections
+
+### `{{PROJECT_OVERVIEW}}`
+
+One sentence. Package.json `description` or inferred.
+
+### `{{SETUP_COMMANDS_BULLETS}}`
+
+3-5 bullets: install, dev, build, test, lint. Format: `- <description>: \`<command>\``.
+
+### `{{SOURCE_FILE_LIST}}`
+
+Flat tree with one-line purpose per file. Then a **feature-to-file table**:
+
+```
+## Feature map
+| Feature | Files |
+|---------|-------|
+| CLI entry | `src/cli.ts` |
+| Core logic | `src/add.ts` |
+```
+
+5-8 rows mapping common operations to exact files. This is more useful to agents than the tree alone.
+
+### `{{WHERE_TO_EDIT}}`
+
+Same as feature map but framed as "What to edit for X": task → files. If Source Files already has both, this can be lighter.
+
+### `{{ESSENTIAL_COMMANDS}}`
+
+Table with 3 columns: Command | Purpose | **When**. Add a "when to run" decision column:
+
+```
+| `pnpm test` | Run all tests | Fast iteration |
+| `pnpm test:run` | Single-run tests | Before committing |
+| `pnpm typecheck` | TypeScript check | Before committing |
+```
+
+### `{{VERIFICATION_CYCLE_INTRO}}`
+
+"After every code change. Do not mark a task complete without passing:" or, if E2E matrix exists: "Run the smallest relevant verification first."
+
+### `{{BEFORE_COMMIT_CHECKLIST}}`
+
+3-4 items: verification cycle, format check, lockfile verification.
+
+### `{{CODE_STYLE}}`
+
+2-4 project-specific rules. No generic advice.
+
+### `{{PRE_VALIDATE}}`
+Commands to run EXACTLY what the pre-commit hook runs, to avoid slow CI lint-staged failures. Format:
+```
+- Run `{{PRE_COMMIT_CMD}}` on changed files before committing — this is what CI runs.
+```
+Detect from: `.githooks/pre-commit`, `lint-staged` config, `.husky/pre-commit`. Read the actual hook to get exact commands.
+
+### `{{HARD_RULES}}`
+
+2-3 numbered, non-negotiable rules. Violating = rejected. Detect from: .env.example → secrets rule; tests/ → test rule; monorepo → contract sync rule.
+
+### `{{PROHIBITIONS}}`
+
+2-3 "**Never** do X" bullets. Bold the word Never. Detect from project context:
+
+- Universal: "**Never** create README or markdown docs unless explicitly asked."
+- If TypeScript strict: "**Never** use `any` types or `as any` assertions."
+- If release scripts exist: "**Never** bump version numbers in feature PRs."
+- If generated build output exists: "**Never** edit generated files by hand."
+- If monorepo: "**Never** push directly to main on upstream."
+
+### `{{BOUNDARIES}}`
+
+Two subsections: "Ask first" and "Never". Detect from project: if monorepo → cross-package refactor rule. If ORM → destructive data rule. If build output → generated files rule. Secrets and destructive git are universal.
+
+### `{{AGENT_DISCLOSURE}}`
+
+If CONTRIBUTING.md or PR template exists, add agent attribution rules. Format:
+
+```
+- All agent-drafted GitHub content (PR comments, reviews, issues) must include attribution footer.
+- Never @mention or tag individuals unless explicitly authorized.
+- Drafted-by: footer required on all agent-generated GitHub messages.
+```
+
+### `{{GLOBAL_CONVENTIONS}}`
+
+5-8 bullets: package manager, import conventions, naming, language, validation approach.
+
+### `{{DEFINITION_OF_DONE}}`
+
+4-6 numbered checklist items. Include: typecheck/lint/tests, new tests, docs updated, no warnings.
+
+### `{{PR_INSTRUCTIONS}}`
+
+2-3 bullets. Include the **"Goal (pick one per PR)"** scoping pattern if the project has a PR template:
+
+```
+- Pick ONE goal per PR. Frame the title to reflect it.
+- Conventional commits: `feat:`, `fix:`, `refactor:`, `test:`, `chore:`.
+- No AI attribution in commits.
+```
+
+## Conditional sections (detect and include)
+
+### `{{WHO_USES_THIS}}`
+
+CLI tool, API, or SDK consumed by AI agents:
+
+```
+## Who uses this
+
+This CLI's primary consumers include AI agents (Claude Code, Cursor).
+Error messages, output format, and flag design directly affect agent success rates.
+Every error message will be parsed by an AI to decide its next action.
+```
+
+### `{{READ_THIS_FIRST}}`
+
+If `docs/` or `doc/` has 3+ markdown files. Ordered list of files to read before making changes.
+
+### `{{ENVIRONMENT_VARIABLES}}`
+
+If `.env.example`, `.env`, or `process.env.` calls found. Table: Variable | Required | Purpose. 3-8 vars.
+
+### `{{E2E_MATRIX}}`
+
+If the project has both unit tests and E2E tests:
+
+```
+| Change | Unit tests | E2E tests |
+|--------|:----------:|:---------:|
+| New feature | Required | Required |
+| Modify behavior | Required | If behavior changes |
+| Bug fix | Required | If regression risk |
+| Refactor | Required | Not needed |
+```
+
+### `{{IO_CONTRACT}}`
+
+For CLI tools or APIs:
+
+```
+## I/O contract
+- **stdout** is data — JSON, structured output, machine-readable.
+- **stderr** is everything else — progress, warnings, hints.
+- Never mix them. Mixing corrupts pipe chains.
+```
+
+### `{{GENERATED_ARTIFACTS_POLICY}}`
+
+If the project has build output directories (dist/, build/, .next/):
+
+```
+## Generated artifacts
+
+Source-first: edit files in `src/`, `lib/`, `app/`. Generated output in `dist/`
+and `build/` is rebuilt — never edit it directly. Stage generated files only
+for release PRs or when the build output itself is the change.
+```
+
+### `{{SUBSYSTEM_RULES}}`
+
+If monorepo or projects with distinct subdirectories (packages/, apps/, cli/):
+
+```
+## Subsystem rules
+
+### `packages/dashboard/`
+- Never use native browser dialogs. Use shadcn/ui instead.
+- Use kebab-case for file and folder names.
+```
+
+One subsection per subdirectory with non-obvious rules. Read existing AGENTS.md in subdirs for clues.
+
+### `{{ARCHITECTURE_DECISIONS}}`
+
+1-3 non-obvious choices with their "why":
+
+```
+- **Why structured errors**: AI agents parse stderr fields to decide next actions.
+  Never use bare error strings for user-facing failures.
+- **Why pnpm**: workspace protocol requires pnpm. npm/yarn won't resolve it.
+```
+
+### `{{DOC_UPDATE_CHECKLIST}}`
+
+If the project has multiple documentation surfaces:
+
+```
+## Documentation checklist
+
+When adding or changing user-facing features, update ALL:
+1. `cli/src/output.rs` — help output
+2. `README.md` — options table, examples
+3. `docs/` — MDX pages
+4. Inline doc comments in source
+```
+
+### `{{INTENT_ROUTING_TABLE}}`
+
+If the project has multiple entrypoints, tools, or skills:
+
+```
+## Entrypoints by intent
+
+| Intent | Entrypoint |
+|--------|-----------|
+| Reproduce from README | `ai-research-reproduction` |
+| Environment setup | `env-and-assets-bootstrap` |
+```
+
+Maps user goals to the correct entrypoint.
+
+### `{{ERROR_TAXONOMY}}`
+
+For CLI/API projects with structured errors:
+
+```
+## Error types
+
+| Failure | Constructor |
+|---------|------------|
+| Invalid flag/arg | `errs.NewValidationError(...).WithParam("--flag")` |
+| Network failure | `errs.NewNetworkError(...)` |
+| API error | Return as-is — never re-wrap |
+```
+
+### `{{WRITING_STYLE_GUIDE}}`
+
+For projects that produce documentation or AI-facing content:
+
+```
+## Writing style
+
+- Structure: H2/H3 hierarchy, short paragraphs (2-4 sentences)
+- Tone: direct, instructional, second person
+- Clarity: active voice, specific over vague, one idea per section
+- Budget: challenge each paragraph — does it justify its token cost?
+```
+
+### `{{GOTCHAS}}`
+
+If platform-specific issues exist (Windows, NTFS, Docker, sandbox):
+
+```
+## Gotchas
+- `npx vite build` hangs on NTFS — use `node node_modules/vite/bin/vite.js build`
+- Server startup takes 30-60s — don't assume failure immediately
+```
+
+### `{{SSH_TROUBLESHOOTING}}`
+Only if git remote uses SSH (`git@github.com`):
+```
+## Git SSH troubleshooting
+If Git fails with `sign_and_send_pubkey` or `Permission denied`:
+- **Do NOT** switch remotes to HTTPS or retry repeatedly.
+- Ask the user to ensure their SSH agent is available and unlocked.
+```
+
+### `{{TASK_GUIDES}}`
+
+1-3 step-by-step guides for repeatable operations. 3-4 steps each.
+
+### `{{CONTRIBUTION_GUARDRAILS}}`
+
+If `.github/CONTRIBUTING.md` or PR template exists:
+
+```
+## Contribution guardrails
+
+- Issue-first: open an issue before a PR unless you're a maintainer.
+- AI agents must disclose AI assistance in PR descriptions.
+- Unsolicited PRs from non-maintainers may be closed without review.
+```
+
+### `{{VERSIONING_POLICY}}`
+
+If the project has multiple independently-versioned components:
+
+```
+## Versioning
+
+| Component | Version file | Bump on |
+|-----------|-------------|---------|
+| Root | `package.json` | Breaking changes |
+| Skills | `skills/*/SKILL.md` | Any change (unbumped = invisible) |
+Do not bump versions in feature PRs — versioning is a release step.
+```
+
+### `{{RELEASING_SECTION}}`
+
+Numbered steps. Only if publish/release/deploy scripts exist.
+
+### `{{DOC_IMPORTS}}`
+
+If the project has existing documentation (CONTRIBUTING.md, docs/\*.md, style guides): reference them with `@import` instead of duplicating content. Format:
+
+```
+> Detailed docs: @CONTRIBUTING.md, @docs/best_practices.md
+```
+
+- **@import** for docs the agent should ALWAYS have in context (conventions, patterns, style rules).
+- **Plain markdown link** `[Topic](path)` for docs only needed occasionally.
+- **Warn about large imports**: if a doc is over ~300 lines (~1500 tokens), flag it: "⚠️ Large file — consider importing only key sections."
+- Never duplicate content that already exists in project docs.
+
+### `{{RELEASING_SECTION}}`
+
+Numbered steps. Only if publish/release/deploy scripts exist.
+
+### `{{RULE_FILE_LINKS}}`
+
+One link per generated rule file. Only in full mode.
+
+### `{{CODEGRAPH_SECTION}}`
+
+Only if `.codegraph/` exists.
+
+### `{{CLAUDE_MD_NOTE}}`
+
+If Claude Code is detected (`.claude/` directory or `CLAUDE.md` exists), also generate a thin `CLAUDE.md` at project root using `assets/claude.md`. AGENTS.md is the universal standard — CLAUDE.md only points to it and adds Claude-specific config if any exists.
+
+## Post-generation limits
+
+- **300 line soft cap**: if the generated AGENTS.md exceeds 300 lines, warn and suggest moving content to `.agents/rules/` or existing project docs with `@import`.
+- **500 line hard cap**: never exceed. Move content to rule files or reference existing docs.

--- a/skills/agents-generator/assets/agents-minimal.md
+++ b/skills/agents-generator/assets/agents-minimal.md
@@ -1,0 +1,60 @@
+# AGENTS.md — Minimal Template
+
+Generate when the user asks for a simple, single-file AGENTS.md following the agents.md standard format (https://agents.md). No YAML frontmatter, no rule files, no ASCII art. Keep it under 30 lines.
+
+Fill `{{PLACEHOLDER}}` markers from project detection. Only include sections whose content is non-empty.
+
+```markdown
+## Setup commands
+
+{{SETUP_COMMANDS}}
+
+## Code style
+
+{{CODE_STYLE}}
+
+## Testing instructions
+
+{{TESTING_INSTRUCTIONS}}
+
+## PR instructions
+
+{{PR_INSTRUCTIONS}}
+```
+
+## Filling rules
+
+### `{{SETUP_COMMANDS}}`
+
+- One bullet per command: install deps, start dev, run build, run lint, format
+- Use the detected package manager (`pnpm install`, `bun install`, etc.)
+- Keep it short — 3-5 bullets max
+
+### `{{CODE_STYLE}}`
+
+- 3-5 project-specific conventions as bullets
+- Only verifiable from config: TypeScript strict, no any, single/double quotes, semicolons, import conventions, UI language
+- Format: `- TypeScript strict mode` not `- We use TypeScript`
+
+### `{{TESTING_INSTRUCTIONS}}`
+
+- What the agent should run before committing
+- The exact test command from package.json
+- One line about adding tests: "- Add or update tests for the code you change"
+- If coverage: mention the command
+
+### `{{PR_INSTRUCTIONS}}`
+
+- Commit format: conventional commits or project-specific
+- What to run before pushing: lint + test + typecheck
+- Branch naming if applicable
+- Attribution rules: "- No AI attribution in commits"
+
+## Omission rules
+
+- Skip any section whose content would be empty
+- Never include architecture descriptions, ASCII diagrams, or stack tables
+- Never include rule file references or `.agents/rules/` mentions
+- If the project has no test runner, skip `## Testing instructions`
+- If the project has no lint setup, omit lint from the PR checklist
+- Keep total file under 30 lines

--- a/skills/agents-generator/assets/agents-nested.md
+++ b/skills/agents-generator/assets/agents-nested.md
@@ -1,0 +1,73 @@
+# AGENTS.md — Nested Template (monorepo sub-package)
+
+Generate for each sub-package in a monorepo. Lightweight, package-specific. No YAML frontmatter. Format follows the agents.md standard.
+
+Fill `{{PLACEHOLDER}}` markers from the sub-package's package.json and config files.
+
+```markdown
+# {{PACKAGE_NAME}}
+
+{{PACKAGE_DESCRIPTION}}
+
+## Setup commands
+
+- Install: `cd {{PACKAGE_RELATIVE_PATH}} && {{PM}} install`
+- Build: `{{BUILD_COMMAND}}`
+- Dev: `{{DEV_COMMAND}}`
+
+{{TEST_SECTION}}
+
+## Code style
+
+{{CODE_STYLE}}
+```
+
+## Filling rules
+
+### `{{PACKAGE_NAME}}`
+
+From `package.json` `name` field, or directory name if not found.
+
+### `{{PACKAGE_DESCRIPTION}}`
+
+One sentence from `package.json` `description`, or inferred from the package's purpose (shared types, API server, frontend app, etc.).
+
+### `{{PACKAGE_RELATIVE_PATH}}`
+
+Path relative to repo root, e.g. `packages/db` or `apps/dashboard`.
+
+### `{{PM}}`
+
+The root package manager: `pnpm`, `bun`, `npm`, `yarn`.
+
+### `{{BUILD_COMMAND}}`
+
+- Monorepo with turborepo: `npx turbo run build --filter={{PACKAGE_NAME}}`
+- Monorepo with pnpm: `pnpm --filter {{PACKAGE_NAME}} build`
+- If no build script in sub-package: omit or say "`cd {{PACKAGE_RELATIVE_PATH}} && {{PM}} run build`"
+
+### `{{DEV_COMMAND}}`
+
+- Same pattern as build. If sub-package has no dev script, omit.
+
+### `{{TEST_SECTION}}`
+
+```
+## Testing instructions
+- Run tests: `{{TEST_COMMAND}}`
+- Add or update tests for the code you change
+```
+
+Only include if the sub-package has a test script or test config.
+
+### `{{CODE_STYLE}}`
+
+- 2-3 sub-package-specific conventions
+- If sub-package is a shared package: mention exports map, entrypoints, rebuild dependencies
+- If sub-package is an app: mention port, router type, framework
+
+## Omission rules
+
+- Skip the whole nested file if the sub-package has no `package.json`
+- Keep under 20 lines
+- No architecture descriptions, no ASCII diagrams, no tables

--- a/skills/agents-generator/assets/architecture.md
+++ b/skills/agents-generator/assets/architecture.md
@@ -1,0 +1,43 @@
+# Architecture Rules
+
+## {{PROJECT_TYPE_TITLE}}
+
+{{PROJECT_TYPE_DESCRIPTION}}
+
+```text
+{{ARCHITECTURE_DIAGRAM}}
+```
+
+## Stack
+
+| Layer           | Technology | Version |
+| --------------- | ---------- | ------- |
+| {{STACK_TABLE}} |
+
+## {{ROUTING_SECTION_TITLE}}
+
+{{ROUTING_TABLE}}
+
+## Data Flow
+
+```
+{{DATA_FLOW}}
+```
+
+{{SERVER_ACTION_VS_API_SECTION}}
+
+{{RATE_LIMIT_SECTION}}
+
+{{LANGUAGE_SECTION}}
+
+## Generation Rules
+
+- **PROJECT_TYPE_TITLE**: "Single App Structure" if not monorepo, "Monorepo Structure" if monorepo.
+- **ARCHITECTURE_DIAGRAM**: ASCII art of the main directory layout. For monorepos, show apps + shared packages + their relationships. For single apps, show app/ → components/ + lib/ + external service connections.
+- **STACK_TABLE**: Extract from package.json + config files. Each row: layer, technology, exact version.
+- **ROUTING_SECTION_TITLE**: "Routes" for Next.js App Router, "Endpoints" for NestJS/Express, "Routes" generic.
+- **ROUTING_TABLE**: List every route with type (server/client/API) and description. Read from app/ or src/app/.
+- **DATA_FLOW**: ASCII diagram of the main data flow (user action → frontend → backend → database/external → response). Use real function names.
+- **SERVER_ACTION_VS_API_SECTION**: If both server actions and API routes exist, explain which is primary and their differences. If only one, skip the comparison.
+- **RATE_LIMIT_SECTION**: If rate-limit.ts or rate limiting middleware exists, document it with limits and expiry.
+- **LANGUAGE_SECTION**: If the project uses i18n or has UI in a language other than English, document it.

--- a/skills/agents-generator/assets/backend.md
+++ b/skills/agents-generator/assets/backend.md
@@ -1,0 +1,35 @@
+# Backend Patterns (NestJS)
+
+## Module Architecture (Screaming Architecture)
+
+Each business module is a directory with its own module, controller, and service:
+
+```text
+src/{feature}/
+  {feature}.module.ts       # NestJS module
+  {feature}.controller.ts   # REST routes
+  {feature}-crud.service.ts # Business logic
+  constants.ts              # Module constants
+  __tests__/                # Unit tests
+```
+
+## Rules
+
+- DTOs decorated with validation, validated via global pipe (ZodValidationPipe or class-validator).
+- Dynamic/unmodelable body: receive as `unknown` in controller, cast to narrowest concrete interface in service — never `any`.
+- When splitting a god service, each new service injects only its own dependencies.
+- Services inject the database service from the shared package, not the generated client directly.
+- Role-checking: use enum values directly from the shared package.
+- Use `@nestjs/swagger` decorators for exposed endpoint documentation.
+
+## Error Handling
+
+- Global exception filter catches all unhandled exceptions.
+- Handle database errors: unique constraint, not found, foreign key, relation violation.
+- Typed business errors with code + consistent message.
+- Standard HTTP exceptions for common cases.
+- Auto-log errors >=500 with stack trace.
+
+## Generation Rules
+
+This template is only used when `@nestjs/core` is detected in dependencies. Adapt all paths and module names based on the actual project structure found in `src/`.

--- a/skills/agents-generator/assets/claude.md
+++ b/skills/agents-generator/assets/claude.md
@@ -1,0 +1,39 @@
+# CLAUDE.md — Template
+
+ONLY generate if Claude Code is detected in the project. Detection signals:
+
+- `.claude/` directory exists
+- `CLAUDE.md` file exists at project root
+- `.claude/skills/` directory exists
+- `claude` appears in devDependencies or as a tool reference
+
+The CLAUDE.md file should be **thin**. Its only job is to point to AGENTS.md. Do not duplicate content.
+
+```markdown
+# CLAUDE.md
+
+See @AGENTS.md
+
+{{CLAUDE_SPECIFIC_SECTION}}
+```
+
+## Filling rules
+
+### `{{CLAUDE_SPECIFIC_SECTION}}`
+
+Only add if the project actually uses Claude-specific features. If none, omit entirely:
+
+- **`.claude/rules/`** — if modular rule files exist: `Additional rules in @.claude/rules/`
+- **`.claude/commands/`** — if custom slash commands exist: `Custom commands: @.claude/commands/`
+- **`.claude/agents/`** — if custom subagents exist: `Custom subagents: @.claude/agents/`
+- **Claude-only behavior**: "Use plan mode for non-trivial tasks", "Use subagents for parallel work"
+
+If none of these apply, CLAUDE.md is just:
+
+```markdown
+# CLAUDE.md
+
+See @AGENTS.md
+```
+
+That's the whole file. Don't add empty sections.

--- a/skills/agents-generator/assets/database.md
+++ b/skills/agents-generator/assets/database.md
@@ -1,0 +1,40 @@
+# Database Rules
+
+## ORM: {{ORM_NAME}}
+
+{{ORM_DESCRIPTION}}
+
+## Schema Location
+
+{{SCHEMA_LOCATION}}
+
+{{MIGRATIONS_SECTION}}
+
+## Conventions
+
+{{DB_CONVENTIONS}}
+
+## Relationships and Queries
+
+{{QUERY_PATTERNS}}
+
+## Generation Rules
+
+- **ORM_NAME**: "Prisma", "Drizzle", "Knex", "TypeORM", "Mongoose", or "Raw SQL".
+- **ORM_DESCRIPTION**: Database provider detected (postgresql, sqlite, mysql, mongodb).
+- **SCHEMA_LOCATION**: Where the schema or DB config lives.
+- **MIGRATIONS_SECTION**:
+  - **Prisma**: `prisma migrate dev` for development, `prisma migrate deploy` for production. `prisma generate` to regenerate client.
+  - **Drizzle**: `drizzle-kit generate` for migrations, `drizzle-kit push` for prototyping.
+  - **Knex**: `knex migrate:make`, `knex migrate:latest`.
+- **DB_CONVENTIONS**:
+  - IDs: `uuid` vs `cuid` vs `autoincrement` vs `ObjectId`. Detect from schema.
+  - Timestamps: `createdAt` + `updatedAt` automatically.
+  - Naming: `snake_case` in DB, `camelCase` in code.
+  - Enums: native DB enums vs strings vs TypeScript enums.
+  - Soft deletes: if `deletedAt` field exists.
+- **QUERY_PATTERNS**:
+  - **Prisma**: `prisma.user.findMany({ where, include, select })`. Include vs select rules. Transactions with `prisma.$transaction`.
+  - **Drizzle**: `db.select().from(users).where(eq(...))`. Relations with `relations`.
+  - **Mongoose**: `Model.find()`, `Model.populate()`, `Model.aggregate()`.
+  - **Raw SQL**: Use parameterized queries, never string interpolation.

--- a/skills/agents-generator/assets/forms.md
+++ b/skills/agents-generator/assets/forms.md
@@ -1,0 +1,56 @@
+# Form Patterns
+
+## Library: {{FORM_LIBRARY}}
+
+{{FORM_LIBRARY_DESCRIPTION}}
+
+## Form Structure
+
+```tsx
+{
+  {
+    FORM_EXAMPLE;
+  }
+}
+```
+
+## Rules
+
+{{FORM_RULES}}
+
+## Validation
+
+{{VALIDATION_SECTION}}
+
+## Errors
+
+{{ERROR_SECTION}}
+
+## Generation Rules
+
+- **FORM_LIBRARY**: "react-hook-form", "formik", "TanStack Form", or "Manual (controlled inputs)".
+- **FORM_LIBRARY_DESCRIPTION**: One sentence about how forms are handled in the project.
+- **FORM_EXAMPLE**: Real example from the project. Read an existing form and adapt. Include: hook import, register/control, handleSubmit, errors, submit handler.
+- **FORM_RULES**:
+  - **react-hook-form**:
+    - `useForm<T>()` with generic type for the form schema.
+    - `register("fieldName")` for simple inputs, `control` + `Controller` for custom components.
+    - `formState: { errors, isSubmitting }` for state.
+    - If using Zod resolver: `zodResolver(schema)` in `useForm`.
+    - Do not mix `useState` with react-hook-form — use `watch()` or `getValues()`.
+  - **formik**:
+    - `useFormik<T>()` or `<Formik>` component.
+    - `validationSchema` for Yup/Zod.
+    - `handleChange`, `handleBlur`, `handleSubmit`.
+  - **Manual**:
+    - `useState` per field.
+    - Manual validation in `handleSubmit`.
+    - No form library.
+- **VALIDATION_SECTION**: If using Zod/Yup/Valibot validation:
+  - Where schemas live (`lib/schemas/`, `src/validations/`).
+  - How they integrate with the form.
+  - Whether they are shared between client and server.
+- **ERROR_SECTION**: How errors are displayed:
+  - Inline below the field.
+  - Toast / sonner for server errors.
+  - Messages in the project's language based on i18n detection.

--- a/skills/agents-generator/assets/frontend-patterns.md
+++ b/skills/agents-generator/assets/frontend-patterns.md
@@ -1,0 +1,44 @@
+# Frontend Patterns
+
+## File Structure
+
+```text
+{{FILE_STRUCTURE}}
+```
+
+## Component Rules
+
+{{COMPONENT_RULES}}
+
+## State Management
+
+{{STATE_MANAGEMENT}}
+
+## Toast / Notification System
+
+{{TOAST_SYSTEM}}
+
+## Analytics
+
+{{ANALYTICS_SECTION}}
+
+## Trust Boundaries
+
+{{TRUST_BOUNDARIES}}
+
+## Generation Rules
+
+- **FILE_STRUCTURE**: ASCII tree of relevant source directories (app/, components/, lib/, src/). Include only code directories, not node_modules, .git, etc.
+- **COMPONENT_RULES**:
+  - Next.js App Router: "use client" rule, server/client component split, where each type lives.
+  - Vite/SPA: folder structure, lazy loading.
+  - Tailwind: prohibit inline `style={{}}` (except cases like global-error).
+  - shadcn/ui: atomic components in components/ui/.
+  - UI language for labels/navigation (English/Spanish/etc.) based on project detection.
+- **STATE_MANAGEMENT**:
+  - Zustand/Redux/Jotai: document stores, server hydration patterns.
+  - useState only: document where main state lives.
+  - Shared hooks: list them with their purpose.
+- **TOAST_SYSTEM**: Detect sonner, shadcn toast, custom system, or none. Document the API.
+- **ANALYTICS_SECTION**: If Google Analytics, GTM, Plausible, etc. exists. Document the hook or helper.
+- **TRUST_BOUNDARIES**: Document what the client validates vs what the server validates, what goes through server actions vs client-side.

--- a/skills/agents-generator/assets/git-workflow.md
+++ b/skills/agents-generator/assets/git-workflow.md
@@ -1,0 +1,61 @@
+# Git Workflow
+
+## Approval Rules
+
+- **NO commits** without the user validating the code first — show the diff.
+- **NO branches** unless explicitly requested.
+- **NO push** unless instructed.
+- Before touching code: show plan (files to touch + proposed commits).
+- After applying: show commands run and results (lint/test/{{QUALITY_TOOL}}).
+
+## Commit Convention
+
+Conventional Commits:
+
+```
+feat: <brief description>
+fix: <brief description>
+refactor: <brief description>
+test: <brief description>
+chore: <brief description>
+docs: <brief description>
+```
+
+Rules:
+
+- One commit per logical change.
+- Short imperative messages.
+- No trailing period.
+- **No "Co-Authored-By" or AI attribution.**
+- {{COMMIT_LANGUAGE}} for commit messages.
+
+{{COMMIT_EXAMPLES}}
+
+## Pre-Commit Verification
+
+Before committing, run:
+
+```
+{{PRE_COMMIT_CYCLE}}
+```
+
+If any step fails, do not commit. Fix and retry.
+
+## Branches
+
+Default base: `{{DEFAULT_BRANCH}}`.
+
+Format:
+
+```
+{{BRANCH_FORMAT}}
+```
+
+## Generation Rules
+
+- **QUALITY_TOOL**: "doctor" if react-doctor is present, otherwise just "lint".
+- **COMMIT_LANGUAGE**: "English" for projects with code in English, "Spanish" if the project uses Spanish in commits.
+- **COMMIT_EXAMPLES**: 2-3 real examples based on the project's typical change types. Read `git log --oneline -5` if available.
+- **PRE_COMMIT_CYCLE**: Shortened version of the full verification cycle.
+- **DEFAULT_BRANCH**: Detect with `git branch --show-current` or `git remote show origin`. Default: "master".
+- **BRANCH_FORMAT**: `feature/<slug>`, `fix/<slug>`, etc. If the project uses issue references (REQ-XXX), include them in the format.

--- a/skills/agents-generator/assets/i18n.md
+++ b/skills/agents-generator/assets/i18n.md
@@ -1,0 +1,50 @@
+# i18n Rules
+
+## Library: {{I18N_LIBRARY}}
+
+{{I18N_DESCRIPTION}}
+
+## Supported Languages
+
+{{LANGUAGES}}
+
+## File Structure
+
+```text
+{{I18N_FILE_STRUCTURE}}
+```
+
+## Usage in Code
+
+```typescript
+{
+  {
+    I18N_USAGE_EXAMPLE;
+  }
+}
+```
+
+## Rules
+
+{{I18N_RULES}}
+
+## Generation Rules
+
+- **I18N_LIBRARY**: "next-intl", "react-i18next", "next-i18next", "Lingui", or "Custom".
+- **I18N_DESCRIPTION**: How i18n works in the project. E.g.: "next-intl with App Router, messages per locale in JSON files, detection via middleware."
+- **LANGUAGES**: List of supported locales. Detect from `i18n.ts`, `next.config.*`, `middleware.ts`, or `messages/{locale}/` folders.
+- **I18N_FILE_STRUCTURE**: Directory tree with translation files.
+- **I18N_USAGE_EXAMPLE**:
+  - **next-intl App Router**: `useTranslations()`, `getTranslations()`, `<NextIntlClientProvider>`.
+  - **next-intl Pages Router**: `getStaticProps` with `useTranslations`.
+  - **react-i18next**: `useTranslation()`, `t("key")`, namespaces.
+  - **next-i18next**: `serverSideTranslations`, `useTranslation`.
+- **I18N_RULES**:
+  - UI uses translations, not hardcoded strings.
+  - Keys in snake_case or camelCase (detect from project).
+  - Interpolation: `t("greeting", { name })` not concatenation.
+  - Date/number formatting with `Intl` or library helpers.
+  - Metadata and SEO also translated (`generateMetadata` with `getTranslations`).
+  - Next.js App Router: middleware handles locale detection + redirect.
+  - Pages Router: `getStaticProps`/`getServerSideProps` load translations.
+  - Translation files nested by feature, not a single flat file.

--- a/skills/agents-generator/assets/platform.md
+++ b/skills/agents-generator/assets/platform.md
@@ -1,0 +1,54 @@
+# {{PLATFORM_NAME}} Rules — Template
+
+ONLY generate if the corresponding platform is detected in the project. Detection signals per platform below.
+
+This file is wrapped in managed blocks. The agent regenerates content between markers on update; human edits outside markers are preserved.
+
+```text
+<!-- AGENTS-GENERATED-START -->
+# {{PLATFORM_RULES_HEADER}}
+
+{{PLATFORM_SPECIFIC_CONTENT}}
+<!-- AGENTS-GENERATED-END -->
+```
+
+## Platform detection and output
+
+| Platform           | Detection signal                                  | Output file                       | Content mapping                                                          |
+| ------------------ | ------------------------------------------------- | --------------------------------- | ------------------------------------------------------------------------ |
+| **Cursor**         | `.cursorrules` exists or `.cursor/` directory     | `.cursorrules`                    | AGENTS.md sections: Setup commands, Code Style, Hard Rules, Prohibitions |
+| **GitHub Copilot** | `.github/copilot-instructions.md` exists          | `.github/copilot-instructions.md` | Flat instructions: Setup, Code Style, Testing                            |
+| **Gemini CLI**     | `GEMINI.md` exists or `.gemini/` directory        | `GEMINI.md`                       | System prompt style: Overview, Commands, Conventions                     |
+| **Windsurf**       | `.windsurfrules` exists or `.windsurf/` directory | `.windsurfrules`                  | Progressive disclosure: Tech Stack, Rules, Testing                       |
+| **Codex**          | Already covered by AGENTS.md (native support)     | —                                 | AGENTS.md is the primary file                                            |
+
+## Filling rules
+
+### `{{PLATFORM_NAME}}`
+
+The platform name: "Cursor", "GitHub Copilot", "Gemini CLI", "Windsurf".
+
+### `{{PLATFORM_RULES_HEADER}}`
+
+Platform-specific heading:
+
+- Cursor: `# Project Rules: {PROJECT_NAME}`
+- Copilot: `# Copilot Instructions`
+- Gemini: `# Gemini CLI Guidelines`
+- Windsurf: `# Windsurf Rules`
+
+### `{{PLATFORM_SPECIFIC_CONTENT}}`
+
+Adapt from AGENTS.md but use platform-specific format:
+
+- **Cursor**: Progressive disclosure with severity levels. Include BAD/GOOD code examples.
+- **Copilot**: Flat markdown. Keep it short — Copilot has limited context window.
+- **Gemini**: System prompt style. Second person, instructional.
+- **Windsurf**: Progressive disclosure. Include cascade rules.
+
+## Generation rules
+
+1. Only generate for platforms actually detected in the project.
+2. Keep each file under 200 lines — they're companions to AGENTS.md, not replacements.
+3. Include a pointer back to AGENTS.md: `> Full rules in @AGENTS.md`
+4. Use managed blocks (`<!-- AGENTS-GENERATED-START -->` / `<!-- AGENTS-GENERATED-END -->`) to preserve human edits.

--- a/skills/agents-generator/assets/sdd-workflow.md
+++ b/skills/agents-generator/assets/sdd-workflow.md
@@ -1,0 +1,46 @@
+# SDD Workflow
+
+Software Design Document — design before implementing.
+
+## Preflight Defaults (cached, do not re-ask)
+
+- **Pace**: {{SDD_PACE}}
+- **Artifacts**: {{SDD_ARTIFACTS}}
+- **Delivery strategy**: {{SDD_DELIVERY}}
+- **Review budget**: {{SDD_REVIEW_BUDGET}} lines
+- **Chain strategy**: {{SDD_CHAIN_STRATEGY}}
+
+## Rules
+
+- Sub-agents can make errors (duplicate blocks, wrong types) — always review their output.
+- After each SDD phase: run the full verification cycle.
+- On archive: verify all tasks marked done, delta specs synced to main specs.
+
+## Post-Apply Verification (MANDATORY)
+
+After `sdd-apply` completes and before advancing to `sdd-verify`, the orchestrator MUST run the verification cycle:
+
+```
+{{VERIFICATION_CYCLE}}
+```
+
+{{MONOREPO_POST_APPLY}}
+{{DOCTOR_POST_APPLY}}
+
+## Spec Verification
+
+Project specs are located at:
+{{SPECS_LOCATIONS}}
+
+Consult these sources before making architectural changes or adding new features.
+
+## Generation Rules
+
+- **SDD_PACE**: "Interactive" by default. "Automatic" if the project uses auto in CI.
+- **SDD_ARTIFACTS**: "both" if OpenSpec + Engram exist, "openspec" if only OpenSpec, "engram" if only Engram.
+- **SDD_DELIVERY**: "ask-on-risk" by default. "exception-ok" if the project prefers large PRs.
+- **SDD_REVIEW_BUDGET**: 400 by default. Adjust based on the project's typical PR size.
+- **SDD_CHAIN_STRATEGY**: "stacked-to-main" if fast merge, "feature-branch-chain" if long feature branches.
+- **MONOREPO_POST_APPLY**: If monorepo, add shared package rebuild steps before the cycle.
+- **DOCTOR_POST_APPLY**: If react-doctor exists, add rule about new issues.
+- **SPECS_LOCATIONS**: List docs/specs/, OpenSpec, relevant Engram topics.

--- a/skills/agents-generator/assets/server-actions.md
+++ b/skills/agents-generator/assets/server-actions.md
@@ -1,0 +1,36 @@
+# Server Actions / Backend
+
+## Entry Point
+
+{{ENTRY_POINT_DESCRIPTION}}
+
+## Flow
+
+{{REQUEST_FLOW}}
+
+## {{RESPONSE_TYPE_TITLE}}
+
+{{RESPONSE_TYPE}}
+
+## Error Handling
+
+{{ERROR_HANDLING}}
+
+## Rate Limiting
+
+{{RATE_LIMITING}}
+
+## Generation Rules
+
+- **ENTRY_POINT_DESCRIPTION**:
+  - Server actions: main file(s), exported function(s), parameters.
+  - API Routes: files in app/api/, HTTP methods, parameters.
+  - NestJS: main controllers, guards, DTOs.
+- **REQUEST_FLOW**: Numbered steps of a typical request flow (validation → rate limit → logic → response).
+- **RESPONSE_TYPE_TITLE**: "DownloadResult", "ApiResponse", or the main response type name.
+- **RESPONSE_TYPE**: Interface/type of the response, with comments on optional vs required fields.
+- **ERROR_HANDLING**:
+  - If ErrorCode enum exists: document it with all codes.
+  - If GlobalExceptionFilter exists: document it.
+  - If detectErrorCode or similar exists: document the heuristic.
+- **RATE_LIMITING**: If rate-limit.ts or middleware exists: document mechanism, limits, expiry.

--- a/skills/agents-generator/assets/styling.md
+++ b/skills/agents-generator/assets/styling.md
@@ -1,0 +1,48 @@
+# Styling Rules
+
+## Approach: {{CSS_APPROACH}}
+
+{{CSS_APPROACH_DESCRIPTION}}
+
+## Rules
+
+{{STYLING_RULES}}
+
+## Themes / Design Tokens
+
+{{THEME_SECTION}}
+
+## Animations
+
+{{ANIMATION_SECTION}}
+
+## Generation Rules
+
+- **CSS_APPROACH**: Detected approach name: "Tailwind CSS", "CSS Modules", "styled-components", "Emotion", "Sass/SCSS", "Plain CSS".
+- **CSS_APPROACH_DESCRIPTION**: One sentence summarizing how styling works. E.g.: "Tailwind CSS v4 with utility-first classes. No separate CSS files except globals.css."
+- **STYLING_RULES**: Approach-specific rules:
+  - **Tailwind**:
+    - No inline `style={{}}` — always Tailwind classes. Exception: dynamically computed values (mouse-position based).
+    - `cn()` for combining conditional classes. If `lib/utils.ts` has `cn`, document it.
+    - Responsive: mobile-first with `sm:`, `md:`, `lg:` breakpoints.
+    - Dark mode: if using `class="dark"` or `prefers-color-scheme`.
+    - shadcn/ui: components use `components/ui/`, theme via CSS variables.
+  - **CSS Modules**:
+    - `.module.css` files next to the component.
+    - `import styles from "./Component.module.css"`.
+    - No global classes (use `:global()` if needed).
+  - **styled-components**:
+    - `styled.div` / `styled(Component)` for styled components.
+    - Theme provider with `ThemeProvider`.
+    - Transient props with `$` prefix.
+  - **Sass/SCSS**:
+    - `.scss` files with variables, mixins, nesting.
+    - No inline `style={{}}`.
+- **THEME_SECTION**: If theming system exists (CSS variables, ThemeProvider, next-themes):
+  - Where tokens are defined (globals.css, theme.ts).
+  - How to switch between light/dark.
+  - Whether it's dark-mode only or has a toggle.
+- **ANIMATION_SECTION**: If using `tw-animate-css`, `framer-motion`, `react-spring`:
+  - `animate-in`, `fade-in`, `slide-in-from-*` (tw-animate-css).
+  - `motion.div`, `AnimatePresence` (framer-motion).
+  - Accessibility: `prefers-reduced-motion`.

--- a/skills/agents-generator/assets/testing.md
+++ b/skills/agents-generator/assets/testing.md
@@ -1,0 +1,67 @@
+# Testing Strategy
+
+## Runner
+
+{{TEST_RUNNER_INFO}}
+
+| Command           | Purpose |
+| ----------------- | ------- |
+| {{TEST_COMMANDS}} |
+
+## Test Files
+
+```text
+{{TEST_FILE_STRUCTURE}}
+```
+
+{{TEST_COUNT}}
+
+## Running Specific Tests
+
+{{SPECIFIC_TEST_COMMANDS}}
+
+## Patterns
+
+{{TEST_PATTERNS}}
+
+## When Writing New Tests
+
+{{NEW_TEST_RULES}}
+
+## Verification
+
+After changes to {{TESTED_AREA}}:
+
+```
+{{VERIFICATION_CYCLE}}
+```
+
+## Generation Rules
+
+- **TEST_RUNNER_INFO**: "Vitest X.Y.Z" or "Jest X.Y.Z". If both exist, document which is used for what.
+- **TEST_COMMANDS**: Extract from package.json scripts. Include watch mode, single-run, coverage.
+- **TEST_FILE_STRUCTURE**: Directory tree with found test files.
+- **TEST_COUNT**: "Total: N tests" counting all test cases. If uncountable, report "N test files".
+- **SPECIFIC_TEST_COMMANDS**: Generate commands to run specific test files. Format:
+  ```
+  # Run all tests
+  {{PM}} {{TEST_RUN_SCRIPT}}
+
+  # Run a specific test file
+  {{PM}} {{TEST_RUNNER}} {{TEST_FILE_PATH}}
+
+  # Run tests matching a pattern
+  {{PM}} {{TEST_RUNNER}} -t "test name pattern"
+  ```
+  - For vitest: `bun run test path/to/file.test.ts` or `bun vitest run -t "pattern"`
+  - For jest: `npm test -- path/to/file.spec.ts` or `npx jest -t "pattern"`
+  - For playwright: `npx playwright test path/to/file.spec.ts`
+  - Read the actual test runner config to determine the correct invocation pattern.
+  - List 2-3 real test file paths as examples.
+- **TEST_PATTERNS**:
+  - If using mocks (vi.mock, jest.mock): document what is mocked and how.
+  - If using global fixtures: document where they are.
+  - If using inline factories/builders: document the pattern.
+  - If there are type narrowing tests (type guards): document it.
+- **NEW_TEST_RULES**: Project-specific rules for new tests (where to create, naming, what to cover).
+- **TESTED_AREA**: "lib/" or "src/" — the main tested directory.

--- a/skills/agents-generator/references/decision-matrix.md
+++ b/skills/agents-generator/references/decision-matrix.md
@@ -1,0 +1,311 @@
+# Decision Matrix — Project Detection and Rule Selection
+
+## Detection Order
+
+Run detections in this order. Each step reads files and sets flags used by later steps.
+
+### 1. Package manager
+
+Check for lockfile: `bun.lock` → bun, `pnpm-lock.yaml` → pnpm, `package-lock.json` → npm, `yarn.lock` → yarn.
+
+### 2. Project type
+
+`workspaces` in root `package.json` → monorepo. Otherwise → single app.
+
+### 3. Framework
+
+| Dep found                | Framework | Router detection                                                                                                                    |
+| ------------------------ | --------- | ----------------------------------------------------------------------------------------------------------------------------------- |
+| `next`                   | Next.js   | `app/` has `page.tsx` or `layout.tsx` → App Router; `pages/` has `.tsx` → Pages Router; both → hybrid (treat as App Router primary) |
+| `@nestjs/core`           | NestJS    | N/A                                                                                                                                 |
+| `vite`                   | Vite      | Check `react` for React, `vue` for Vue, `svelte` for Svelte                                                                         |
+| `@angular/core`          | Angular   | N/A                                                                                                                                 |
+| `express`                | Express   | N/A                                                                                                                                 |
+| `fastify`                | Fastify   | N/A                                                                                                                                 |
+| `remix` / `@remix-run/*` | Remix     | N/A                                                                                                                                 |
+| `astro`                  | Astro     | N/A                                                                                                                                 |
+
+### 4. Monorepo tool (if monorepo)
+
+| File found                 | Tool                              |
+| -------------------------- | --------------------------------- |
+| `turbo.json`               | Turborepo                         |
+| `nx.json`                  | Nx                                |
+| `lerna.json`               | Lerna                             |
+| `pnpm-workspace.yaml` only | pnpm workspaces (no orchestrator) |
+
+### 5. Language
+
+`tsconfig.json` exists → TypeScript. Check `compilerOptions.strict: true` → strict mode.
+
+### 6. CSS approach
+
+| Signal                                      | Approach                     |
+| ------------------------------------------- | ---------------------------- |
+| `tailwindcss` in deps                       | Tailwind CSS                 |
+| `components.json` exists                    | shadcn/ui (implies Tailwind) |
+| `styled-components` in deps                 | styled-components            |
+| `@emotion/*` in deps                        | Emotion                      |
+| `.module.css` or `.module.scss` files found | CSS Modules                  |
+| `sass` or `node-sass` in deps               | Sass/SCSS                    |
+| None of the above                           | Plain CSS / CSS imports      |
+
+### 7. Testing
+
+| Dep found                          | Runner     | Extra                                                  |
+| ---------------------------------- | ---------- | ------------------------------------------------------ |
+| `vitest`                           | Vitest     | Check `vitest.config.*` for env (node/jsdom/happy-dom) |
+| `jest`                             | Jest       | Check `jest.config.*` for env                          |
+| `playwright` or `@playwright/test` | Playwright | E2E tests present                                      |
+| `cypress`                          | Cypress    | E2E tests present                                      |
+| None                               | —          | Skip testing rules                                     |
+
+### 8. Validation
+
+| Dep found         | Library                                           |
+| ----------------- | ------------------------------------------------- |
+| `zod`             | Zod                                               |
+| `yup`             | Yup                                               |
+| `class-validator` | class-validator                                   |
+| `valibot`         | Valibot                                           |
+| None              | Plain TypeScript (type guards, manual validation) |
+
+### 9. ORM / Database
+
+| Dep found     | ORM              | Detect provider                                                    |
+| ------------- | ---------------- | ------------------------------------------------------------------ |
+| `prisma`      | Prisma           | Read `prisma/schema.prisma` → `datasource db { provider = "..." }` |
+| `drizzle-orm` | Drizzle          | Check `drizzle.config.*` for `dialect`                             |
+| `knex`        | Knex             | Check `knexfile.*` for client                                      |
+| `typeorm`     | TypeORM          | Check config for `type`                                            |
+| `mongoose`    | MongoDB/Mongoose | N/A                                                                |
+
+Provider affects ID type conventions (UUID for PostgreSQL, autoincrement for SQLite/MySQL, ObjectId for MongoDB).
+
+### 10. State management
+
+| Dep found               | Library                    |
+| ----------------------- | -------------------------- |
+| `zustand`               | Zustand                    |
+| `@reduxjs/toolkit`      | Redux Toolkit              |
+| `jotai`                 | Jotai                      |
+| `valtio`                | Valtio                     |
+| `recoil`                | Recoil                     |
+| `mobx`                  | MobX                       |
+| `xstate`                | XState                     |
+| `@tanstack/react-query` | React Query (server state) |
+| `swr`                   | SWR (server state)         |
+| None                    | useState / useReducer only |
+
+Server-state libraries (React Query, SWR) need different rules than client-state (Zustand, Redux).
+
+### 11. API client pattern
+
+| Signal                                     | Pattern               |
+| ------------------------------------------ | --------------------- |
+| `@trpc/*` in deps                          | tRPC                  |
+| `graphql` + `@apollo/client`               | GraphQL (Apollo)      |
+| `graphql` + `relay-runtime`                | GraphQL (Relay)       |
+| `@tanstack/react-query` + `fetch`          | REST with React Query |
+| `swr` + `fetch`                            | REST with SWR         |
+| `axios` in deps                            | REST with Axios       |
+| Server action files (`"use server"`) found | Server Actions        |
+| `app/api/` with `route.ts` files           | Next.js API Routes    |
+| `src/` with NestJS controllers             | NestJS REST           |
+| None of the above                          | fetch() directly      |
+
+### 12. Form library
+
+| Dep found              | Library                                 |
+| ---------------------- | --------------------------------------- |
+| `react-hook-form`      | react-hook-form                         |
+| `formik`               | Formik                                  |
+| `@tanstack/react-form` | TanStack Form                           |
+| `@hookform/resolvers`  | react-hook-form + Zod/Yup resolver      |
+| None                   | Controlled/uncontrolled inputs manually |
+
+### 13. Auth library
+
+| Dep found                                 | Library               | Extra detection                                       |
+| ----------------------------------------- | --------------------- | ----------------------------------------------------- |
+| `next-auth`                               | NextAuth v5 (Auth.js) | Check for `auth.ts`, `middleware.ts` route protection |
+| `next-auth` v4                            | NextAuth v4           | Check for `[...nextauth].ts`                          |
+| `@clerk/nextjs`                           | Clerk                 | Check for `middleware.ts`                             |
+| `lucia` / `lucia-auth`                    | Lucia                 | Check for `auth.ts`                                   |
+| `@supabase/supabase-js` + `@supabase/ssr` | Supabase Auth         | Check for middleware                                  |
+| `firebase` + `firebase/auth`              | Firebase Auth         | Check for `firebase.ts` config                        |
+| `@auth0/*`                                | Auth0                 | Check for `auth0.ts`                                  |
+| None                                      | No auth or custom     | —                                                     |
+
+### 14. i18n library
+
+| Dep found                   | Library       | Extra detection                                 |
+| --------------------------- | ------------- | ----------------------------------------------- |
+| `next-intl`                 | next-intl     | Check `i18n.ts`, `messages/`, middleware config |
+| `react-i18next` + `i18next` | react-i18next | Check `i18n.ts`, locale JSON files              |
+| `next-i18next`              | next-i18next  | Check `next-i18next.config.js`                  |
+| `lingui/*`                  | Lingui        | Check `lingui.config.*`                         |
+| None                        | No i18n       | Check `lang=` in `<html>` for language hint     |
+
+### 15. Backend pattern
+
+| Signal                          | Pattern            |
+| ------------------------------- | ------------------ |
+| Files containing `"use server"` | Server Actions     |
+| `app/api/` with `route.ts`      | Next.js API Routes |
+| NestJS controllers              | NestJS REST        |
+| Express/Fastify route files     | REST API           |
+| tRPC routers                    | tRPC API           |
+| GraphQL resolvers               | GraphQL API        |
+
+### 16. Linting & Quality
+
+| File/Dep found         | Tool                    |
+| ---------------------- | ----------------------- |
+| `eslint` in deps       | ESLint                  |
+| `eslint.config.*`      | ESLint flat config      |
+| `.eslintrc.*`          | ESLint legacy config    |
+| `prettier` in deps     | Prettier                |
+| `.prettierrc*`         | Prettier configured     |
+| `react-doctor` in deps | react-doctor            |
+| `doctor.config.*`      | react-doctor configured |
+| `biome.json`           | Biome                   |
+| `.oxlintrc.*`          | oxlint                  |
+
+## Rule File Selection
+
+Map detected flags to rule files to generate:
+
+| Rule File              | Required When                                                               |
+| ---------------------- | --------------------------------------------------------------------------- |
+| `architecture.md`      | Always                                                                      |
+| `frontend-patterns.md` | Has React/Next.js/Vite/Angular/Vue/Svelte frontend                          |
+| `backend-patterns.md`  | Has NestJS backend                                                          |
+| `server-actions.md`    | Uses server actions OR has API routes OR has NestJS/Express/Fastify backend |
+| `styling.md`           | Has Tailwind, CSS Modules, or styled-components (not plain CSS)             |
+| `forms.md`             | Has react-hook-form, formik, or TanStack Form                               |
+| `database.md`          | Has Prisma, Drizzle, Knex, TypeORM, or Mongoose                             |
+| `i18n.md`              | Has next-intl, react-i18next, or similar                                    |
+| `testing.md`           | Has test runner (vitest/jest/playwright/cypress) in devDeps                 |
+| `git-workflow.md`      | Always                                                                      |
+| `sdd-workflow.md`      | Always                                                                      |
+
+## AGENTS.md Section Selection
+
+Sections included in the generated AGENTS.md based on detections:
+
+| Section                        | Include When                                        |
+| ------------------------------ | --------------------------------------------------- |
+| Monorepo Structure             | `workspaces` in package.json                        |
+| Monorepo Tool Commands         | Turborepo/Nx/Lerna detected                         |
+| Next.js Router Convention      | Next.js detected → App Router vs Pages Router rules |
+| Zod Validation Convention      | `zod` or `yup` or `valibot` in deps                 |
+| Plain TS Validation Convention | No validation library, but TypeScript strict        |
+| Prisma Convention              | `prisma` in deps                                    |
+| Drizzle Convention             | `drizzle-orm` in deps                               |
+| Server Actions Convention      | `"use server"` files detected                       |
+| tRPC Convention                | tRPC detected                                       |
+| GraphQL Convention             | GraphQL detected                                    |
+| Tailwind Convention            | `tailwindcss` in deps                               |
+| shadcn/ui Convention           | `components.json` exists                            |
+| CSS Modules Convention         | `.module.css` files found                           |
+| Styled Components Convention   | `styled-components` in deps                         |
+| State Management Section       | Zustand/Redux/Jotai/MobX/XState in deps             |
+| Server State Section           | React Query/SWR in deps                             |
+| Form Library Section           | react-hook-form/formik/TanStack Form in deps        |
+| i18n Section                   | i18n library detected                               |
+| Auth Section                   | Auth library detected                               |
+| react-doctor Convention        | `doctor.config.*` or `react-doctor` in deps         |
+| UI Language Convention         | Check `lang=` attribute or i18n config              |
+
+## Command Generation
+
+Generate commands table from `package.json` `scripts`. Map `scripts` keys directly:
+
+```json
+{ "scripts": { "dev": "...", "build": "...", "lint": "...", "test": "..." } }
+```
+
+Becomes:
+
+| Comando          | Qué hace               |
+| ---------------- | ---------------------- |
+| `{pm} dev`       | Servidor de desarrollo |
+| `{pm} run build` | Build de producción    |
+| `{pm} run lint`  | Linting                |
+| `{pm} run test`  | Tests (watch)          |
+
+Add extra rows for: `test:run` (single-run), `test:coverage`, `doctor`, `format`, `typecheck`.
+
+Where `{pm}` = `bun` for bun (scripts without `run`), `pnpm` for pnpm, `npm run` for npm, `yarn` for yarn.
+
+### Monorepo command generation
+
+If monorepo with Turborepo: generate `turbo run {cmd}` variants.
+If monorepo with pnpm: generate `pnpm --filter {pkg} {cmd}` examples.
+If monorepo with Nx: generate `nx {cmd} {pkg}` variants.
+
+### Verification cycle
+
+Assemble from detected tools:
+
+```
+{typecheck}   →   {lint}   →   {test}   →   {doctor}
+```
+
+- `{typecheck}`: `tsc --noEmit` if TypeScript, `bunx tsc --noEmit` if bun, skip if no TS.
+- `{lint}`: `{pm} run lint` or detected lint command.
+- `{test}`: `{pm} run test:run` or `{pm} run test` (whichever is single-run).
+- `{doctor}`: `{pm} doctor` or `{pm}x react-doctor@latest` if react-doctor detected. Skip if not.
+
+### Monorepo rebuild note
+
+If monorepo with shared packages: add note about rebuilding packages before cycle:
+
+```
+Si se modificaron packages compartidos ({shared_pkg_list}), ejecutar su rebuild primero:
+  {rebuild_commands}
+```
+
+## Framework-Specific Conventions
+
+### Next.js App Router
+
+- Server Components by default. `"use client"` solo cuando se usen hooks.
+- Server actions en `lib/actions.ts` o `src/actions/`.
+- `error.tsx`, `loading.tsx`, `not-found.tsx` por segmento.
+- `generateMetadata()` para SEO.
+- `next/image` para imágenes, `next/font` para fuentes.
+- Path alias `@/*` → `./*` o `./src/*`.
+
+### Next.js Pages Router
+
+- `getServerSideProps`, `getStaticProps`, `getStaticPaths`.
+- `pages/api/` para API routes.
+- `pages/_app.tsx`, `pages/_document.tsx`.
+- Sin server components. Todo es client o API.
+
+### NestJS
+
+- Módulos como directorios: `src/{feature}/{feature}.module.ts`.
+- DTOs con decoradores. Validación con `class-validator` o `ZodValidationPipe`.
+- Guards para auth: `@UseGuards(AuthGuard)`.
+- `PrismaService` como provider global.
+
+## Edge Cases
+
+| Situation                        | Action                                                                 |
+| -------------------------------- | ---------------------------------------------------------------------- |
+| No test runner                   | Skip testing.md, skip test from verification cycle                     |
+| No lint tool                     | Skip lint from verification cycle                                      |
+| No TypeScript                    | Skip `tsc --noEmit`, skip no-any rule, use JSDoc conventions instead   |
+| No config files at all           | Minimal defaults, note that project needs setup                        |
+| Multiple frameworks              | Pick primary based on root package.json, note secondary                |
+| Both App Router and Pages Router | Treat as App Router primary, note Pages Router legacy routes           |
+| No package.json scripts          | Generate commands from direct tool invocations (`npx next dev`)        |
+| Bun without `bun run` scripts    | Use `bunx` prefix for npx equivalents                                  |
+| Monorepo without workspaces      | Treat each `apps/*` or `packages/*` as independent                     |
+| CSS: multiple approaches         | Pick primary (Tailwind wins over CSS Modules over plain CSS)           |
+| Auth: multiple libraries         | Pick primary, note secondary (e.g., NextAuth for web, Clerk for admin) |
+| i18n with Pages Router           | Different routing rules than App Router i18n                           |
+| Database with multiple providers | Document each, note which is primary                                   |

--- a/skills/agents-generator/references/example-output/README.md
+++ b/skills/agents-generator/references/example-output/README.md
@@ -1,0 +1,78 @@
+# Example Output — sssall (Next.js 16 + Bun + Server Actions)
+
+This is the concrete output the skill should produce for a project with this stack. Use it as a quality benchmark: your generated AGENTS.md should be this specific, this actionable, and this free of placeholder text.
+
+## Project Signals Detected
+
+| Signal          | Detected                                                                                          |
+| --------------- | ------------------------------------------------------------------------------------------------- |
+| Package manager | Bun (`bun.lock`)                                                                                  |
+| Framework       | Next.js 16 App Router (`app/page.tsx`, `app/layout.tsx`)                                          |
+| Router type     | App Router (server components default)                                                            |
+| Language        | TypeScript strict (`tsconfig.json`)                                                               |
+| CSS             | Tailwind CSS 4 + shadcn/ui New York                                                               |
+| Testing         | Vitest 4.x (5 test files, 74 tests, all in `lib/`)                                                |
+| Validation      | Plain TypeScript (type guards: `isDownloadError()`, no Zod)                                       |
+| ORM             | None                                                                                              |
+| State           | useState / useCallback only (no Zustand/Redux)                                                    |
+| Server state    | None (React Query/SWR not present)                                                                |
+| API pattern     | Server Actions (`"use server"` in `lib/actions.ts`) + REST fallback (`app/api/download/route.ts`) |
+| Forms           | Manual controlled inputs (no react-hook-form)                                                     |
+| i18n            | None (hardcoded Spanish UI)                                                                       |
+| Auth            | None                                                                                              |
+| Backend         | None (server actions + btch-downloader)                                                           |
+| Linting         | ESLint 10 + react-doctor 0.9.3                                                                    |
+| Monorepo        | No (single app)                                                                                   |
+
+## Files Generated
+
+```
+AGENTS.md                              ← 85 lines, all placeholders filled
+.agents/rules/
+  architecture.md                      ← Stack table, route table, ASCII data flow diagram
+  frontend-patterns.md                 ← Component specs, state locations, trust boundaries
+  server-actions.md                    ← downloadVideo flow, DownloadResult type, rate limiter
+  testing.md                           ← Vitest commands, test file tree, 74 tests counted
+  git-workflow.md                      ← Conventional commits, pre-commit cycle
+  sdd-workflow.md                      ← Preflight defaults, post-apply verification
+```
+
+## Skipped (with reasons)
+
+| Rule file             | Reason                                                                     |
+| --------------------- | -------------------------------------------------------------------------- |
+| `backend-patterns.md` | No NestJS backend                                                          |
+| `styling.md`          | Tailwind covered in frontend-patterns; no CSS Modules or styled-components |
+| `forms.md`            | No form library (manual controlled inputs only)                            |
+| `database.md`         | No ORM                                                                     |
+| `i18n.md`             | No i18n library (hardcoded Spanish)                                        |
+
+## Key Quality Checks
+
+Compare your generated AGENTS.md against these criteria:
+
+1. **Commands are exact**: The AGENTS.md says `bun dev`, not `npm run dev` or `pnpm dev`. It reads `package.json` scripts: `"doctor": "npx react-doctor@latest"` → `bun doctor`.
+2. **Verification cycle is real**: `bunx tsc --noEmit → bun run lint → bun run test:run → bun doctor`. Every command exists in `package.json`.
+3. **Global conventions match the stack**: "Sin librería de validación externa — TypeScript types + guards manuales (`isDownloadError()`)." Not "Zod para validación."
+4. **Architecture diagram is specific**: ASCII art shows actual directories (`app/`, `components/`, `lib/downloader/`), not generic placeholders.
+5. **Data flow names real functions**: `detectPlatform()` → `downloadVideo()` → `downloadFromUrl()` → `ttdl()/igdl()/fbdown()/twitter()`. Not "validation → API call → database."
+6. **Route table is complete**: Every route file listed with its type (client/server) and description in Spanish.
+7. **Test count is accurate**: "74 tests" counted from actual test files, not estimated.
+8. **No placeholder text anywhere**: Search for `{{`, `TODO`, `add here`, `...` in the output — there should be zero matches.
+
+## Reference Project
+
+The benchmark output comes from a real project with this stack. The actual generated files (relative to project root):
+
+```
+AGENTS.md                              ← Main file with commands, conventions, PR instructions
+.agents/rules/
+  architecture.md                      ← Stack table, routes, ASCII data flow
+  frontend-patterns.md                 ← Component specs, state, trust boundaries
+  server-actions.md                    ← Entry points, error handling, rate limiting
+  testing.md                           ← Test commands, file tree, patterns
+  git-workflow.md                      ← Commit conventions, pre-commit cycle
+  sdd-workflow.md                      ← Preflight defaults, post-apply verification
+```
+
+Use this as a quality benchmark when generating for any project — your output should match this level of specificity regardless of the target stack.

--- a/skills/agents-generator/references/template-filling-guide.md
+++ b/skills/agents-generator/references/template-filling-guide.md
@@ -1,0 +1,67 @@
+# Template Filling Guide
+
+When filling template placeholders in `assets/*.md`, follow these concreteness rules. The output must be as specific as the example in `references/example-output/README.md`.
+
+## Quick Decision Table
+
+Full detection logic is in `decision-matrix.md`. This is the quick-reference table for selecting templates:
+
+| Signal                                | Decision                                                                                          |
+| ------------------------------------- | ------------------------------------------------------------------------------------------------- |
+| `workspaces` in package.json          | Monorepo → generate package dependency rules, shared package rebuild commands                     |
+| `turbo.json`, `nx.json`, `lerna.json` | Monorepo tool → adapt commands (`turbo run`, `nx`, `lerna run`)                                   |
+| `next` in deps + `app/` vs `pages/`   | Next.js Router type → App Router (server components default) vs Pages Router (getServerSideProps) |
+| `@nestjs/core`                        | NestJS backend → module architecture, guards, DTOs                                                |
+| `@trpc/*`                             | tRPC → completely different backend rules than REST                                               |
+| `react-hook-form`, `formik`           | Form library → generate `forms.md`                                                                |
+| `next-intl`, `react-i18next`          | i18n → generate `i18n.md`                                                                         |
+| `prisma`, `drizzle-orm`               | ORM → generate `database.md`                                                                      |
+| `styled-components`, `.module.css`    | Non-Tailwind CSS → generate `styling.md` with different rules                                     |
+| `next-auth`, `@clerk/nextjs`, `lucia` | Auth → route protection rules                                                                     |
+| `@tanstack/react-query`, `swr`        | Server state → different state rules than Zustand/Redux                                           |
+| `vitest`, `jest`, `playwright`        | Test runner(s) → generate `testing.md` with correct commands                                      |
+| No TypeScript                         | JS project → skip `tsc`, different type safety rules                                              |
+
+## Placeholder Filling Rules
+
+### `{{STACK_TABLE}}`
+
+Each row must have **exact version numbers** from `package.json`. Never write "latest" or "X.Y.Z". Format: `| Capa | Tecnología | Versión |`. Include framework, UI, runtime, ORM, validation, testing, linting, analytics, fonts.
+
+### `{{ARCHITECTURE_DIAGRAM}}`
+
+ASCII art using **actual directory names** from the project. Show real connections — which file imports which. No boxes labeled "Component" or "Service". For monorepos, show package dependency arrows. For single apps, show app/ → components/ + lib/ → external services.
+
+### `{{DATA_FLOW}}`
+
+Numbered steps with **real function names**: `detectPlatform()` not "validate input"; `ttdl(url)` not "call API". Show the complete chain: user action → frontend → backend/server action → external library/database → response → UI update. Use ASCII arrows between steps.
+
+### `{{ROUTING_TABLE}}`
+
+**Every route file** found in `app/` or `pages/`. Include: route path, type (server/client/API), file path, and 1-line purpose in the project's UI language. Check for: `page.tsx`, `layout.tsx`, `route.ts`, `error.tsx`, `loading.tsx`, `not-found.tsx`, `sitemap.ts`, `robots.ts`, API routes, dynamic routes.
+
+### `{{ESSENTIAL_COMMANDS}}`
+
+Only commands whose **script key exists** in `package.json`. Use `{pm} run <key>` or `{pm} <key>` format matching the package manager. If a script is missing, omit that row — don't invent commands. Core rows: dev, build, lint, test, test:run, test:coverage, and quality tool (doctor/lint-staged) if present.
+
+### `{{TEST_COUNT}}`
+
+Count actual `test()` / `it()` calls across all test files. Report `"N tests"` with the real number. If you cannot count accurately, report the number of test files: `"N test files"`.
+Also report: test runner + version, environment (node/jsdom), coverage provider and target, strict TDD mode (yes/no).
+
+### `{{COMMIT_EXAMPLES}}`
+
+2-3 examples using **real file names** or feature names from the project's recent git history. Read `git log --oneline -5` if available to get realistic examples. Format: `type: message`, one per line.
+
+### `{{VERIFICATION_CYCLE}}`
+
+Assemble from validated commands: `{typecheck} → {lint} → {test} → {doctor}`. Only include steps whose tool exists. Use the exact command format from package.json.
+
+### `{{GLOBAL_CONVENTIONS}}`
+
+List 5-8 project-specific conventions. Each must be verifiable from config files, not generic advice. Examples:
+
+- ✅ "Bun siempre. No npm ni yarn." (detected from bun.lock)
+- ✅ "Sin librería de validación externa — TypeScript types + guards manuales." (no zod in deps)
+- ❌ "Usar buenas prácticas de TypeScript." (generic, unverifiable)
+- ❌ "Código limpio y documentado." (generic, unverifiable)


### PR DESCRIPTION
## Summary

- Add the community `agents-generator` skill and its required templates and references.
- Add AAS provenance, MIT license metadata, `critical` risk labeling, authorized-use warning, explicit triggers, and limitations.
- Repair three deterministic upstream template links that pointed to files absent from the imported bundle.

## Change Classification

- [x] Skill PR
- [ ] Docs PR
- [ ] Infra PR

## Issue Link

Closes #1065

## Quality Bar Checklist ✅

- [x] **Standards**: Read `docs/contributors/quality-bar.md` and `docs/contributors/security-guardrails.md`.
- [x] **Metadata**: `npm run validate` passes for all 2,000 skills.
- [x] **Risk Label**: Assigned `risk: critical` because the skill writes agent instructions and backups in a target project.
- [x] **Triggers**: Added an explicit `## When to Use` section.
- [x] **Limitations**: Added a `## Limitations` section covering human review, command validation boundaries, and scope.
- [x] **Security**: Added an authorized-use warning and ran `npm run security:docs` with no findings.
- [ ] **Automated Skill Review**: Will be checked on the exact PR head before merge.
- [x] **Manual Logic Review**: Reviewed the upstream workflow, bundled templates, references, write behavior, backups, command validation, and risk label.
- [x] **Local Test**: Ran `npm run chain` and `npm run test` (106 test files/suites passed with generated state).
- [x] **Repo Checks**: Ran `npm run validate:references`.
- [x] **Source-Only PR**: No generated registry artifacts or plugin mirrors are included.
- [x] **Credits**: Added the upstream source credit in `README.md`.
- [x] **License provenance**: Declared MIT and the immutable upstream license URL in frontmatter.
- [x] **Maintainer Edits**: Same-repository maintainer PR; GitHub reports fork collaboration can only be enabled on cross-repository PRs.

## Additional Validation

- `npm run check:warning-budget`: 0/0
- `npm run pr:evidence -- --base origin/main --head HEAD ...`: `blocking: false`, no security flags
- `npm run check:readme-credits -- --base origin/main --head HEAD`: passed
- `git diff --check origin/main...HEAD`: passed

The imported source is pinned to upstream commit `7a3201208a01bd25e69ad11e665efc1392f5356a`. The bundle includes the required `assets/` and `references/` files so the skill's documented reads remain self-contained.
