### PR TITLE
fix: pin patched fast-uri dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Security
+
+- Pinned and bundled Ajv's `fast-uri` dependency on the patched 3.1.x line, resolving GHSA-7p8r-x3mc-p8w7 in the production dependency tree.
+
 ## [15.8.0] - 2026-08-02 - "Governed Integrations and Agent Project Workflows"
 
 > Added four evidence-first skills for GitHub attachments, governed AI gateways, project-specific agent instructions, and revenue analytics through MCP.

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,12 +9,14 @@
       "version": "15.8.0",
       "bundleDependencies": [
         "ajv",
+        "fast-uri",
         "sanitize-filename",
         "yaml"
       ],
       "license": "MIT",
       "dependencies": {
         "ajv": "^8.20.0",
+        "fast-uri": "^3.1.5",
         "sanitize-filename": "^1.6.4",
         "yaml": "^2.9.0"
       },
@@ -52,9 +54,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
-      "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
+      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
       "funding": [
         {
           "type": "github",

--- a/package.json
+++ b/package.json
@@ -79,11 +79,13 @@
   },
   "dependencies": {
     "ajv": "^8.20.0",
+    "fast-uri": "^3.1.5",
     "sanitize-filename": "^1.6.4",
     "yaml": "^2.9.0"
   },
   "bundledDependencies": [
     "ajv",
+    "fast-uri",
     "sanitize-filename",
     "yaml"
   ],


### PR DESCRIPTION
# Pull Request Description

## Summary

- Pin and bundle `fast-uri` 3.1.5 as the Ajv runtime dependency.
- Refresh the lockfile so production installs no longer resolve vulnerable 3.1.4.
- Record the security fix under the unreleased changelog.

The previous main branch failed its canonical-sync workflow at the npm audit step because `ajv@8.20.0` resolved `fast-uri@3.1.4`, affected by GHSA-7p8r-x3mc-p8w7. Ajv accepts the patched 3.1.x line, so this keeps the existing Ajv version and makes the production package resolution explicit and reproducible.

## Change Classification

- [ ] Skill PR
- [ ] Docs PR
- [x] Infra PR

## Quality Bar Checklist ✅

- [x] **Standards**: Read `docs/contributors/quality-bar.md` and `docs/contributors/security-guardrails.md`.
- [x] **Metadata**: Not applicable; no `SKILL.md` changed.
- [x] **Risk Label**: Not applicable; no skill changed.
- [x] **Triggers**: Not applicable; no skill changed.
- [x] **Limitations**: Not applicable; no skill changed.
- [x] **Security**: Not an offensive skill change.
- [x] **Safety scan**: `npm run security:docs` passes.
- [x] **Automated Skill Review**: Not applicable; no `SKILL.md` changed.
- [x] **Manual Logic Review**: Confirmed Ajv's declared `^3.0.1` range accepts `fast-uri@3.1.5`, and verified the exact installed production tree.
- [x] **Local Test**: `npm ci`, canonical generation, and the complete 106-test suite pass on the exact commit.
- [x] **Repo Checks**: `npm run validate`, `npm run validate:references`, and `npm run check:warning-budget` pass.
- [x] **Source-Only PR**: No generated registry artifact is included.
- [x] **Credits**: Not applicable.
- [x] **License provenance**: Not applicable.
- [x] **Maintainer Edits**: Enabled.

## Validation

- `npm audit --omit=dev --audit-level=high`: 0 vulnerabilities
- `npm run validate`: pass (2,002 skills; legacy advisories unchanged)
- `npm run validate:references`: pass
- `npm run security:docs`: pass
- `npm run check:warning-budget`: 0/0
- `npm test`: 106/106 test files passed; network integration tests intentionally skipped by the local runner

## Screenshots (if applicable)

Not applicable.
