### PR TITLE
fix: update vulnerable web app tooling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Security
 
 - Pinned and bundled Ajv's `fast-uri` dependency on the patched 3.1.x line, resolving GHSA-7p8r-x3mc-p8w7 in the production dependency tree.
+- Updated the web app's PostCSS and transitive brace-expansion and ip-address tooling to patched releases, clearing the remaining local npm audit findings.
 
 ## [15.8.0] - 2026-08-02 - "Governed Integrations and Agent Project Workflows"
 

--- a/apps/web-app/package-lock.json
+++ b/apps/web-app/package-lock.json
@@ -40,7 +40,7 @@
         "express-rate-limit": "^8.5.2",
         "globals": "^16.5.0",
         "jsdom": "^24.0.0",
-        "postcss": "8.5.18",
+        "postcss": "8.5.25",
         "tailwindcss": "^4.2.0",
         "typescript": "^5.4.0",
         "typescript-eslint": "^8.65.0",
@@ -2321,9 +2321,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.8",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
-      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3814,9 +3814,9 @@
       "license": "MIT"
     },
     "node_modules/ip-address": {
-      "version": "10.2.0",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
-      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.4.0.tgz",
+      "integrity": "sha512-oSK96Grm3aP6OrS263xVxbNDGVL7rzBtYdpGqlDG8iQdoenDoTs/nkki+DflYbAEE8Xl6o5YxhxlrKvI3nqKXQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -5441,9 +5441,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.15",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.15.tgz",
-      "integrity": "sha512-y7Wygv/7mEOvxTuEQDB8StXdMRBWf1kR/tlhAzBRUFkB2jfcLOAxO/SHmOO2zgz1pVgK29/kyupn059/bCHdjA==",
+      "version": "3.3.17",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.17.tgz",
+      "integrity": "sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==",
       "dev": true,
       "funding": [
         {
@@ -5706,9 +5706,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.18",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.18.tgz",
-      "integrity": "sha512-xdB1oSLHbz1vRWgCDalrCqEFTWzFlhqFC5tIHLMOSUIjhm3XXQ1qrFy8S/ESr1JYRRXqM3c1QFiMZUJdUTqyMQ==",
+      "version": "8.5.25",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.25.tgz",
+      "integrity": "sha512-DTPx3RWSSnWyzLxQnlH0rJP+EW5ekl16ZU4/psbIhA0e53kJfdgaN5vKM+xP7yJtXVu+nfdVFmlgFDEKAe4Pyw==",
       "dev": true,
       "funding": [
         {
@@ -5726,7 +5726,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.12",
+        "nanoid": "^3.3.16",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },

--- a/apps/web-app/package.json
+++ b/apps/web-app/package.json
@@ -48,7 +48,7 @@
     "express-rate-limit": "^8.5.2",
     "globals": "^16.5.0",
     "jsdom": "^24.0.0",
-    "postcss": "8.5.18",
+    "postcss": "8.5.25",
     "tailwindcss": "^4.2.0",
     "typescript": "^5.4.0",
     "typescript-eslint": "^8.65.0",


### PR DESCRIPTION
# Pull Request Description

## Summary

- Update the web app's direct PostCSS pin from 8.5.18 to 8.5.25.
- Refresh transitive `brace-expansion` from 5.0.8 to 5.0.9 and `ip-address` from 10.2.0 to 10.4.0.
- Record the remediation in the unreleased changelog.

These patch updates resolve the local web-app audit findings for GHSA-rgw5-rvv9-x895, GHSA-mwp4-54f8-5fhr, GHSA-4xrf-jv44-h6hh, GHSA-22jq-vg5j-6vgg, and GHSA-fxqj-rqcc-2cmp without changing the production dependency surface.

## Change Classification

- [ ] Skill PR
- [ ] Docs PR
- [x] Infra PR

## Quality Bar Checklist ✅

- [x] **Standards**: Read `docs/contributors/quality-bar.md` and `docs/contributors/security-guardrails.md`.
- [x] **Metadata**: Not applicable; no `SKILL.md` changed.
- [x] **Risk Label**: Not applicable; no skill changed.
- [x] **Triggers**: Not applicable; no skill changed.
- [x] **Limitations**: Not applicable; no skill changed.
- [x] **Security**: Not an offensive skill change.
- [x] **Safety scan**: `npm run security:docs` passes.
- [x] **Automated Skill Review**: Not applicable; no `SKILL.md` changed.
- [x] **Manual Logic Review**: Reviewed the exact lockfile diff and confirmed only patched package releases plus PostCSS's patched nanoid range changed.
- [x] **Local Test**: Fresh installs, lint, production build, web coverage, and the complete repository suite pass.
- [x] **Repo Checks**: `npm run validate`, `npm run validate:references`, and `npm run check:warning-budget` pass.
- [x] **Source-Only PR**: No generated registry artifact is included.
- [x] **Credits**: Not applicable.
- [x] **License provenance**: Not applicable.
- [x] **Maintainer Edits**: Enabled.

## Validation

- Root `npm audit --omit=dev --audit-level=high`: 0 vulnerabilities
- Web app `npm audit --audit-level=moderate`: 0 vulnerabilities
- Web app `npm audit --omit=dev --audit-level=moderate`: 0 vulnerabilities
- Web app lint: pass
- Web app production build and prerender: pass
- Web app coverage: 20 files and 152 tests passed
- `npm run validate`: pass (2,002 skills; legacy advisories unchanged)
- `npm run validate:references`: pass
- `npm run security:docs`: pass
- `npm run check:warning-budget`: 0/0
- `npm test`: 106/106 test files passed; network integration tests intentionally skipped by the local runner

## Screenshots (if applicable)

Not applicable.
