### PR TITLE
fix: refresh loki-mode vulnerable lockfiles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Pinned and bundled Ajv's `fast-uri` dependency on the patched 3.1.x line, resolving GHSA-7p8r-x3mc-p8w7 in the production dependency tree.
 - Updated the web app's PostCSS and transitive brace-expansion and ip-address tooling to patched releases, clearing the remaining local npm audit findings.
+- Refreshed the bundled `loki-mode` todo example lockfiles to patched `ip-address` and PostCSS releases, clearing the remaining Dependabot findings in the canonical skill and generated Claude mirror.
 
 ## [15.8.0] - 2026-08-02 - "Governed Integrations and Agent Project Workflows"
 

--- a/skills/loki-mode/examples/todo-app-generated/backend/package-lock.json
+++ b/skills/loki-mode/examples/todo-app-generated/backend/package-lock.json
@@ -909,9 +909,9 @@
       "license": "ISC"
     },
     "node_modules/ip-address": {
-      "version": "10.2.0",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
-      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.4.0.tgz",
+      "integrity": "sha512-oSK96Grm3aP6OrS263xVxbNDGVL7rzBtYdpGqlDG8iQdoenDoTs/nkki+DflYbAEE8Xl6o5YxhxlrKvI3nqKXQ==",
       "license": "MIT",
       "engines": {
         "node": ">= 12"

--- a/skills/loki-mode/examples/todo-app-generated/frontend/package-lock.json
+++ b/skills/loki-mode/examples/todo-app-generated/frontend/package-lock.json
@@ -746,9 +746,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.12",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
-      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
+      "version": "3.3.17",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.17.tgz",
+      "integrity": "sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==",
       "dev": true,
       "funding": [
         {
@@ -785,9 +785,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.18",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.18.tgz",
-      "integrity": "sha512-xdB1oSLHbz1vRWgCDalrCqEFTWzFlhqFC5tIHLMOSUIjhm3XXQ1qrFy8S/ESr1JYRRXqM3c1QFiMZUJdUTqyMQ==",
+      "version": "8.5.25",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.25.tgz",
+      "integrity": "sha512-DTPx3RWSSnWyzLxQnlH0rJP+EW5ekl16ZU4/psbIhA0e53kJfdgaN5vKM+xP7yJtXVu+nfdVFmlgFDEKAe4Pyw==",
       "dev": true,
       "funding": [
         {
@@ -805,7 +805,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.12",
+        "nanoid": "^3.3.16",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },


### PR DESCRIPTION
# Pull Request Description

Refreshes the bundled `loki-mode` todo example lockfiles to resolve all eight open Dependabot alerts on the canonical skill and its generated Claude mirror.

- backend: `ip-address` 10.2.0 -> 10.4.0
- frontend: PostCSS 8.5.18 -> 8.5.25 and its compatible Nano ID resolution
- no application source, manifest constraints, or generated mirrors are included

## Change Classification

- [x] Skill PR
- [ ] Docs PR
- [ ] Infra PR

## Security evidence

- Both bundled example directories complete `npm ci` and `npm audit` with zero vulnerabilities.
- Backend and frontend production builds pass.
- Repository validation, reference validation, documentation security, warning budget, generated-state preview, and all 106 repository tests pass.
- Changed-skill evidence is non-blocking and covers both modified Git records; historical executable entries in the bundled skill are byte-identical before and after.

## Quality Bar Checklist

- [x] **Standards**: Read `docs/contributors/quality-bar.md` and `docs/contributors/security-guardrails.md`.
- [x] **Metadata**: Existing `SKILL.md` frontmatter remains valid under `npm run validate`.
- [x] **Risk Label**: Existing `risk: critical` classification is unchanged.
- [x] **Triggers**: Existing usage guidance is unchanged.
- [x] **Limitations**: Existing limitations are unchanged.
- [x] **Security**: No offensive classification or new command guidance is introduced.
- [x] **Safety scan**: `npm run security:docs` passes.
- [ ] **Automated Skill Review**: Awaiting the exact-head `skill-review` workflow.
- [x] **Manual Logic Review**: Reviewed the exact lockfile delta, dependency ranges, integrity records, builds, audits, and changed-skill evidence.
- [x] **Local Test**: Both examples build from their refreshed lockfiles.
- [x] **Repo Checks**: `npm run validate:references` passes.
- [x] **Source-Only PR**: Generated registry artifacts and plugin mirrors are excluded.
- [x] **Credits**: No attribution change is applicable.
- [x] **License provenance**: No source or license provenance change is introduced.
- [x] **Maintainer Edits**: Same-repository maintainer branch.

## Screenshots

Not applicable.
