### PR TITLE
docs: align Unified AI gateway review with v0.4.9

### DIFF
--- a/skills/unified-ai-gateway/SKILL.md
+++ b/skills/unified-ai-gateway/SKILL.md
@@ -26,11 +26,11 @@ installations require the manual setup below.
 
 ## Version Note
 
-The current public project release is `v0.4.8`. The inspection procedure below
-intentionally pins the reviewed, immutable `v0.4.0` image and its recorded
-digests; those values are a historical security baseline and must not be
-silently replaced with a mutable tag. For a normal provider-free demo, use the
-current `v0.4.8` command in the [project README](https://github.com/happy520ai/unified-ai-system#try-it-in-60-seconds).
+The current public project release and latest reviewed immutable MCP image are
+both `v0.4.9`. The inspection procedure below pins its recorded digests; those
+values must not be silently replaced with a mutable tag. For a normal
+provider-free demo, use the current `v0.4.9` command in the
+[project README](https://github.com/happy520ai/unified-ai-system#try-it-in-60-seconds).
 A new content review is required before changing this pinned procedure.
 
 ## Prerequisites And Setup
@@ -39,7 +39,7 @@ A new content review is required before changing this pinned procedure.
 2. If the nine tools are already visible, skip setup and do not register a
    duplicate server.
 3. Explain the first stage: it downloads one reviewed platform from the
-   immutable `0.4.0` multi-platform index into Docker's cache, inspects its
+   immutable `0.4.9` multi-platform index into Docker's cache, inspects its
    metadata and layer history, creates but never starts a temporary container,
    exports its root filesystem, removes that temporary container, and writes an
    inspection inventory to a temporary directory. The reviewed platforms are
@@ -49,7 +49,7 @@ A new content review is required before changing this pinned procedure.
    the inspection. Do not execute the image or register it yet:
 
 ```bash
-IMAGE='ghcr.io/happy520ai/unified-ai-system/mcp-server@sha256:c185d124d1f672b5cf210a7b7d4c7dbdc907b81a5f7b62fe312a0dc18839e045'
+IMAGE='ghcr.io/happy520ai/unified-ai-system/mcp-server@sha256:751a0d32acd2d6b1da6ad9ac67987fbd1ff36ce26b7160014d8605f18b7907b3'
 PLATFORM='linux/amd64' # Use linux/arm64 only on a reviewed ARM64 engine.
 REVIEW_DIR="$(mktemp -d)"
 
@@ -93,25 +93,25 @@ deletion is another filesystem change and requires approval for the exact path.
 
 5. Read every generated inventory and report the inspection before proceeding.
    Compare it with the versioned
-   [image content review](https://github.com/happy520ai/unified-ai-system/blob/4bbc5e81d1f372a5c80ba5597973f3284965adf6/docs/security/mcp-image-review-0.4.0.md).
+   [image content review](https://github.com/happy520ai/unified-ai-system/blob/master/docs/security/mcp-image-review-0.4.9.md).
    Require OCI index digest
-   `sha256:c185d124d1f672b5cf210a7b7d4c7dbdc907b81a5f7b62fe312a0dc18839e045`.
+   `sha256:751a0d32acd2d6b1da6ad9ac67987fbd1ff36ce26b7160014d8605f18b7907b3`.
    For linux/amd64, require manifest digest
-   `sha256:bb3ba00366a924d511c776986f890d62196ecc380034daf9c42f54000dcc7f2d`
+   `sha256:ff6cf988b01d5fb2e97aabe8e952f6a303dcffe650df5b4dcb0ba3d51ee88c06`
    and config digest
-   `sha256:3224ec32c8a1407ba704febf897157866f6cabf86fb515d760b0466fe64c9df1`.
+   `sha256:0c2c0c7b9c7fb7ca24c73d9a903bcf719b079a0b285a3a3269ee3ae059905e97`.
    For linux/arm64, require manifest digest
-   `sha256:2a58da07d11de97a4b4051f4a82ac444e7fefb5235556d7997080c96db2da6ae`
+   `sha256:90318b9e373820f863c1c1addc759be4b5ce186f2ecb6232ee502fad7c6613de`
    and config digest
-   `sha256:1e480c2b6711283f9571079d96c73f5dfc423a30d86c22d05c0dfd052113a9b7`.
+   `sha256:c2047eb63fdc42bcb16d53fca17d78a4a6fb355cf6320b9aa6688e594371054f`.
    Require source `https://github.com/happy520ai/unified-ai-system`, revision
-   `9f606b0b4189ef9759bdc01857919c254209e4be`, version `0.4.0`, license
+   `342a47313927870bcc696be13c9e5fb922062dac`, version `0.4.9`, license
    `Apache-2.0`, entrypoint `docker-entrypoint.sh`, and command
    `node packages/mcp-server/src/index.js`.
 
    Report these reviewed risks explicitly: the image uses the default root
    user; includes Debian shell/package utilities and 11 base-image SUID/SGID
-   files; contains 519 internal pnpm links, two native Node binaries, and eight
+   files; contains 522 internal pnpm links, three native Node binaries, and eight
    lifecycle-hook declarations; and starts a child gateway with loopback HTTP.
    The optional `AI_GATEWAY_MCP_URL` can make an HTTP or HTTPS connection only
    when explicitly passed. The registered command below passes no host files,
@@ -127,7 +127,7 @@ deletion is another filesystem change and requires approval for the exact path.
    disabled, then inspect the stored configuration:
 
 ```bash
-IMAGE='ghcr.io/happy520ai/unified-ai-system/mcp-server@sha256:c185d124d1f672b5cf210a7b7d4c7dbdc907b81a5f7b62fe312a0dc18839e045'
+IMAGE='ghcr.io/happy520ai/unified-ai-system/mcp-server@sha256:751a0d32acd2d6b1da6ad9ac67987fbd1ff36ce26b7160014d8605f18b7907b3'
 PLATFORM='linux/amd64' # Match the reviewed platform inspected above.
 codex mcp add unified-ai-system -- docker run --rm -i --pull never --platform "$PLATFORM" --network none --cap-drop ALL --security-opt no-new-privileges "$IMAGE"
 codex mcp get unified-ai-system --json
@@ -200,7 +200,7 @@ Agent:
 - Treat MCP registration, image pulls, container creation, networking, and
   teardown as host-state changes that require informed user approval.
 - Never substitute a mutable tag, a different OCI index, or an unreviewed
-  platform manifest for the reviewed `0.4.0` identities. Keep download and
+  platform manifest for the reviewed `0.4.9` identities. Keep download and
   inspection approval separate from registration and activation approval.
 - Keep `--pull never` in the registered command. If the reviewed image is
   absent from the local cache, fail closed and return to the first approval
@@ -220,7 +220,7 @@ Agent:
 - The credential-free chat tool proves only the deterministic local fake path.
 - It does not configure real providers or handle provider credentials.
 - The published MCP image requires Docker.
-- The reviewed `0.4.0` path covers linux/amd64 and linux/arm64. Do not activate
+- The reviewed `0.4.9` path covers linux/amd64 and linux/arm64. Do not activate
   another platform image without a separate content review.
 - The image runs as the container's default root user and bundles the gateway
   source, package-manager tooling, native dependencies, and base-image
@@ -243,4 +243,4 @@ Agent:
 - [Unified AI System](https://github.com/happy520ai/unified-ai-system)
 - [60-second Codex MCP quickstart](https://github.com/happy520ai/unified-ai-system/blob/master/docs/codex-mcp-quickstart.md)
 - [MCP server guide](https://github.com/happy520ai/unified-ai-system/blob/master/packages/mcp-server/README.md)
-- [MCP image content review](https://github.com/happy520ai/unified-ai-system/blob/4bbc5e81d1f372a5c80ba5597973f3284965adf6/docs/security/mcp-image-review-0.4.0.md)
+- [MCP image content review](https://github.com/happy520ai/unified-ai-system/blob/master/docs/security/mcp-image-review-0.4.9.md)

--- a/skills/unified-ai-gateway/SKILL.md
+++ b/skills/unified-ai-gateway/SKILL.md
@@ -26,11 +26,11 @@ installations require the manual setup below.
 
 ## Version Note
 
-The current public project release is `v0.4.3`. The inspection procedure below
+The current public project release is `v0.4.6`. The inspection procedure below
 intentionally pins the reviewed, immutable `v0.4.0` image and its recorded
 digests; those values are a historical security baseline and must not be
 silently replaced with a mutable tag. For a normal provider-free demo, use the
-current `v0.4.3` command in the [project README](https://github.com/happy520ai/unified-ai-system#try-it-in-60-seconds).
+current `v0.4.6` command in the [project README](https://github.com/happy520ai/unified-ai-system#try-it-in-60-seconds).
 A new content review is required before changing this pinned procedure.
 
 ## Prerequisites And Setup

--- a/skills/unified-ai-gateway/SKILL.md
+++ b/skills/unified-ai-gateway/SKILL.md
@@ -93,7 +93,7 @@ deletion is another filesystem change and requires approval for the exact path.
 
 5. Read every generated inventory and report the inspection before proceeding.
    Compare it with the versioned
-   [image content review](https://github.com/happy520ai/unified-ai-system/blob/master/docs/security/mcp-image-review-0.4.9.md).
+   [image content review](https://github.com/happy520ai/unified-ai-system/blob/8561ec5c9e9d1ecf499c1be5aba0ba3720219074/docs/security/mcp-image-review-0.4.9.md).
    Require OCI index digest
    `sha256:751a0d32acd2d6b1da6ad9ac67987fbd1ff36ce26b7160014d8605f18b7907b3`.
    For linux/amd64, require manifest digest
@@ -243,4 +243,4 @@ Agent:
 - [Unified AI System](https://github.com/happy520ai/unified-ai-system)
 - [60-second Codex MCP quickstart](https://github.com/happy520ai/unified-ai-system/blob/master/docs/codex-mcp-quickstart.md)
 - [MCP server guide](https://github.com/happy520ai/unified-ai-system/blob/master/packages/mcp-server/README.md)
-- [MCP image content review](https://github.com/happy520ai/unified-ai-system/blob/master/docs/security/mcp-image-review-0.4.9.md)
+- [MCP image content review](https://github.com/happy520ai/unified-ai-system/blob/8561ec5c9e9d1ecf499c1be5aba0ba3720219074/docs/security/mcp-image-review-0.4.9.md)

--- a/skills/unified-ai-gateway/SKILL.md
+++ b/skills/unified-ai-gateway/SKILL.md
@@ -26,11 +26,11 @@ installations require the manual setup below.
 
 ## Version Note
 
-The current public project release is `v0.4.6`. The inspection procedure below
+The current public project release is `v0.4.8`. The inspection procedure below
 intentionally pins the reviewed, immutable `v0.4.0` image and its recorded
 digests; those values are a historical security baseline and must not be
 silently replaced with a mutable tag. For a normal provider-free demo, use the
-current `v0.4.6` command in the [project README](https://github.com/happy520ai/unified-ai-system#try-it-in-60-seconds).
+current `v0.4.8` command in the [project README](https://github.com/happy520ai/unified-ai-system#try-it-in-60-seconds).
 A new content review is required before changing this pinned procedure.
 
 ## Prerequisites And Setup


### PR DESCRIPTION
## Summary

- align the public release note and provider-free demo with `v0.4.9`
- replace the historical `v0.4.0` image baseline with the reviewed immutable `v0.4.9` OCI index, platform manifests, configs, and source revision
- preserve the critical-risk approval sequence, fake-provider default, disabled networking, dropped capabilities, and no-new-privileges boundary

## Safety and scope

This remains a documentation-only skill update. It changes no runtime code, credentials, provider selection, or permissions. The setup continues to require separate approval for image inspection and MCP registration, pins an immutable digest, and fails closed on any inspection mismatch.

## Validation

- `pnpm run validate` - passed, 2,007 skills
- `pnpm run validate:references` - passed
- `pnpm run security:docs` - passed
- `pnpm run check:warning-budget` - passed, 0/0
- README source-credit check against `upstream/main` - passed
- all six constituent generation steps in `npm run chain` - passed; generated artifacts were excluded from this source-only PR
- `git diff --check` - passed

A complete local test run also exercised the repository suite; four unrelated AAS adapter cases require POSIX mode/symlink semantics unavailable in this Windows session. GitHub Actions remains the authoritative Linux gate.

Source project: https://github.com/happy520ai/unified-ai-system
Release: https://github.com/happy520ai/unified-ai-system/releases/tag/v0.4.9
Image review: https://github.com/happy520ai/unified-ai-system/blob/master/docs/security/mcp-image-review-0.4.9.md